### PR TITLE
:art: Added respond method to Alexa game engine and gadget controller

### DIFF
--- a/lib/platforms/alexaSkill/gadgetController.js
+++ b/lib/platforms/alexaSkill/gadgetController.js
@@ -114,6 +114,24 @@ class GadgetController {
             },
         });
     }
+
+    /**
+     * Delete 'shouldEndSession' attribute, add speech text and send response
+     * @param {speechBuilder|string} speech speechBuilder object whose speech attribute will be used
+     */
+    respond(speech) {
+        if (_.get(speech, 'constructor.name') === 'String') {
+            this.response.setOutputSpeech(
+                speech
+            );
+        } else if (_.get(speech, 'constructor.name') === 'AlexaSpeechBuilder') {
+            this.response.setOutputSpeech(
+                speech.toString()
+            );
+        }
+        this.response.deleteShouldEndSession();
+        this.jovo.respond();
+    }
 }
 
 /**

--- a/lib/platforms/alexaSkill/gameEngine.js
+++ b/lib/platforms/alexaSkill/gameEngine.js
@@ -121,6 +121,24 @@ class GameEngine {
             originatingRequestId,
         });
     }
+
+    /**
+     * Delete 'shouldEndSession' attribute, add speech text and send response
+     * @param {speechBuilder|string} speech speechBuilder object whose speech attribute will be used
+     */
+    respond(speech) {
+        if (_.get(speech, 'constructor.name') === 'String') {
+            this.response.setOutputSpeech(
+                speech
+            );
+        } else if (_.get(speech, 'constructor.name') === 'AlexaSpeechBuilder') {
+            this.response.setOutputSpeech(
+                speech.toString()
+            );
+        }
+        this.response.deleteShouldEndSession();
+        this.jovo.respond();
+    }
 }
 
 /**


### PR DESCRIPTION
## Proposed changes
Added a 'respond()' method to both the game engine and the gadget controller, such that you can now send a response using either of the two commands:
this.alexaSkill().gameEngine().respond(this.speech);
this.alexaSkill().gadgetController().respond(this.speech);
This method adds the speech text from either a speechBuilder object or a string to the response text, deletes the shouldEndSession attribute from the response object, and send it. This is an elegant shorthand for
this.alexaSkill().response.deleteShouldEndSession();
this.respond();

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly -> Working on it!
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed