### PR TITLE
Fix link to config.js doc

### DIFF
--- a/docs/configuration/project-structure.md
+++ b/docs/configuration/project-structure.md
@@ -188,7 +188,7 @@ module.exports = {
 };
 ```
 
-> [You can find everything related to the `config.js` here](./project-js.md './project-js').
+> [You can find everything related to the `config.js` here](./config-js.md './config-js').
 
 ### index.js - Host Configuration
 


### PR DESCRIPTION
Fix link to config.js doc.  It was pointed to project.js path.