### PR TITLE
Set Field for primaryKey to 255 chars

### DIFF
--- a/jovo-integrations/jovo-db-mysql/src/MySQL.ts
+++ b/jovo-integrations/jovo-db-mysql/src/MySQL.ts
@@ -150,7 +150,7 @@ export class MySQL implements Db {
                 return reject(new Error('dataColumnName must be set'));
             }
             const sql = `
-                    CREATE TABLE ${this.config.tableName} (${this.config.primaryKeyColumn} VARCHAR(200) NOT NULL,
+                    CREATE TABLE ${this.config.tableName} (${this.config.primaryKeyColumn} VARCHAR(255) NOT NULL,
                     ${this.config.dataColumnName} TEXT NULL,
                     PRIMARY KEY (${this.config.primaryKeyColumn}));
             `;


### PR DESCRIPTION
In some cases the UserID got cropped and the userData was not accessible anymore.

'userId: A string that represents a unique identifier for the user who made the request. The length of this identifier can vary, but is never more than 255 characters. The userId is automatically generated when a user enables the skill in the Alexa app.'
https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html

## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed