### PR TITLE
Update addText to accept arbitrary SSML wrapping elements

### DIFF
--- a/jovo-core/src/SpeechBuilder.ts
+++ b/jovo-core/src/SpeechBuilder.ts
@@ -1,9 +1,19 @@
 'use strict';
 import {Jovo} from "./Jovo";
 const _sample = require('lodash.sample');
+const _merge = require('lodash.merge');
+
+export interface SsmlElements {
+    [tag: string]: SsmlElementAttributes;
+}
+
+export interface SsmlElementAttributes {
+    [attribute: string] : string | number | boolean;
+}
 
 /** Class SpeechBuilder */
 export class SpeechBuilder {
+    prosody = {};
     speech = '';
     jovo: Jovo | undefined;
 
@@ -24,11 +34,10 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addSentence(text: string | string[], condition?: boolean, probability?: number): this {
-        if (Array.isArray(text)) {
-            return this.addText('<s>' + _sample(text) + '</s>', condition, probability);
-        }
-        return this.addText('<s>' + text + '</s>', condition, probability);
+    addSentence(text: string | string[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
+        return this.addText(Array.isArray(text) ? _sample(text) : text, condition, probability, _merge({
+            s: {}
+        }, surroundSsml));
     }
 
     /**
@@ -38,11 +47,12 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addSayAsCardinal(n: number | number[], condition?: boolean, probability?: number): this {
-        if (Array.isArray(n)) {
-            return this.addText('<say-as interpret-as="cardinal">'+ _sample(n) +'</say-as>', condition, probability);
-        }
-        return this.addText('<say-as interpret-as="cardinal">'+n+'</say-as>', condition, probability);
+    addSayAsCardinal(n: number | number[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
+        return this.addText(Array.isArray(n) ? _sample(n) : n, condition, probability, _merge({
+            'say-as': {
+                'interpret-as': 'cardinal'
+            }
+        }, surroundSsml));
     }
 
     /**
@@ -52,7 +62,7 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addCardinal(n: number | number[], condition?: boolean, probability?: number): this {
+    addCardinal(n: number | number[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
         return this.addSayAsCardinal(n, condition, probability);
     }
 
@@ -63,11 +73,12 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addSayAsOrdinal(n: number | number[], condition?: boolean, probability?: number): this {
-        if (Array.isArray(n)) {
-            return this.addText('<say-as interpret-as="ordinal">'+ _sample(n) +'</say-as>', condition, probability);
-        }
-        return this.addText('<say-as interpret-as="ordinal">'+n+'</say-as>', condition, probability);
+    addSayAsOrdinal(n: number | number[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
+        return this.addText(Array.isArray(n) ? _sample(n) : n, condition, probability, _merge({
+            'say-as': {
+                'interpret-as': 'ordinal'
+            }
+        }, surroundSsml));
     }
 
     /**
@@ -77,7 +88,7 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addOrdinal(n: number | number[], condition?: boolean, probability?: number): this {
+    addOrdinal(n: number | number[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
         return this.addSayAsOrdinal(n, condition, probability);
     }
 
@@ -88,11 +99,12 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addSayAsCharacters(characters: string | string[], condition?: boolean, probability?: number): this {
-        if (Array.isArray(characters)) {
-            return this.addText('<say-as interpret-as="characters">'+_sample(characters)+'</say-as>', condition, probability);
-        }
-        return this.addText('<say-as interpret-as="characters">'+characters+'</say-as>', condition, probability);
+    addSayAsCharacters(characters: string | string[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
+        return this.addText(Array.isArray(characters) ? _sample(characters) : characters, condition, probability, _merge({
+            'say-as': {
+                'interpret-as': 'characters'
+            }
+        }, surroundSsml));
     }
 
     /**
@@ -102,7 +114,7 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addCharacters(characters: string | string[], condition?: boolean, probability?: number): this {
+    addCharacters(characters: string | string[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
         return this.addSayAsCharacters(characters, condition, probability);
     }
 
@@ -114,24 +126,27 @@ export class SpeechBuilder {
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addBreak(time: string | string[], condition?: boolean, probability?: number): this {
+    addBreak(time: string | string[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
         const strengthValues = ['none', 'x-weak', 'weak', 'medium', 'strong', 'x-strong'];
         const breakTime = Array.isArray(time) ? _sample(time) : time;
-        if (strengthValues.indexOf(breakTime) > -1) {
-            return this.addText('<break strength="' + breakTime + '"/>', condition, probability);
-        } else {
-            return this.addText('<break time="' + breakTime + '"/>', condition, probability);
-        }
+        const attributeName = strengthValues.indexOf(breakTime) > -1 ? 'strength' : 'time';
+        return this.addText('', condition, probability, _merge({
+            break: {
+                [attributeName]: breakTime
+            }
+        }, surroundSsml));
     }
+
     /**
      * Adds text to speech
      * @public
      * @param {string} text
      * @param {boolean} condition
      * @param {number} probability
+     * @param {SsmlElement}  ssml element description
      * @return {SpeechBuilder}
      */
-    addText(text: string | string[], condition?: boolean, probability?: number): this {
+    addText(text: string | string[], condition?: boolean, probability?: number, surroundSsml?: SsmlElements): this {
         if (typeof condition === "boolean" && condition === false) {
             return this;
         }
@@ -144,8 +159,50 @@ export class SpeechBuilder {
             this.speech += ' ';
         }
 
-        this.speech += Array.isArray(text) ? _sample(text) : text;
+        let _text = Array.isArray(text) ? _sample(text) : text;
+
+        if (typeof surroundSsml === "object") {
+            Object.entries(surroundSsml).forEach(([tagName, attributes]) => {
+                _text = this.wrapInSsmlElement(_text, tagName, attributes);
+            });
+        }
+
+        this.speech += _text;
+
         return this;
+    }
+
+    /**
+     * Sets prosody for this speech builder, to be applied on all speech.
+     * @public
+     * @param {SsmlElementAttributes} prosody
+     * @return {SpeechBuilder}
+     */
+    setProsody(prosody: SsmlElementAttributes) {
+        this.prosody = prosody;
+        return this;
+    }
+
+    /**
+     * Builds attribute string from attribute key-values
+     * @private
+     * @param {SsmlElementAttributes} attributes
+     * @return {string}
+     */
+    buildAttributeString(attributes: SsmlElementAttributes) {
+        return Object.entries(attributes).map(([attrName, attrVal]) => ` ${attrName}="${attrVal}"`).join('');
+    }
+
+    /**
+     * Builds an enclosing tag around text
+     * @private
+     * @param {string} text
+     * @param {string} tagName
+     * @param {SsmlElementAttributes} attributes
+     * @return {string}
+     */
+    wrapInSsmlElement(text: string, tagName: string, attributes: SsmlElementAttributes) {
+        return text ? `<${tagName}${this.buildAttributeString(attributes)}>${text}</${tagName}>` : `<${tagName}${this.buildAttributeString(attributes)}/>`;
     }
 
     /**
@@ -157,7 +214,14 @@ export class SpeechBuilder {
      * @return {SpeechBuilder}
      */
     addPhoneme(text: string, ph: string, alphabet = 'ipa'): this {
-        return this.addText(`<phoneme alphabet="${alphabet}" ph="${SpeechBuilder.escapeXml(ph)}">${text}</phoneme>`);
+        return this.addText(
+            text, undefined, undefined, {
+                phoneme: {
+                    alphabet,
+                    ph: SpeechBuilder.escapeXml(ph)
+                }
+            } 
+        );
     }
 
     /**
@@ -197,6 +261,9 @@ export class SpeechBuilder {
      * @return {string}
      */
     toString(): string {
+        if (Object.keys(this.prosody).length) {
+            this.speech = this.wrapInSsmlElement(this.speech, 'prosody', this.prosody);
+        }
         return this.speech;
     }
 

--- a/jovo-core/test/speechbuilder.test.ts
+++ b/jovo-core/test/speechbuilder.test.ts
@@ -16,6 +16,16 @@ test('is ssml string without duplicate <speak> tags', () => {
     expect(ssmlString).toBe('<speak>test</speak>');
 });
 
+test('setProsody', () => {
+    const speechBuilder = new SpeechBuilder();
+    speechBuilder.addText('text1').addText('text2').setProsody({rate: 'fast'});
+    expect(speechBuilder.toString()).toBe('<prosody rate="fast">text1 text2</prosody>');
+
+    // order shouldn't matter
+    const speechBuilder2 = new SpeechBuilder();
+    speechBuilder2.setProsody({rate: 'fast'}).addText('text1').addText('text2');
+    expect(speechBuilder2.toString()).toBe('<prosody rate="fast">text1 text2</prosody>');
+});
 
 test('addText', () => {
     const speechBuilder = new SpeechBuilder();
@@ -41,6 +51,26 @@ test('addText', () => {
     expect(speechBuilder4.toString()).toBe('');
     speechBuilder4.addText('text1', true, 1.0);
     expect(speechBuilder4.toString()).toBe('text1');
+
+    const speechBuilder5 = new SpeechBuilder();
+    speechBuilder5.addText('text1', true, 1.0, {
+        prosody: {
+            pitch: '+1st',
+            rate: 'fast'
+        }
+    });
+    expect(speechBuilder5.toString()).toBe('<prosody pitch="+1st" rate="fast">text1</prosody>');
+
+    const speechBuilder6 = new SpeechBuilder();
+    speechBuilder6.addText('text1', true, 1.0, {
+        emphasis: {
+            level: 'moderate'
+        },
+        prosody: {
+            rate: 'fast'
+        }
+    });
+    expect(speechBuilder6.toString()).toBe('<prosody rate="fast"><emphasis level="moderate">text1</emphasis></prosody>');
 });
 
 test('addBreak', () => {


### PR DESCRIPTION
## Proposed changes
Changes to SpeechBuilder's addText method to support arbitrary SSML elements. #431 

These changes simplify adding other helper methods for SSML syntax and allow users to add SSML supported by a specific platform even if Jovo hasn't been updated its API with helper methods.

I'd like feedback on if it would make sense for another argument to added to the other public methods as well, so a user could addSentence with some surrounding SSML tags.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed