### PR TITLE
 🐛 SimpleCard didn't include content

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/modules/Cards.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/modules/Cards.ts
@@ -125,7 +125,7 @@ export class Cards implements Plugin {
             _set(alexaSkill.$response, 'response.card',
                 new SimpleCard()
                     .setTitle(_get(cardSimpleCard, 'title'))
-                    .setContent(_get(cardSimpleCard, 'text'))
+                    .setContent(_get(cardSimpleCard, 'content'))
             );
         }
         const cardImageCard = _get(output, 'Alexa.card.ImageCard') || _get(output, 'card.ImageCard');


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
`SimpleCard` didn't include the `content` property, because it tried to access `text`, which doesn't exist.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed