### PR TITLE
showVideo(...) should not drop session attributes

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/modules/Display.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/modules/Display.ts
@@ -100,6 +100,12 @@ export class Display implements Plugin {
             if (_get(response, 'response.shouldEndSession')) {
                 delete response.response.shouldEndSession;
             }
+
+            // set sessionAttributes (necessary since AlexaCore's handler runs before us
+            // and skips adding session attributes due to shouldEndSession being true at that point)
+            if (alexaSkill.$session && alexaSkill.$session.$data) {
+                _set(response, 'sessionAttributes', alexaSkill.$session.$data);
+            }
         }
         // }
     }

--- a/jovo-integrations/jovo-platform-alexa/test/modules/Display.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/modules/Display.test.ts
@@ -1,0 +1,49 @@
+import {HandleRequest, JovoRequest, TestSuite, SessionConstants} from "jovo-core";
+import {App, ExpressJS} from "jovo-framework";
+import {Alexa} from "../../src";
+import _get = require('lodash.get');
+
+process.env.NODE_ENV = 'UNIT_TEST';
+let app: App;
+let t: TestSuite;
+jest.setTimeout(550);
+
+beforeEach(() => {
+    app = new App();
+    const alexa = new Alexa();
+    app.use(alexa);
+    t = alexa.makeTestSuite();
+});
+
+describe('test Display functions', () => {
+
+    test('test showVideo', async (done) => {
+        app.setHandler({
+            LAUNCH() {
+                this.setSessionAttribute('myKey', 'myValue');
+                this.$alexaSkill!.showVideo('https://url.to.video', 'titleABC');
+            },
+        });
+
+        const launchRequest:JovoRequest = await t.requestBuilder.launch();
+        app.handle(ExpressJS.dummyRequest(launchRequest));
+
+        app.on('response', (handleRequest: HandleRequest) => {
+
+            const response = handleRequest.jovo!.$response;
+            expect(_get(response, 'response.directives[0].type')).toEqual('VideoApp.Launch');
+            expect(_get(response, 'response.shouldEndSession')).toBeUndefined();
+
+            expect(_get(response, 'response.directives[0].videoItem.source')).toEqual('https://url.to.video');
+            expect(_get(response, 'response.directives[0].videoItem.metadata.title')).toEqual('titleABC');
+
+            // verify that session attributes are returned in response
+            expect(_get(response, 'sessionAttributes')).toStrictEqual({
+                myKey: 'myValue'
+            });
+
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
## Proposed changes
Related to my last PR, I also discovered that showVideo was causing session attributes to be dropped as well. This resolves it the exact same way, as well as adding a test to help verify its behavior when you inevitably refactor my fix :)

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed