### PR TITLE
Add alexa res getters

### DIFF
--- a/docs/basic-concepts/requests-responses/response.md
+++ b/docs/basic-concepts/requests-responses/response.md
@@ -6,6 +6,9 @@ Learn more about the Jovo `$response` object.
 * [Cross-Platform Methods](#cross-platform-methods)
    * [Response Setters](#response-setters)
    * [Response Getters](#response-getters)
+* [Platform Specific Methods](#platform-specific-methods)
+   * [Alexa Methods](#alexa-methods)
+      * [Alexa Response Getters](#alexa-response-getters)
 
 ## Introduction
 
@@ -25,9 +28,9 @@ The response gets assembled from the `$output` object in the [`platform.output` 
 
 ### Response Setters
 
-| Method        | Description        | 
-| ------------- |-------------| 
-| `setSessionData(sessionData: SessionData)` | Setts session data. [Learn more about session data here](../../basic-concepts/data#session-data '../data#session-data'). | 
+| Method        | Description        |
+| ------------- |-------------|
+| `setSessionData(sessionData: SessionData)` | Setts session data. [Learn more about session data here](../../basic-concepts/data#session-data '../data#session-data'). |
 
 
 ### Response Getters
@@ -36,16 +39,37 @@ For some use cases (especially [Unit Testing](../../testing/unit-testing.md '../
 
 You can use these cross-platform helper methods:
 
-| Method        | Description        | 
-| ------------- |-------------| 
-| `getSpeech(): string` | Returns speech text without "speak" and tags. | 
-| `getReprompt(): string` | Returns reprompt text without "speak" tags. | 
+| Method        | Description        |
+| ------------- |-------------|
+| `getSpeech(): string` | Returns speech text without "speak" and tags. |
+| `getReprompt(): string` | Returns reprompt text without "speak" tags. |
 | `hasSessionData(name: string, value?: any): boolean` | Checks if response has a specific session attribute in it.
-| `getSessionData(): SessionData | undefined` | Returns session data. [Learn more about session data here](../../basic-concepts/data#session-data '../data#session-data'). | 
-| `hasSessionEnded(): boolean` | Returns `true` if session ended | 
-| `hasState(state: string): boolean` | Checks if response has state in it | 
+| `getSessionData(): SessionData | undefined` | Returns session data. [Learn more about session data here](../../basic-concepts/data#session-data '../data#session-data'). |
+| `hasSessionEnded(): boolean` | Returns `true` if session ended |
+| `hasState(state: string): boolean` | Checks if response has state in it |
 
+## Platform Specific Methods
 
+### Alexa Methods
+
+#### Alexa Response Getters
+
+| Method        | Description        |
+| ------------- |-------------|
+| `hasAskForAddressCard(): boolean` | Checks that Alexa permissions card is present and contains `read::alexa:device:all:address` |
+| `hasAskForCountryAndPostalCodeCard(): boolean` | Checks that Alexa permissions card is present and contains `read::alexa:device:all:address:country_and_postal_code` |
+| `hasLinkAccountCard(): boolean` | Checks that Alexa `LinkAcount` card is present. |
+| `hasStandardCard(title?: string, text?: string, smallImageUrl?: string, largeImageUrl?: string): boolean` | Checks if response has a standard Alexa card. |
+| `hasSimpleCard(title?: string, text?: string): boolean` | Checks if response has a simple Alexa card.|
+| `hasAplDirective(): boolean` | Checks if response APL directive.|
+| `hasDisplayDirective(): boolean` | Checks if response has display template directive.|
+| `hasAudioDirective(): boolean` | Checks if response has audio directive.|
+| `hasVideoDirective(): boolean` | Checks if response has video directive.|
+| `getDirectives(): Directives object | undefind` | Returns entire directives object from response.|
+| `getAplDirective(): APL object | undefind` | Returns APL object from response.|
+| `getDisplayDirective(): Display object |undefind` | Returns Display Template object from response.|
+| `getAudioDirective(): Audio object | undefind` | Returns Audio Player object from response.|
+| `getVideoDirective(): Video object | undefind` | Returns Video Player object from response.|
 
 
 <!--[metadata]: {"description": "Learn more about the Jovo $response object.",

--- a/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/CountryPostalCardAsk.json
+++ b/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/CountryPostalCardAsk.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "sessionAttributes": {},
+  "response": {
+    "outputSpeech": {
+      "type": "SSML",
+      "ssml": "<speak>Simple Ask</speak>"
+    },
+    "reprompt": {
+      "outputSpeech": {
+        "type": "SSML",
+        "ssml": "<speak>Simple Ask Reprompt</speak>"
+      }
+    },
+    "card": {
+      "type": "AskForPermissionsConsent",
+      "permissions": [
+        "read::alexa:device:all:address:country_and_postal_code"
+      ]
+    },
+    "shouldEndSession": false
+  }
+}

--- a/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/FullAddressCardAsk.json
+++ b/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/FullAddressCardAsk.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "sessionAttributes": {},
+  "response": {
+    "outputSpeech": {
+      "type": "SSML",
+      "ssml": "<speak>Simple Ask</speak>"
+    },
+    "reprompt": {
+      "outputSpeech": {
+        "type": "SSML",
+        "ssml": "<speak>Simple Ask Reprompt</speak>"
+      }
+    },
+    "card": {
+      "type": "AskForPermissionsConsent",
+      "permissions": [
+        "read::alexa:device:all:address"
+      ]
+    },
+    "shouldEndSession": false
+  }
+}

--- a/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/LinkAccountCardAsk.json
+++ b/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/LinkAccountCardAsk.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0",
+  "sessionAttributes": {},
+  "response": {
+    "outputSpeech": {
+      "type": "SSML",
+      "ssml": "<speak>Simple Ask</speak>"
+    },
+    "reprompt": {
+      "outputSpeech": {
+        "type": "SSML",
+        "ssml": "<speak>Simple Ask Reprompt</speak>"
+      }
+    },
+    "card": {
+      "type": "LinkAccount"
+    },
+    "shouldEndSession": false
+  }
+}

--- a/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/directives.json
+++ b/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/directives.json
@@ -1,0 +1,88 @@
+{
+  "version": "1.0",
+  "response": {
+    "shouldEndSession": false,
+    "outputSpeech": {
+      "type": "SSML",
+      "ssml": "<speak>Sample Text</speak>"
+    },
+    "reprompt": {
+      "outputSpeech": {
+        "type": "SSML",
+        "ssml": "<speak>What else can I do for you?</speak>"
+      }
+    },
+    "directives": [
+      {
+        "type": "Display.RenderTemplate",
+        "template": {
+          "type": "BodyTemplate7",
+          "token": "BodyTemplate7",
+          "title": "Title",
+          "backgroundImage": {
+            "contentDescription": "Textured grey background",
+            "sources": [
+              {
+                "url": "http://url.com"
+              }
+            ]
+          },
+          "image": {
+            "contentDescription": "Mount St. Helens landscape",
+            "sources": [
+              {
+                "url": "http://url.com"
+              }
+            ]
+          },
+          "backButton": "HIDDEN"
+        }
+      },
+      {
+        "version": "1.0",
+        "document": {
+          "type": "APL",
+          "version": "1.0",
+          "import": [],
+          "resources": [],
+          "styles": {},
+          "layouts": {},
+          "mainTemplate": {
+            "description": "apl template",
+            "parameters": [
+              "datasources"
+            ],
+            "items": [
+              {
+                "type": "baseContainer"
+              }
+            ]
+          }
+        },
+        "datasources": {
+          "templateData": {
+            "type": "object",
+            "header": {
+              "headerTitle": "Title"
+            },
+            "textContent": {
+              "text": "Sample text"
+            }
+          }
+        }
+      }
+    ],
+    "card": {
+      "type": "Standard",
+      "image": {
+        "smallImageUrl": "https://via.placeholder.com/720x480",
+        "largeImageUrl": "https://via.placeholder.com/1200x800"
+      },
+      "title": "Standard Title",
+      "text": "Standard Text"
+    }
+  },
+  "sessionAttributes": {
+    "session": "attribute"
+  }
+}

--- a/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/directives.json
+++ b/jovo-integrations/jovo-platform-alexa/sample-response-json/v1/directives.json
@@ -39,6 +39,17 @@
         }
       },
       {
+        "type": "AudioPlayer.Play",
+        "playBehavior": "REPLACE_ALL",
+        "audioItem": {
+          "stream": {
+            "url": "www.sampleAudio.mp3",
+            "token": "someToken",
+            "offsetInMilliseconds": 0
+          }
+        }
+      },
+      {
         "version": "1.0",
         "document": {
           "type": "APL",
@@ -68,6 +79,15 @@
             "textContent": {
               "text": "Sample text"
             }
+          }
+        }
+      },
+      {
+        "type": "VideoApp.Launch",
+        "videoItem": {
+          "source": "www.sampleVideo.mp4",
+          "metadata": {
+            "title": "Sample Video Title"
           }
         }
       }

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
@@ -45,6 +45,10 @@ export class AlexaResponse implements JovoResponse {
         return _get(this, 'response.card');
     }
 
+    getDirectives() {
+        return _get(this, 'response.directives');
+    }
+
     getSessionData(path?: string) {
         if (path) {
             return this.getSessionAttribute(path);
@@ -212,6 +216,34 @@ export class AlexaResponse implements JovoResponse {
         return true;
     }
 
+    getApl() {
+        if (this.getDirectives()) {
+            const directivesArray = this.getDirectives();
+
+            for (const directiveItem of directivesArray) {
+                if (directiveItem.document) {
+                    if (directiveItem.document.type === 'APL') {
+                        return directiveItem;
+                    }
+                }
+
+            }
+        }
+        return;
+    }
+
+    getDisplayTemplate() {
+        if (this.getDirectives()) {
+            const directivesArray = this.getDirectives();
+
+            for (const directiveItem of directivesArray) {
+                if (directiveItem.type === 'Display.RenderTemplate') {
+                    return directiveItem;
+                }
+            }
+        }
+        return;
+    }
     /**
      * Checks if response is a tell request
      * @param {string| string[]} speechText

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
@@ -48,6 +48,79 @@ export class AlexaResponse implements JovoResponse {
     getDirectives() {
         return _get(this, 'response.directives');
     }
+    getDirective(directiveType?: string) {
+        const allDirectives = this.getDirectives();
+
+        for (const directiveItem of allDirectives) {
+            if (directiveItem.type && directiveItem.type.indexOf(directiveType) > -1) {
+                return directiveItem;
+            }
+        }
+    }
+
+    getAplDirective() {
+        const allDirectives = this.getDirectives();
+
+        if (allDirectives) {
+            for (const directiveItem of allDirectives) {
+                if (directiveItem.document && directiveItem.document.type === 'APL') {
+                    return directiveItem;
+                }
+            }
+        }
+
+        return;
+    }
+    hasAplDirective(): boolean {
+        if (!this.getAplDirective()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    getDisplayDirective() {
+        if (this.getDirectives()) {
+            return this.getDirective('Display');
+        }
+        return;
+    }
+
+    hasDisplayDirective(): boolean {
+        if (!this.getDisplayDirective()) {
+            return false;
+        }
+
+        return true;
+    }
+    getAudioDirective() {
+        if (this.getDirectives()) {
+            return this.getDirective('AudioPlayer');
+        }
+        return;
+    }
+
+    hasAudioDirective(): boolean {
+        if (!this.getAudioDirective()) {
+            return false;
+        }
+
+        return true;
+    }
+    getVideoDirective() {
+        if (this.getDirectives()) {
+            return this.getDirective('VideoApp');
+        }
+        return;
+    }
+
+    hasVideoDirective(): boolean {
+        if (!this.getVideoDirective()) {
+            return false;
+        }
+
+        return true;
+    }
 
     getSessionData(path?: string) {
         if (path) {
@@ -68,8 +141,6 @@ export class AlexaResponse implements JovoResponse {
     getSessionAttributes() {
         return _get(this, 'sessionAttributes');
     }
-
-
 
     setSessionAttributes(sessionData: SessionData) {
         _set(this, 'sessionAttributes', sessionData);
@@ -216,34 +287,6 @@ export class AlexaResponse implements JovoResponse {
         return true;
     }
 
-    getApl() {
-        if (this.getDirectives()) {
-            const directivesArray = this.getDirectives();
-
-            for (const directiveItem of directivesArray) {
-                if (directiveItem.document) {
-                    if (directiveItem.document.type === 'APL') {
-                        return directiveItem;
-                    }
-                }
-
-            }
-        }
-        return;
-    }
-
-    getDisplayTemplate() {
-        if (this.getDirectives()) {
-            const directivesArray = this.getDirectives();
-
-            for (const directiveItem of directivesArray) {
-                if (directiveItem.type === 'Display.RenderTemplate') {
-                    return directiveItem;
-                }
-            }
-        }
-        return;
-    }
     /**
      * Checks if response is a tell request
      * @param {string| string[]} speechText

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
@@ -287,6 +287,71 @@ export class AlexaResponse implements JovoResponse {
         return true;
     }
 
+        /**
+     * Checks if response object contains a LinkAccount card.
+     * @return {boolean}
+     */
+    hasLinkAccountCard(): boolean {
+        const cardObject = this.getCard();
+
+        if (!cardObject) {
+            return false;
+        }
+
+        if (cardObject.type !== 'LinkAccount') {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if response object contains a ask for address card.
+     * @return {boolean}
+     */
+    hasAskForAddressCard(): boolean {
+        const cardObject = this.getCard();
+
+        if (!cardObject) {
+            return false;
+        }
+        if (cardObject.type !== 'AskForPermissionsConsent') {
+            return false;
+        }
+
+        if (cardObject.permissions.length === 0) {
+            return false;
+        }
+        if (cardObject.permissions[0] !== 'read::alexa:device:all:address') {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if response object contains a ask for country and postal code card.
+     * @return {boolean}
+     */
+    hasAskForCountryAndPostalCodeCard():boolean {
+        const cardObject = this.getCard();
+
+        if (!cardObject) {
+            return false;
+        }
+        if (cardObject.type !== 'AskForPermissionsConsent') {
+            return false;
+        }
+
+        if (cardObject.permissions.length === 0) {
+            return false;
+        }
+
+        if (cardObject.permissions[0] !== 'read::alexa:device:all:address:country_and_postal_code') {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Checks if response is a tell request
      * @param {string| string[]} speechText

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaResponse.ts
@@ -287,7 +287,7 @@ export class AlexaResponse implements JovoResponse {
         return true;
     }
 
-        /**
+    /**
      * Checks if response object contains a LinkAccount card.
      * @return {boolean}
      */

--- a/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
@@ -13,111 +13,184 @@ process.env.NODE_ENV = 'TEST';
 
 test('test getDirectives', () => {
     const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
-    const directivesArray = directivesResponse.getApl();
-console.log(directivesArray);
+    const directivesArray = directivesResponse.getDirectives();
+
     expect(directivesArray).not.toBeUndefined();
     expect(directivesArray[0].type).toMatch('Display.RenderTemplate');
-    expect(directivesArray[1].document.type).toMatch('APL');
+    expect(directivesArray[1].type).toMatch('AudioPlayer.Play');
+    expect(directivesArray[2].document.type).toMatch('APL');
+    expect(directivesArray[3].type).toMatch('VideoApp.Launch');
 
     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
     expect(askResponse.getDirectives()).toBeUndefined();
+});
+
+test('test getAplDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    expect(directivesResponse.getAplDirective()).not.toBeUndefined();
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.getAplDirective()).toBeUndefined();
+});
+
+test('test hasAplDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    expect(directivesResponse.hasAplDirective()).toBe(true);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasAplDirective()).toBe(false);
+});
+
+test('test getDisplayDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    const displayDirective = directivesResponse.getDisplayDirective();
+
+    expect(displayDirective).not.toBeUndefined();
+    expect(displayDirective.type).toMatch('Display.RenderTemplate');
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.getDisplayDirective()).toBeUndefined();
+});
+
+test('test hasDisplayDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    expect(directivesResponse.hasDisplayDirective()).toBe(true);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasDisplayDirective()).toBe(false);
+});
+
+test('test getAudioDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    const displayDirective = directivesResponse.getAudioDirective();
+
+    expect(displayDirective).not.toBeUndefined();
+    expect(displayDirective.type).toMatch('AudioPlayer.Play');
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.getAudioDirective()).toBeUndefined();
+});
+
+test('test hasAudioDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    expect(directivesResponse.hasAudioDirective()).toBe(true);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasAudioDirective()).toBe(false);
+});
+
+test('test getVideoDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    const displayDirective = directivesResponse.getVideoDirective();
+
+    expect(displayDirective).not.toBeUndefined();
+    expect(displayDirective.type).toMatch('VideoApp.Launch');
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.getVideoDirective()).toBeUndefined();
+});
+
+test('test hasVideoDirective', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    expect(directivesResponse.hasVideoDirective()).toBe(true);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasVideoDirective()).toBe(false);
+});
+test('test isTell', () => {
+    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+    expect(tellResponse.isTell()).toBe(true);
+    expect(tellResponse.isTell('Simple Tell')).toBe(true);
+    expect(tellResponse.isTell(['Simple Tell', 'foo', 'bar'])).toBe(true);
+
+    expect(tellResponse.isTell('Foo')).toBe(false);
+    expect(tellResponse.isTell(['foo', 'bar'])).toBe(false);
+
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.isTell()).toBe(false);
 
 });
 
-// test('test isTell', () => {
-//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-//     expect(tellResponse.isTell()).toBe(true);
-//     expect(tellResponse.isTell('Simple Tell')).toBe(true);
-//     expect(tellResponse.isTell(['Simple Tell', 'foo', 'bar'])).toBe(true);
+test('test isAsk', () => {
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.isAsk()).toBe(true);
+    expect(askResponse.isAsk('Simple Ask')).toBe(true);
+    expect(askResponse.isAsk('Simple Ask', 'Simple Ask Reprompt')).toBe(true);
 
-//     expect(tellResponse.isTell('Foo')).toBe(false);
-//     expect(tellResponse.isTell(['foo', 'bar'])).toBe(false);
+    expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'])).toBe(true);
+    expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'], ['Simple Ask Reprompt', 'foo', 'bar'])).toBe(true);
 
+    expect(askResponse.isAsk('Foo')).toBe(false);
+    expect(askResponse.isAsk(['foo', 'bar'])).toBe(false);
 
-//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-//     expect(askResponse.isTell()).toBe(false);
+    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+    expect(tellResponse.isAsk()).toBe(false);
 
-// });
+});
 
-// test('test isAsk', () => {
-//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-//     expect(askResponse.isAsk()).toBe(true);
-//     expect(askResponse.isAsk('Simple Ask')).toBe(true);
-//     expect(askResponse.isAsk('Simple Ask', 'Simple Ask Reprompt')).toBe(true);
+test('test hasState', () => {
+    const responseWithState = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    responseWithState.sessionAttributes = {"_JOVO_STATE_":"test"};
 
-//     expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'])).toBe(true);
-//     expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'], ['Simple Ask Reprompt', 'foo', 'bar'])).toBe(true);
+    expect(responseWithState.hasState('test')).toBe(true);
+    expect(responseWithState.hasState('test123')).toBe(false);
+    expect(responseWithState.hasState()).toBe(true);
 
-//     expect(askResponse.isAsk('Foo')).toBe(false);
-//     expect(askResponse.isAsk(['foo', 'bar'])).toBe(false);
+    const responseWithoutState = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+    expect(responseWithoutState.hasState('test123')).toBe(false);
+    expect(responseWithoutState.hasState()).toBe(false);
+});
 
-//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-//     expect(tellResponse.isAsk()).toBe(false);
+test('test hasSimpleCard', () => {
+    const simpleCardResponse = AlexaResponse.fromJSON(_cloneDeep(simpleCard));
+    expect(simpleCardResponse.hasSimpleCard()).toBe(true);
 
-// });
+    expect(simpleCardResponse.hasSimpleCard('Simple Title')).toBe(true);
+    expect(simpleCardResponse.hasSimpleCard('title')).toBe(false);
 
-// test('test hasState', () => {
-//     const responseWithState = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-//     responseWithState.sessionAttributes = {"_JOVO_STATE_":"test"};
+    expect(simpleCardResponse.hasSimpleCard('Simple Title', 'Simple Text')).toBe(true);
+    expect(simpleCardResponse.hasSimpleCard('Simple Title', 'no')).toBe(false);
 
-//     expect(responseWithState.hasState('test')).toBe(true);
-//     expect(responseWithState.hasState('test123')).toBe(false);
-//     expect(responseWithState.hasState()).toBe(true);
+    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+    expect(tellResponse.hasStandardCard()).toBe(false);
+});
 
-//     const responseWithoutState = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-//     expect(responseWithoutState.hasState('test123')).toBe(false);
-//     expect(responseWithoutState.hasState()).toBe(false);
-// });
+test('test hasStandardCard', () => {
+    const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
+    expect(standardCardResponse.hasStandardCard()).toBe(true);
 
-// test('test hasSimpleCard', () => {
-//     const simpleCardResponse = AlexaResponse.fromJSON(_cloneDeep(simpleCard));
-//     expect(simpleCardResponse.hasSimpleCard()).toBe(true);
+    expect(standardCardResponse.hasStandardCard('Standard Title')).toBe(true);
+    expect(standardCardResponse.hasStandardCard('title')).toBe(false);
 
-//     expect(simpleCardResponse.hasSimpleCard('Simple Title')).toBe(true);
-//     expect(simpleCardResponse.hasSimpleCard('title')).toBe(false);
+    expect(standardCardResponse.hasStandardCard('Standard Title', 'Standard Text')).toBe(true);
+    expect(standardCardResponse.hasStandardCard('Standard Title', 'no')).toBe(false);
 
-//     expect(simpleCardResponse.hasSimpleCard('Simple Title', 'Simple Text')).toBe(true);
-//     expect(simpleCardResponse.hasSimpleCard('Simple Title', 'no')).toBe(false);
+    expect(standardCardResponse.hasStandardCard(
+        'Standard Title',
+        'Standard Text',
+        'https://via.placeholder.com/720x480'
+    )).toBe(true);
+    expect(standardCardResponse.hasStandardCard(
+        'Standard Title',
+        'Standard Text',
+        'https://via.placeholder.com/'
+    )).toBe(false);
 
-//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-//     expect(tellResponse.hasStandardCard()).toBe(false);
-// });
+    expect(standardCardResponse.hasStandardCard(
+        'Standard Title',
+        'Standard Text',
+        'https://via.placeholder.com/720x480',
+        'https://via.placeholder.com/1200x800'
+    )).toBe(true);
+    expect(standardCardResponse.hasStandardCard(
+        'Standard Title',
+        'Standard Text',
+        'https://via.placeholder.com/',
+        'https://via.placeholder.com/'
+    )).toBe(false);
 
-// test('test hasStandardCard', () => {
-//     const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
-//     expect(standardCardResponse.hasStandardCard()).toBe(true);
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasStandardCard()).toBe(false);
 
-//     expect(standardCardResponse.hasStandardCard('Standard Title')).toBe(true);
-//     expect(standardCardResponse.hasStandardCard('title')).toBe(false);
-
-//     expect(standardCardResponse.hasStandardCard('Standard Title', 'Standard Text')).toBe(true);
-//     expect(standardCardResponse.hasStandardCard('Standard Title', 'no')).toBe(false);
-
-//     expect(standardCardResponse.hasStandardCard(
-//         'Standard Title',
-//         'Standard Text',
-//         'https://via.placeholder.com/720x480'
-//     )).toBe(true);
-//     expect(standardCardResponse.hasStandardCard(
-//         'Standard Title',
-//         'Standard Text',
-//         'https://via.placeholder.com/'
-//     )).toBe(false);
-
-//     expect(standardCardResponse.hasStandardCard(
-//         'Standard Title',
-//         'Standard Text',
-//         'https://via.placeholder.com/720x480',
-//         'https://via.placeholder.com/1200x800'
-//     )).toBe(true);
-//     expect(standardCardResponse.hasStandardCard(
-//         'Standard Title',
-//         'Standard Text',
-//         'https://via.placeholder.com/',
-//         'https://via.placeholder.com/'
-//     )).toBe(false);
-
-//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-//     expect(askResponse.hasStandardCard()).toBe(false);
-
-// });
+});

--- a/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
@@ -2,6 +2,7 @@
 
 import {AlexaResponse} from "../src/core/AlexaResponse";
 import _cloneDeep = require('lodash.clonedeep');
+const directivesJSON = require('./../sample-response-json/v1/directives.json');
 const askJSON = require('./../sample-response-json/v1/ASK.json');
 const tellJSON = require('./../sample-response-json/v1/TELL.json');
 const simpleCard = require('./../sample-response-json/v1/SimpleCardTell.json');
@@ -10,100 +11,113 @@ const standardCard = require('./../sample-response-json/v1/StandardCardAsk.json'
 
 process.env.NODE_ENV = 'TEST';
 
-test('test isTell', () => {
-    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-    expect(tellResponse.isTell()).toBe(true);
-    expect(tellResponse.isTell('Simple Tell')).toBe(true);
-    expect(tellResponse.isTell(['Simple Tell', 'foo', 'bar'])).toBe(true);
-
-    expect(tellResponse.isTell('Foo')).toBe(false);
-    expect(tellResponse.isTell(['foo', 'bar'])).toBe(false);
-
+test('test getDirectives', () => {
+    const directivesResponse = AlexaResponse.fromJSON(_cloneDeep(directivesJSON));
+    const directivesArray = directivesResponse.getApl();
+console.log(directivesArray);
+    expect(directivesArray).not.toBeUndefined();
+    expect(directivesArray[0].type).toMatch('Display.RenderTemplate');
+    expect(directivesArray[1].document.type).toMatch('APL');
 
     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-    expect(askResponse.isTell()).toBe(false);
+    expect(askResponse.getDirectives()).toBeUndefined();
 
 });
 
-test('test isAsk', () => {
-    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-    expect(askResponse.isAsk()).toBe(true);
-    expect(askResponse.isAsk('Simple Ask')).toBe(true);
-    expect(askResponse.isAsk('Simple Ask', 'Simple Ask Reprompt')).toBe(true);
+// test('test isTell', () => {
+//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+//     expect(tellResponse.isTell()).toBe(true);
+//     expect(tellResponse.isTell('Simple Tell')).toBe(true);
+//     expect(tellResponse.isTell(['Simple Tell', 'foo', 'bar'])).toBe(true);
 
-    expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'])).toBe(true);
-    expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'], ['Simple Ask Reprompt', 'foo', 'bar'])).toBe(true);
+//     expect(tellResponse.isTell('Foo')).toBe(false);
+//     expect(tellResponse.isTell(['foo', 'bar'])).toBe(false);
 
-    expect(askResponse.isAsk('Foo')).toBe(false);
-    expect(askResponse.isAsk(['foo', 'bar'])).toBe(false);
 
-    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-    expect(tellResponse.isAsk()).toBe(false);
+//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+//     expect(askResponse.isTell()).toBe(false);
 
-});
+// });
 
-test('test hasState', () => {
-    const responseWithState = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-    responseWithState.sessionAttributes = {"_JOVO_STATE_":"test"};
+// test('test isAsk', () => {
+//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+//     expect(askResponse.isAsk()).toBe(true);
+//     expect(askResponse.isAsk('Simple Ask')).toBe(true);
+//     expect(askResponse.isAsk('Simple Ask', 'Simple Ask Reprompt')).toBe(true);
 
-    expect(responseWithState.hasState('test')).toBe(true);
-    expect(responseWithState.hasState('test123')).toBe(false);
-    expect(responseWithState.hasState()).toBe(true);
+//     expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'])).toBe(true);
+//     expect(askResponse.isAsk(['Simple Ask', 'foo', 'bar'], ['Simple Ask Reprompt', 'foo', 'bar'])).toBe(true);
 
-    const responseWithoutState = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-    expect(responseWithoutState.hasState('test123')).toBe(false);
-    expect(responseWithoutState.hasState()).toBe(false);
-});
+//     expect(askResponse.isAsk('Foo')).toBe(false);
+//     expect(askResponse.isAsk(['foo', 'bar'])).toBe(false);
 
-test('test hasSimpleCard', () => {
-    const simpleCardResponse = AlexaResponse.fromJSON(_cloneDeep(simpleCard));
-    expect(simpleCardResponse.hasSimpleCard()).toBe(true);
+//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+//     expect(tellResponse.isAsk()).toBe(false);
 
-    expect(simpleCardResponse.hasSimpleCard('Simple Title')).toBe(true);
-    expect(simpleCardResponse.hasSimpleCard('title')).toBe(false);
+// });
 
-    expect(simpleCardResponse.hasSimpleCard('Simple Title', 'Simple Text')).toBe(true);
-    expect(simpleCardResponse.hasSimpleCard('Simple Title', 'no')).toBe(false);
+// test('test hasState', () => {
+//     const responseWithState = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+//     responseWithState.sessionAttributes = {"_JOVO_STATE_":"test"};
 
-    const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
-    expect(tellResponse.hasStandardCard()).toBe(false);
-});
+//     expect(responseWithState.hasState('test')).toBe(true);
+//     expect(responseWithState.hasState('test123')).toBe(false);
+//     expect(responseWithState.hasState()).toBe(true);
 
-test('test hasStandardCard', () => {
-    const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
-    expect(standardCardResponse.hasStandardCard()).toBe(true);
+//     const responseWithoutState = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+//     expect(responseWithoutState.hasState('test123')).toBe(false);
+//     expect(responseWithoutState.hasState()).toBe(false);
+// });
 
-    expect(standardCardResponse.hasStandardCard('Standard Title')).toBe(true);
-    expect(standardCardResponse.hasStandardCard('title')).toBe(false);
+// test('test hasSimpleCard', () => {
+//     const simpleCardResponse = AlexaResponse.fromJSON(_cloneDeep(simpleCard));
+//     expect(simpleCardResponse.hasSimpleCard()).toBe(true);
 
-    expect(standardCardResponse.hasStandardCard('Standard Title', 'Standard Text')).toBe(true);
-    expect(standardCardResponse.hasStandardCard('Standard Title', 'no')).toBe(false);
+//     expect(simpleCardResponse.hasSimpleCard('Simple Title')).toBe(true);
+//     expect(simpleCardResponse.hasSimpleCard('title')).toBe(false);
 
-    expect(standardCardResponse.hasStandardCard(
-        'Standard Title',
-        'Standard Text',
-        'https://via.placeholder.com/720x480'
-    )).toBe(true);
-    expect(standardCardResponse.hasStandardCard(
-        'Standard Title',
-        'Standard Text',
-        'https://via.placeholder.com/'
-    )).toBe(false);
+//     expect(simpleCardResponse.hasSimpleCard('Simple Title', 'Simple Text')).toBe(true);
+//     expect(simpleCardResponse.hasSimpleCard('Simple Title', 'no')).toBe(false);
 
-    expect(standardCardResponse.hasStandardCard(
-        'Standard Title',
-        'Standard Text',
-        'https://via.placeholder.com/720x480',
-        'https://via.placeholder.com/1200x800'
-    )).toBe(true);
-    expect(standardCardResponse.hasStandardCard(
-        'Standard Title',
-        'Standard Text',
-        'https://via.placeholder.com/',
-        'https://via.placeholder.com/'
-    )).toBe(false);
+//     const tellResponse = AlexaResponse.fromJSON(_cloneDeep(tellJSON));
+//     expect(tellResponse.hasStandardCard()).toBe(false);
+// });
 
-    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
-    expect(askResponse.hasStandardCard()).toBe(false);
+// test('test hasStandardCard', () => {
+//     const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
+//     expect(standardCardResponse.hasStandardCard()).toBe(true);
 
-});
+//     expect(standardCardResponse.hasStandardCard('Standard Title')).toBe(true);
+//     expect(standardCardResponse.hasStandardCard('title')).toBe(false);
+
+//     expect(standardCardResponse.hasStandardCard('Standard Title', 'Standard Text')).toBe(true);
+//     expect(standardCardResponse.hasStandardCard('Standard Title', 'no')).toBe(false);
+
+//     expect(standardCardResponse.hasStandardCard(
+//         'Standard Title',
+//         'Standard Text',
+//         'https://via.placeholder.com/720x480'
+//     )).toBe(true);
+//     expect(standardCardResponse.hasStandardCard(
+//         'Standard Title',
+//         'Standard Text',
+//         'https://via.placeholder.com/'
+//     )).toBe(false);
+
+//     expect(standardCardResponse.hasStandardCard(
+//         'Standard Title',
+//         'Standard Text',
+//         'https://via.placeholder.com/720x480',
+//         'https://via.placeholder.com/1200x800'
+//     )).toBe(true);
+//     expect(standardCardResponse.hasStandardCard(
+//         'Standard Title',
+//         'Standard Text',
+//         'https://via.placeholder.com/',
+//         'https://via.placeholder.com/'
+//     )).toBe(false);
+
+//     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+//     expect(askResponse.hasStandardCard()).toBe(false);
+
+// });

--- a/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
@@ -199,8 +199,8 @@ test('test hasStandardCard', () => {
 });
 
 test('test hasLinkAccountCard', () => {
-    const LinkAccountResponse = AlexaResponse.fromJSON(_cloneDeep(linkAccountCard));
-    expect(LinkAccountResponse.hasLinkAccountCard()).toBe(true);
+    const linkAccountResponse = AlexaResponse.fromJSON(_cloneDeep(linkAccountCard));
+    expect(linkAccountResponse.hasLinkAccountCard()).toBe(true);
 
     const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
     expect(standardCardResponse.hasLinkAccountCard()).toBe(false);
@@ -211,11 +211,11 @@ test('test hasLinkAccountCard', () => {
 });
 
 test('test hasAskForAddressCard', () => {
-    const FullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
-    expect(FullAddressResponse.hasAskForAddressCard()).toBe(true);
+    const fullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
+    expect(fullAddressResponse.hasAskForAddressCard()).toBe(true);
 
-    const CountryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
-    expect(CountryPostalResponse.hasAskForAddressCard()).toBe(false);
+    const countryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
+    expect(countryPostalResponse.hasAskForAddressCard()).toBe(false);
 
     const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
     expect(standardCardResponse.hasAskForAddressCard()).toBe(false);
@@ -226,11 +226,11 @@ test('test hasAskForAddressCard', () => {
 });
 
 test('test hasAskForCountryAndPostalCodeCard', () => {
-    const CountryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
-    expect(CountryPostalResponse.hasAskForCountryAndPostalCodeCard()).toBe(true);
+    const countryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
+    expect(countryPostalResponse.hasAskForCountryAndPostalCodeCard()).toBe(true);
 
-    const FullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
-    expect(FullAddressResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);
+    const fullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
+    expect(fullAddressResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);
 
     const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
     expect(standardCardResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);

--- a/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
+++ b/jovo-integrations/jovo-platform-alexa/test/AlexaResponse.test.ts
@@ -5,6 +5,9 @@ import _cloneDeep = require('lodash.clonedeep');
 const directivesJSON = require('./../sample-response-json/v1/directives.json');
 const askJSON = require('./../sample-response-json/v1/ASK.json');
 const tellJSON = require('./../sample-response-json/v1/TELL.json');
+const countryPostalCard = require('./../sample-response-json/v1/CountryPostalCardAsk.json');
+const fullAddressCard = require('./../sample-response-json/v1/FullAddressCardAsk.json');
+const linkAccountCard = require('./../sample-response-json/v1/LinkAccountCardAsk.json');
 const simpleCard = require('./../sample-response-json/v1/SimpleCardTell.json');
 const standardCard = require('./../sample-response-json/v1/StandardCardAsk.json');
 
@@ -192,5 +195,47 @@ test('test hasStandardCard', () => {
 
     const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
     expect(askResponse.hasStandardCard()).toBe(false);
+
+});
+
+test('test hasLinkAccountCard', () => {
+    const LinkAccountResponse = AlexaResponse.fromJSON(_cloneDeep(linkAccountCard));
+    expect(LinkAccountResponse.hasLinkAccountCard()).toBe(true);
+
+    const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
+    expect(standardCardResponse.hasLinkAccountCard()).toBe(false);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasLinkAccountCard()).toBe(false);
+
+});
+
+test('test hasAskForAddressCard', () => {
+    const FullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
+    expect(FullAddressResponse.hasAskForAddressCard()).toBe(true);
+
+    const CountryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
+    expect(CountryPostalResponse.hasAskForAddressCard()).toBe(false);
+
+    const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
+    expect(standardCardResponse.hasAskForAddressCard()).toBe(false);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasAskForAddressCard()).toBe(false);
+
+});
+
+test('test hasAskForCountryAndPostalCodeCard', () => {
+    const CountryPostalResponse = AlexaResponse.fromJSON(_cloneDeep(countryPostalCard));
+    expect(CountryPostalResponse.hasAskForCountryAndPostalCodeCard()).toBe(true);
+
+    const FullAddressResponse = AlexaResponse.fromJSON(_cloneDeep(fullAddressCard));
+    expect(FullAddressResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);
+
+    const standardCardResponse = AlexaResponse.fromJSON(_cloneDeep(standardCard));
+    expect(standardCardResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);
+
+    const askResponse = AlexaResponse.fromJSON(_cloneDeep(askJSON));
+    expect(askResponse.hasAskForCountryAndPostalCodeCard()).toBe(false);
 
 });


### PR DESCRIPTION
## Proposed changes
add in more alexa response getters ported from Jovo V1. They include:

`hasAskForAddressCard()`
 `hasAskForCountryAndPostalCodeCard()`
 `hasLinkAccountCard()`
 `hasStandardCard()`
 `hasSimpleCard()`
 `hasAplDirective()`
 `hasDisplayDirective()` 
 `hasAudioDirective()` 
 `hasVideoDirective()` 
 `getDirectives()`
 `getAplDirective()`
 `getDisplayDirective()` 
 `getAudioDirective()` 
 `getVideoDirective()`

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x ] My code follows the code style of this project
- [x ] My change requires a change to the documentation
- [x ] I have updated the documentation accordingly
- [x ] I have added tests to cover my changes
- [x ] All new and existing tests passed