### PR TITLE
🐛 DB: Saves updatedAt only if it's defined

### DIFF
--- a/jovo-integrations/jovo-db-datastore/src/DatastoreDb.ts
+++ b/jovo-integrations/jovo-db-datastore/src/DatastoreDb.ts
@@ -114,7 +114,9 @@ export class DatastoreDb implements Db {
             entity = entities[0];
         }
 
-        _set(entity, 'updatedAt', updatedAt);
+        if (updatedAt) {
+            entity.updatedAt = updatedAt;
+        }
 
         // Don't confuse with the "data" key form the "save" method, actually this is
         // the data node necessary for datastore, whereas in the "save" method we add a second data

--- a/jovo-integrations/jovo-db-dynamodb/src/DynamoDb.ts
+++ b/jovo-integrations/jovo-db-dynamodb/src/DynamoDb.ts
@@ -172,9 +172,12 @@ export class DynamoDb implements Db {
             Item: {
                 [this.config.primaryKeyColumn!]: primaryKey,
                 [key]: data,
-                updatedAt
             }
         };
+        if (updatedAt) {
+            getDataMapParams.Item.updatedAt = updatedAt;
+        }
+
         if (!this.isCreating) {
             return await this.docClient!.put(getDataMapParams).promise();
         }

--- a/jovo-integrations/jovo-db-filedb/src/FileDb.ts
+++ b/jovo-integrations/jovo-db-filedb/src/FileDb.ts
@@ -101,13 +101,18 @@ export class FileDb implements Db {
 
         if(userData) {
             _set(userData, key, data);
-            _set(userData, 'updatedAt', updatedAt);
+            if (updatedAt) {
+                userData.updatedAt = updatedAt;
+            }
         } else {
             const newData = {
                 [this.config.primaryKeyColumn!]: primaryKey,
                 [key]: data,
-                updatedAt
             };
+            if (updatedAt) {
+                newData.updatedAt = updatedAt;
+            }
+
             users.push(newData);
         }
         Log.verbose(`Saving data to: ${this.config.pathToFile}`);

--- a/jovo-integrations/jovo-db-filedb/src/FileDb2.ts
+++ b/jovo-integrations/jovo-db-filedb/src/FileDb2.ts
@@ -78,13 +78,18 @@ export class FileDb2 implements Db {
             const oldDataContent = await this.readFile(pathToFile);
             const oldData = JSON.parse(oldDataContent);
             _set(oldData, key, data);
-            _set(oldData, 'updatedAt', updatedAt);
+            if (updatedAt) {
+                oldData.updatedAt = updatedAt;
+            }   
+
             return await this.saveFile(pathToFile, oldData);
         } else {
             const newData = {
                 [key]: data,
-                updatedAt
             };
+            if (updatedAt) {
+                newData.updatedAt = updatedAt;
+            }
             return await this.saveFile(pathToFile, newData);
         }
     }

--- a/jovo-integrations/jovo-db-firestore/src/Firestore.ts
+++ b/jovo-integrations/jovo-db-firestore/src/Firestore.ts
@@ -139,9 +139,11 @@ export class Firestore implements Db {
         this.errorHandling();
 
         const userData = {
-                [key]: data,
-                updatedAt
+            [key]: data,
         };
+        if (updatedAt) {
+            userData.updatedAt = updatedAt;
+        }
 
         const docRef: firebase.firestore.DocumentReference = this.firestore!.collection(this.config.collectionName).doc(primaryKey);
         await docRef.set(userData, {merge: true});

--- a/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
+++ b/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
@@ -125,9 +125,12 @@ export class MongoDb implements Db {
                 $set: {
                     [this.config.primaryKeyColumn!]: primaryKey,
                     [key]: data,
-                    updatedAt
                 }
             };
+            if (updatedAt) {
+                item.$set.updatedAt = updatedAt;
+            }
+            
             await collection.updateOne({ userId: primaryKey }, item, { upsert: true });
         } catch (e) {
             throw new JovoError(

--- a/jovo-integrations/jovo-platform-dialogflow/package-lock.json
+++ b/jovo-integrations/jovo-platform-dialogflow/package-lock.json
@@ -1,25 +1,14 @@
 {
 	"name": "jovo-platform-dialogflow",
-	"version": "2.2.0",
+	"version": "2.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/lodash.clonedeep": {
-			"version": "4.5.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-			"dev": true,
-			"requires": {
-				"@types/lodash": "*"
-			},
-			"dependencies": {
-				"@types/lodash": {
-					"version": "4.14.123",
-					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-					"integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
-					"dev": true
-				}
-			}
+		"typescript": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+			"dev": true
 		}
 	}
 }

--- a/jovo-integrations/jovo-platform-dialogflow/package-lock.json
+++ b/jovo-integrations/jovo-platform-dialogflow/package-lock.json
@@ -1,14 +1,25 @@
 {
 	"name": "jovo-platform-dialogflow",
-	"version": "2.1.5",
+	"version": "2.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
-			"dev": true
+		"@types/lodash.clonedeep": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.123",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+					"integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+					"dev": true
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
The DB integrations saved `updatedAt` even if it was `undefined` which caused errors with Firestore. As it's generally not a good practice to save undefined values, the changes were made to every db integration.

You can find the issue here: [#472](https://github.com/jovotech/jovo-framework/issues/472)
## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed