### PR TITLE
Keep Session Attributes on Session End

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/modules/AlexaCore.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/modules/AlexaCore.ts
@@ -120,12 +120,11 @@ export class AlexaCore implements Plugin {
         }
 
 
-        if (_get(alexaSkill.$response, 'response.shouldEndSession') === false) {
-            // set sessionAttributes
-            if (alexaSkill.$session && alexaSkill.$session.$data) {
-                _set(alexaSkill.$response, 'sessionAttributes', alexaSkill.$session.$data);
-            }
+        // set sessionAttributes
+        if (alexaSkill.$session && alexaSkill.$session.$data) {
+            _set(alexaSkill.$response, 'sessionAttributes', alexaSkill.$session.$data);
         }
+
 
         if (_get(output, 'Alexa.Directives')) {
             _set(alexaSkill.$response, 'response.directives', _get(output, 'Alexa.Directives'));


### PR DESCRIPTION
## Proposed changes

Currently the framework removes session attributes from the last response that is sent when the session ends:

https://github.com/jovotech/jovo-framework/blob/master/jovo-integrations/jovo-platform-alexa/src/modules/AlexaCore.ts#L123

Although this is the last response and therefore the session attributes won't be used for anything when the skill is live, they are useful for storing data that can be used in unit tests.

Based on this I would like to remove the check that only sets the session attributes on responses that keep the session open.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed