### PR TITLE
Fix for intent exception causing unhandled rejection

### DIFF
--- a/jovo-framework/test/handler.test.ts
+++ b/jovo-framework/test/handler.test.ts
@@ -91,6 +91,117 @@ test('test skip exception on non existing route', async (done) => {
     done();
 });
 
+test('test applyHandle on route that returns rejected promise', async () => {
+    const rejectionReason = 'rejection reason';
+
+    expect.assertions(1);
+
+    const appConfig: AppConfig = {
+        handlers: {
+            IntentA() {
+                return Promise.reject(rejectionReason);
+            }
+        }
+    };
+
+    try {
+        // @ts-ignore
+        await Handler.applyHandle(null, {
+            path: 'IntentA',
+            type: EnumRequestType.INTENT,
+        }, appConfig);
+    } catch (e) {
+        expect(e).toEqual(rejectionReason);
+    }
+});
+
+test('test applyHandle on route that immediately throws exception', async () => {
+    const errorMessage = 'an error';
+
+    expect.assertions(1);
+
+    const appConfig: AppConfig = {
+        handlers: {
+            IntentA() {
+                throw new Error(errorMessage);
+            }
+        }
+    };
+
+    try {
+        // @ts-ignore
+        await Handler.applyHandle(null, {
+            path: 'IntentA',
+            type: EnumRequestType.INTENT,
+        }, appConfig);
+    } catch (e) {
+        expect(e).toEqual(new Error(errorMessage));
+    }
+});
+
+test('test applyHandle on route with callback', async () => {
+    const appConfig: AppConfig = {
+        handlers: {
+            IntentA(jovo: Jovo, callback: () => void) {
+                callback();
+            }
+        }
+    };
+
+    // @ts-ignore
+    await Handler.applyHandle(null, {
+        path: 'IntentA',
+        type: EnumRequestType.INTENT,
+    }, appConfig);
+});
+
+test('test applyHandle on route with callback that immediately throws exception', async () => {
+    const errorMessage = 'an error';
+
+    expect.assertions(1);
+
+    const appConfig: AppConfig = {
+        handlers: {
+            IntentA(callback: () => {}) {
+                throw new Error(errorMessage);
+            }
+        }
+    };
+
+    try {
+        // @ts-ignore
+        await Handler.applyHandle(null, {
+            path: 'IntentA',
+            type: EnumRequestType.INTENT,
+        }, appConfig);
+    } catch (e) {
+        expect(e).toEqual(new Error(errorMessage));
+    }
+});
+
+
+test('test applyHandle on route that returns a promise wrapped in a promise', async () => {
+    let executed = false;
+
+    const appConfig: AppConfig = {
+        handlers: {
+            async IntentA() {
+                return new Promise((resolve) => {
+                    executed = true;
+                    resolve();
+                });
+            }
+        }
+    };
+
+    // @ts-ignore
+    await Handler.applyHandle(null, {
+        path: 'IntentA',
+        type: EnumRequestType.INTENT,
+    }, appConfig);
+
+    expect(executed).toBeTruthy();
+});
 
 test('test handleOnRequest', () => {
     const appConfig: AppConfig = {


### PR DESCRIPTION
## Proposed changes
This fixes an issue I encountered where the app would hang (and log an unhandled exception) if an intent immediately threw an exception. The root cause was using an async function as a Promise executor (more details here: https://eslint.org/docs/rules/no-async-promise-executor). There's no tslint rule yet for it unfortunately.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed