### PR TITLE
fix missing playerActivity

### DIFF
--- a/jovo-integrations/jovo-platform-alexa/src/modules/AudioPlayerPlugin.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/modules/AudioPlayerPlugin.ts
@@ -50,7 +50,7 @@ export class AudioPlayer {
 
     constructor(alexaSkill: AlexaSkill) {
         this.alexaSkill = alexaSkill;
-
+        this.playerActivity=_get(alexaSkill.$request, 'context.AudioPlayer.playerActivity');
         this.offsetInMilliseconds = _get(alexaSkill.$request, 'context.AudioPlayer.offsetInMilliseconds');
         this.token = _get(alexaSkill.$request, 'context.AudioPlayer.token') || _get(alexaSkill.$request, 'request.token');
 


### PR DESCRIPTION
this.$alexaSkill.$audioPlayer.playerActivity isn't set.

the fix retrieve the status of the  player from the context.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed