### PR TITLE
GoogleAssistant- add multi simple responses

### DIFF
--- a/jovo-framework/src/middleware/user/JovoUser.ts
+++ b/jovo-framework/src/middleware/user/JovoUser.ts
@@ -327,7 +327,7 @@ export class JovoUser implements Plugin {
         Log.verbose(Log.header('Jovo user (load)', 'framework'));
         Log.yellow().verbose(`this.$user.getId(): ${userId}`);
 
-        if (!data) {
+        if (!data || data === undefined) {
             handleRequest.jovo.$user.isDeleted = false;
         } else {
             handleRequest.jovo.$user.new = false;

--- a/jovo-integrations/jovo-platform-alexa/src/core/AlexaRequest.ts
+++ b/jovo-integrations/jovo-platform-alexa/src/core/AlexaRequest.ts
@@ -200,9 +200,14 @@ export class AlexaRequest implements JovoRequest {
                 input.value = slots[slot].value;
                 input.key = slots[slot].value;
             }
-            if (_get(slots[slot], 'resolutions.resolutionsPerAuthority[0].values[0]')) {
-                input.key = _get(slots[slot], 'resolutions.resolutionsPerAuthority[0].values[0]').value.name;
-                input.id = _get(slots[slot], 'resolutions.resolutionsPerAuthority[0].values[0]').value.id;
+            const resolutionsPerAuthority=_get(slots[slot], 'resolutions.resolutionsPerAuthority')
+            if(resolutionsPerAuthority){
+                resolutionsPerAuthority.forEach(function(item){
+                    if (_get(item, 'values[0]')) {
+                        input.key = _get(item, 'values[0]').value.name;
+                        input.id = _get(item, 'values[0]').value.id;
+                    }
+                })
             }
             inputs[slot] = input;
         });

--- a/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleActionResponse.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/core/GoogleActionResponse.ts
@@ -4,6 +4,7 @@ import _get = require('lodash.get');
 export interface RichResponseItem {
     simpleResponse: {
         ssml?: string;
+        displayText?: string | undefined;
     };
 }
 

--- a/jovo-integrations/jovo-platform-googleassistant/src/index.ts
+++ b/jovo-integrations/jovo-platform-googleassistant/src/index.ts
@@ -339,7 +339,7 @@ declare module './core/GoogleAction' {
 
 declare module './core/GoogleAction' {
     interface GoogleAction {
-        displayText(displayText: string): this;
+        displayText(displayText: string, speech: string | undefined): this;
     }
 }
 


### PR DESCRIPTION
## Proposed changes
Allow multi simple responses with GoogleAssistant

## How to use : 
`
this.$googleAction.displayText("chat buble 1 ","<speak>speech for first response</speak>")
this.$googleAction.displayText("chat buble 2 ","<speak>speech for second response</speak>")
`


## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed