### PR TITLE
TestSuite is now generic, with platform-specific interfaces available

### DIFF
--- a/jovo-core/src/TestSuite.ts
+++ b/jovo-core/src/TestSuite.ts
@@ -1,28 +1,28 @@
 import {Conversation, ConversationConfig} from "./Conversation";
 import {JovoRequest, JovoResponse} from "./Interfaces";
 
-export interface RequestBuilder {
+export interface RequestBuilder<T extends JovoRequest = JovoRequest> {
     type: string;
-    launch(json?: any): Promise<JovoRequest>; // tslint:disable-line
-    intent(json?: any): Promise<JovoRequest>; // tslint:disable-line
-    intent(name: string, slots: any): Promise<JovoRequest>; // tslint:disable-line
-    audioPlayerRequest(json?: any): Promise<JovoRequest>; // tslint:disable-line
-    end(json?: any): Promise<JovoRequest>; // tslint:disable-line
-    rawRequest(json: any): Promise<JovoRequest>; // tslint:disable-line
-    rawRequestByKey(key: string): Promise<JovoRequest>; // tslint:disable-line
+    launch(json?: any): Promise<T>; // tslint:disable-line
+    intent(json?: any): Promise<T>; // tslint:disable-line
+    intent(name: string, slots: any): Promise<T>; // tslint:disable-line
+    audioPlayerRequest(json?: any): Promise<T>; // tslint:disable-line
+    end(json?: any): Promise<T>; // tslint:disable-line
+    rawRequest(json: any): Promise<T>; // tslint:disable-line
+    rawRequestByKey(key: string): Promise<T>; // tslint:disable-line
 }
 
-export interface ResponseBuilder {
-    create(json: any): JovoResponse; // tslint:disable-line
+export interface ResponseBuilder<T extends JovoResponse = JovoResponse> {
+    create(json: any): T; // tslint:disable-line
 }
 
 /**
  * Defines a class with static functions for testing purpose.
  */
-export class TestSuite {
-    requestBuilder: RequestBuilder;
-    responseBuilder: ResponseBuilder;
-    constructor(requestBuilder: RequestBuilder, responseBuilder: ResponseBuilder) {
+export class TestSuite<T extends RequestBuilder = RequestBuilder, K extends ResponseBuilder = ResponseBuilder>  {
+    requestBuilder: T;
+    responseBuilder: K;
+    constructor(requestBuilder: T, responseBuilder: K) {
         this.requestBuilder = requestBuilder;
         this.responseBuilder = responseBuilder;
     }

--- a/jovo-integrations/jovo-platform-alexa/src/Alexa.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/Alexa.ts
@@ -10,6 +10,7 @@ import {
     HandleRequest, ActionSet, ExtensibleConfig,Jovo
 } from "jovo-core";
 import {AlexaSkill} from "./core/AlexaSkill";
+import {AlexaTestSuite} from "./core/Interfaces";
 import {AlexaCore} from "./modules/AlexaCore";
 import {AudioPlayerPlugin} from "./modules/AudioPlayerPlugin";
 import {CanFulfillIntent} from "./modules/CanFulfillIntent";
@@ -111,7 +112,7 @@ export class Alexa extends Extensible implements Platform {
 
     }
 
-    makeTestSuite() {
+    makeTestSuite(): AlexaTestSuite {
         return new TestSuite(new AlexaRequestBuilder(), new AlexaResponseBuilder());
     }
 

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaRequestBuilder.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaRequestBuilder.ts
@@ -16,7 +16,7 @@ const samples: {[key: string]: string} = {
     'Display.ElementSelected': 'Display.ElementSelected.json',
 };
 
-export class AlexaRequestBuilder implements RequestBuilder {
+export class AlexaRequestBuilder implements RequestBuilder<AlexaRequest> {
      type = 'AlexaSkill';
 
     async launch(json?: any): Promise<AlexaRequest> { // tslint:disable-line

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponseBuilder.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponseBuilder.ts
@@ -1,8 +1,8 @@
 import {AlexaResponse} from "./AlexaResponse";
 import {ResponseBuilder} from "jovo-core";
 
-export class AlexaResponseBuilder implements ResponseBuilder {
-    create(json: any) { // tslint:disable-line
+export class AlexaResponseBuilder implements ResponseBuilder<AlexaResponse> {
+    create(json: any): AlexaResponse { // tslint:disable-line
         return AlexaResponse.fromJSON(json);
     }
 }

--- a/jovo-integrations/jovo-platform-alexa/src/core/Interfaces.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/Interfaces.ts
@@ -1,3 +1,8 @@
+import { TestSuite } from "jovo-core";
+import { AlexaRequestBuilder } from "./AlexaRequestBuilder";
+import { AlexaResponseBuilder } from "./AlexaResponseBuilder";
+
+export interface AlexaTestSuite extends TestSuite<AlexaRequestBuilder, AlexaResponseBuilder> {}
 
 export interface HouseholdList {
     items: HouseholdListItem[];

--- a/jovo-integrations/jovo-platform-alexa/src/index.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/index.ts
@@ -3,6 +3,7 @@ import {LinkAccountCard} from "./response/visuals/LinkAccountCard";
 export { AlexaRequestBuilder } from "./core/AlexaRequestBuilder";
 export { Alexa } from './Alexa';
 export { AlexaSkill } from './core/AlexaSkill';
+export { AlexaTestSuite } from './core/Interfaces';
 export { AlexaRequest } from './core/AlexaRequest';
 export { AlexaResponse } from './core/AlexaResponse';
 

--- a/jovo-integrations/jovo-platform-dialogflow/src/Dialogflow.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/Dialogflow.ts
@@ -10,6 +10,7 @@ import {DialogflowAgent} from "./DialogflowAgent";
 import {DialogflowCore} from "./DialogflowCore";
 import {DialogflowRequestBuilder} from "./core/DialogflowRequestBuilder";
 import {DialogflowResponseBuilder} from "./core/DialogflowResponseBuilder";
+import {DialogflowTestSuite} from './core/Interfaces';
 
 export interface DialogflowConfig extends ExtensibleConfig {
 }
@@ -42,7 +43,7 @@ export class Dialogflow extends Extensible implements Platform {
         ], this);
     }
 
-    makeTestSuite() {
+    makeTestSuite(): DialogflowTestSuite {
         return new TestSuite(new DialogflowRequestBuilder(), new DialogflowResponseBuilder());
     }
 

--- a/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowRequestBuilder.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowRequestBuilder.ts
@@ -16,7 +16,7 @@ const samples: {[key: string]: {[key: string]: string} | string} = {
     }
 };
 
-export class DialogflowRequestBuilder implements RequestBuilder {
+export class DialogflowRequestBuilder implements RequestBuilder<DialogflowRequest> {
      type = 'DialogflowAgent';
      platform: string;
      platformRequestClazz: JovoRequest;

--- a/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponseBuilder.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponseBuilder.ts
@@ -1,10 +1,10 @@
 import {ResponseBuilder, JovoResponse} from "jovo-core";
 import {DialogflowResponse} from "./DialogflowResponse";
 
-export class DialogflowResponseBuilder implements ResponseBuilder {
+export class DialogflowResponseBuilder implements ResponseBuilder<DialogflowResponse> {
     platform: string;
     platformResponseClazz: JovoResponse;
-    create(json: any) { // tslint:disable-line
+    create(json: any): DialogflowResponse { // tslint:disable-line
         const dialogflowResponse = DialogflowResponse.fromJSON(json) as DialogflowResponse;
         if (dialogflowResponse.payload) {
             // @ts-ignore

--- a/jovo-integrations/jovo-platform-dialogflow/src/core/Interfaces.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/core/Interfaces.ts
@@ -1,0 +1,5 @@
+import { TestSuite } from "jovo-core";
+import { DialogflowRequestBuilder } from "./DialogflowRequestBuilder";
+import { DialogflowResponseBuilder } from "./DialogflowResponseBuilder";
+
+export interface DialogflowTestSuite extends TestSuite<DialogflowRequestBuilder, DialogflowResponseBuilder> {}

--- a/jovo-integrations/jovo-platform-dialogflow/src/index.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/index.ts
@@ -5,7 +5,7 @@ export { DialogflowNlu } from "./DialogflowNlu";
 export { DialogflowResponse } from "./core/DialogflowResponse";
 export { DialogflowRequest } from "./core/DialogflowRequest";
 export { DialogflowRequestBuilder } from "./core/DialogflowRequestBuilder";
-
+export { DialogflowTestSuite } from './core/Interfaces';
 
 
 declare module 'jovo-core/dist/src/Jovo' {

--- a/jovo-integrations/jovo-platform-googleassistant/src/GoogleAssistant.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/GoogleAssistant.ts
@@ -23,6 +23,7 @@ import {GoogleActionRequest} from "./core/GoogleActionRequest";
 import {GoogleActionResponse} from "./core/GoogleActionResponse";
 import {GoogleAssistantRequestBuilder} from "./core/GoogleAssistantRequestBuilder";
 import {GoogleAssistantResponseBuilder} from "./core/GoogleAssistantResponseBuilder";
+import {GoogleAssistantTestSuite} from './core/Interfaces';
 
 export interface Config extends ExtensibleConfig {
     handlers?: any; //tslint:disable-line
@@ -117,7 +118,7 @@ export class GoogleAssistant extends Extensible implements Platform {
 
     }
 
-    makeTestSuite() {
+    makeTestSuite(): GoogleAssistantTestSuite {
         this.remove('DialogflowNlu');
         this.initDialogflow();
         return new TestSuite(this.requestBuilder, this.responseBuilder);

--- a/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleAssistantRequestBuilder.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleAssistantRequestBuilder.ts
@@ -8,7 +8,7 @@ const samples: {[key: string]: string} = {
 
 };
 
-export class GoogleAssistantRequestBuilder implements RequestBuilder {
+export class GoogleAssistantRequestBuilder implements RequestBuilder<GoogleActionRequest> {
     type = 'GoogleAction';
 
     launch(json?: any): Promise<GoogleActionRequest> { //tslint:disable-line

--- a/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleAssistantResponseBuilder.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleAssistantResponseBuilder.ts
@@ -1,8 +1,8 @@
 import {ResponseBuilder} from "jovo-core";
 import {GoogleActionResponse} from "./GoogleActionResponse";
 
-export class GoogleAssistantResponseBuilder implements ResponseBuilder {
-    create(json: any) { // tslint:disable-line
+export class GoogleAssistantResponseBuilder implements ResponseBuilder<GoogleActionResponse> {
+    create(json: any): GoogleActionResponse { // tslint:disable-line
         return GoogleActionResponse.fromJSON(json);
     }
 }

--- a/jovo-integrations/jovo-platform-googleassistant/src/core/Interfaces.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/core/Interfaces.ts
@@ -1,0 +1,5 @@
+import { TestSuite } from "jovo-core";
+import { GoogleAssistantRequestBuilder } from "./GoogleAssistantRequestBuilder";
+import { GoogleAssistantResponseBuilder } from "./GoogleAssistantResponseBuilder";
+
+export interface GoogleAssistantTestSuite extends TestSuite<GoogleAssistantRequestBuilder, GoogleAssistantResponseBuilder> {}

--- a/jovo-integrations/jovo-platform-googleassistant/src/index.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/index.ts
@@ -1,4 +1,5 @@
 export { GoogleAssistant } from './GoogleAssistant';
+export { GoogleAssistantTestSuite } from './core/Interfaces';
 export { BasicCard } from './response/BasicCard';
 export { Carousel } from './response/Carousel';
 export { CarouselItem } from './response/CarouselItem';


### PR DESCRIPTION
## Proposed changes
Made the TestSuite interface generic and created platform-specific sub-interfaces of it, with the purpose of making using platform-specific request/response methods easier in unit tests. Feel free to refactor anything I didn't do quite right! I think this'll also only work in Typescript 2.3+ (due to my usage of generic defaults), so if that's a problem feel free to reject this.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed