### PR TITLE
setAlexaHandler/setGoogleAssistantHandler don't works with a list of object.

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/Alexa.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/Alexa.ts
@@ -122,9 +122,9 @@ export class Alexa extends Extensible implements Platform {
                 if (typeof obj !== 'object') {
                     throw new Error('Handler must be of type object.');
                 }
-                _set(this.config.plugin, 'Alexa.handlers', obj);
+                const sourceHandler = _get(this.config.plugin,'Alexa.handlers');
+                _set(this.config.plugin, 'Alexa.handlers', _merge(sourceHandler,obj));            
             }
-
             return this;
         };
 

--- a/jovo-integrations/jovo-platform-googleassistant/src/GoogleAssistant.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/GoogleAssistant.ts
@@ -112,9 +112,9 @@ export class GoogleAssistant extends Extensible implements Platform {
                 if (typeof obj !== 'object') {
                     throw new Error('Handler must be of type object.');
                 }
-                _set(this.config.plugin, 'GoogleAssistant.handlers', obj);
+               const sourceHandler = _get(this.config.plugin,'GoogleAssistant.handlers');
+               _set(this.config.plugin, 'GoogleAssistant.sourceHandler', _merge(handlers,obj));
             }
-
             return this;
         };
 


### PR DESCRIPTION
## Proposed changes
Calling setAlexaHandler/setGoogleAssistantHandler with a list of object won't fill correctly the handlers list.
Both function use _set to add handler in the handler list.
_set erase the previous list.



## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed