### PR TITLE
Image shouldn't be required for ListTemplate1

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/response/visuals/ListTemplate1.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/response/visuals/ListTemplate1.ts
@@ -3,7 +3,7 @@ import {Image, ImageShort, PlainText, RichText, Template, TextContent} from './T
 
 export interface ListItem {
     token: string;
-    image: Image | ImageShort;
+    image?: Image | ImageShort;
     textContent: TextContent;
 }
 
@@ -17,6 +17,9 @@ export class ListTemplate1 extends Template {
 /* eslint-enable */
 
     listItems: ListItem[] = [];
+
+    protected itemImageRequired = false;
+
     /**
      * Constructor
      * Sets type of template to 'BodyTemplate1'
@@ -26,11 +29,11 @@ export class ListTemplate1 extends Template {
     }
 
     addItem(listItem: ListItem): this;
-    addItem(token: string, image: string | Image | ImageShort, primaryText?: string | RichText | PlainText, secondaryText?: string | RichText | PlainText, tertiaryText?: string | RichText | PlainText): this;
+    addItem(token: string, image?: string | Image | ImageShort, primaryText?: string | RichText | PlainText, secondaryText?: string | RichText | PlainText, tertiaryText?: string | RichText | PlainText): this;
     addItem(tokenOrListItem: string | ListItem, image?: string | Image | ImageShort, primaryText?: string | RichText | PlainText, secondaryText?: string | RichText | PlainText, tertiaryText?: string | RichText | PlainText): this {
         if (typeof tokenOrListItem === 'string') {
 
-            if (!image) {
+            if (!image && this.itemImageRequired) {
                 throw new Error('Image is needed');
             }
 
@@ -38,16 +41,25 @@ export class ListTemplate1 extends Template {
                 throw new Error('At least primaryText is needed');
             }
 
-            this.listItems.push({
+            const listItem: ListItem = {
                 token: tokenOrListItem,
-                image: Template.makeImage(image),
                 textContent: Template.makeTextContent(
                     primaryText,
                     secondaryText,
                     tertiaryText
                 )
-            });
+            };
+
+            if (image) {
+                listItem.image = Template.makeImage(image);
+            }
+
+            this.listItems.push(listItem);
         } else {
+            if (!tokenOrListItem.image && this.itemImageRequired) {
+                throw new Error('Image is needed');
+            }
+
             this.listItems.push(tokenOrListItem);
         }
         return this;

--- a/jovo-integrations/jovo-platform-alexa/src/response/visuals/ListTemplate2.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/response/visuals/ListTemplate2.ts
@@ -18,6 +18,9 @@ export class ListTemplate2 extends ListTemplate1 {
     constructor() {
         super();
         this.type = 'ListTemplate2';
+
+        // In ListTemplate1 item images are optional, but in ListTemplate2 they are required
+        this.itemImageRequired = true;
     }
 }
 

--- a/jovo-integrations/jovo-platform-alexa/test/modules/RenderTemplates.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/modules/RenderTemplates.test.ts
@@ -388,35 +388,58 @@ test('test BodyTemplate7', () => {
 
 
 test('test ListTemplate1', () => {
-   const listTemplate1 = new ListTemplate1();
-   listTemplate1.addItem('token', {contentDescription: 'desc', sources: [{url: 'image_url'}]}, 'primaryText', 'secondaryText', 'tertiaryText');
+    const listTemplate1 = new ListTemplate1();
+    listTemplate1.addItem('token', { contentDescription: 'desc', sources: [{ url: 'image_url' }] }, 'primaryText', 'secondaryText', 'tertiaryText');
 
-   expect(listTemplate1.type).toBe('ListTemplate1');
-   expect(listTemplate1.listItems[0]).toEqual({
-       token: 'token',
-       image: {
-           contentDescription: 'desc',
-           sources: [
-               {
-                   url: 'image_url'
-               }
-           ]
-       },
-       textContent: {
-           primaryText: {
-               type: 'RichText',
-               text: 'primaryText'
-           },
-           secondaryText: {
-               type: 'RichText',
-               text: 'secondaryText'
-           },
-           tertiaryText: {
-               type: 'RichText',
-               text: 'tertiaryText'
-           }
-       }
-   });
+    expect(listTemplate1.type).toBe('ListTemplate1');
+    expect(listTemplate1.listItems[0]).toStrictEqual({
+        token: 'token',
+        image: {
+            contentDescription: 'desc',
+            sources: [
+                {
+                    url: 'image_url'
+                }
+            ]
+        },
+        textContent: {
+            primaryText: {
+                type: 'RichText',
+                text: 'primaryText'
+            },
+            secondaryText: {
+                type: 'RichText',
+                text: 'secondaryText'
+            },
+            tertiaryText: {
+                type: 'RichText',
+                text: 'tertiaryText'
+            }
+        }
+    });
+    listTemplate1.listItems = [];
+
+    // Test addItem with no image
+    listTemplate1.addItem('token', undefined, 'primaryText', 'secondaryText', 'tertiaryText');
+
+    expect(listTemplate1.type).toBe('ListTemplate1');
+    expect(listTemplate1.listItems[0]).toStrictEqual({
+        token: 'token',
+        textContent: {
+            primaryText: {
+                type: 'RichText',
+                text: 'primaryText'
+            },
+            secondaryText: {
+                type: 'RichText',
+                text: 'secondaryText'
+            },
+            tertiaryText: {
+                type: 'RichText',
+                text: 'tertiaryText'
+            }
+        }
+    });
     listTemplate1.listItems = [];
 
     const listItem: ListItem = {
@@ -445,7 +468,7 @@ test('test ListTemplate1', () => {
     };
 
     listTemplate1.addItem(listItem);
-    expect(listTemplate1.listItems[0]).toEqual({
+    expect(listTemplate1.listItems[0]).toStrictEqual({
         token: 'token',
         image: {
             sources: [
@@ -470,33 +493,33 @@ test('test ListTemplate1', () => {
         }
     });
 
-   listTemplate1.listItems = [];
-   // setItems
-   listTemplate1.setItems([{
-       token: 'token',
-       image: {
-           sources: [
-               {
-                   url: 'image_url'
-               }
-           ]
-       },
-       textContent: {
-           primaryText: {
-               type: 'RichText',
-               text: 'primaryText'
-           },
-           secondaryText: {
-               type: 'RichText',
-               text: 'secondaryText'
-           },
-           tertiaryText: {
-               type: 'RichText',
-               text: 'tertiaryText'
-           }
-       }
-   }]);
-    expect(listTemplate1.listItems[0]).toEqual({
+    listTemplate1.listItems = [];
+    // setItems
+    listTemplate1.setItems([{
+        token: 'token',
+        image: {
+            sources: [
+                {
+                    url: 'image_url'
+                }
+            ]
+        },
+        textContent: {
+            primaryText: {
+                type: 'RichText',
+                text: 'primaryText'
+            },
+            secondaryText: {
+                type: 'RichText',
+                text: 'secondaryText'
+            },
+            tertiaryText: {
+                type: 'RichText',
+                text: 'tertiaryText'
+            }
+        }
+    }]);
+    expect(listTemplate1.listItems[0]).toStrictEqual({
         token: 'token',
         image: {
             sources: [
@@ -528,7 +551,7 @@ test('test ListTemplate2', () => {
     listTemplate2.addItem('token', {contentDescription: 'desc', sources: [{url: 'image_url'}]}, 'primaryText', 'secondaryText', 'tertiaryText');
 
     expect(listTemplate2.type).toBe('ListTemplate2');
-    expect(listTemplate2.listItems[0]).toEqual({
+    expect(listTemplate2.listItems[0]).toStrictEqual({
         token: 'token',
         image: {
             contentDescription: 'desc',
@@ -554,6 +577,11 @@ test('test ListTemplate2', () => {
         }
     });
     listTemplate2.listItems = [];
+
+    // ensure an error is thrown if image isn't passed in (it's required for ListTemplate2)
+    expect(() => listTemplate2.addItem('token', undefined, 'primaryText'))
+        .toThrow('Image is needed');
+
     // setItems
     listTemplate2.setItems([{
         token: 'token',
@@ -579,7 +607,7 @@ test('test ListTemplate2', () => {
             }
         }
     }]);
-    expect(listTemplate2.listItems[0]).toEqual({
+    expect(listTemplate2.listItems[0]).toStrictEqual({
         token: 'token',
         image: {
             sources: [


### PR DESCRIPTION
## Proposed changes
For ListTemplate1 an image is optional for items, however Jovo was throwing a validation error if it was missing. This corrects that, while still preserving the validation for ListTemplate2 (which does require an image on items).

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed