### PR TITLE
 🐛 Fixes bug where outDir was ./dist/src/ in `jovo-db-firestore`

### DIFF
--- a/jovo-integrations/jovo-db-firestore/tsconfig.json
+++ b/jovo-integrations/jovo-db-firestore/tsconfig.json
@@ -9,11 +9,12 @@
     "preserveConstEnums": true,
     "declaration": true,
     "strict": true,
-    "outDir": "./dist/src/",
+    "outDir": "./dist/",
     "target": "es2017",
     "sourceMap": true
   },
   "include": [
+    "**/*.d.ts",
     "src/**/*",
     "test/**/*"
   ],


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Fixes bug, where `jovo-db-firestore` module could not been found after installation.
The `outDir` option inside the `tsconfig.json` file was `./dist/src/` resulting in the wrong folder structure.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed