### PR TITLE
Fix dialogflow test suite

### DIFF
--- a/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponse.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponse.ts
@@ -52,6 +52,9 @@ export class DialogflowResponse implements JovoResponse {
 
 
     getSessionAttributes() {
+        if (!_get(this, 'outputContexts')) {
+            return {};
+        }
         const sessionContext =_get(this, 'outputContexts').find((context: Context) => {
             return context.name.indexOf('/contexts/_jovo_session_') > -1;
         });

--- a/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponseBuilder.ts
+++ b/jovo-integrations/jovo-platform-dialogflow/src/core/DialogflowResponseBuilder.ts
@@ -6,10 +6,7 @@ export class DialogflowResponseBuilder implements ResponseBuilder<DialogflowResp
     platformResponseClazz: JovoResponse;
     create(json: any): DialogflowResponse { // tslint:disable-line
         const dialogflowResponse = DialogflowResponse.fromJSON(json) as DialogflowResponse;
-        if (dialogflowResponse.payload) {
-            // @ts-ignore
-            dialogflowResponse.payload[this.platform] = this.platformResponseClazz.fromJSON(dialogflowResponse.payload[this.platform]);
-        }
+
         return dialogflowResponse;
     }
 }


### PR DESCRIPTION
## Proposed changes
This PR makes dialogflow test suite work. Previously, DialogflowResponseBuilder had two class attributes: platform and platformResponseClazz. Both were undefined. Additionally, DialogflowResponse has optional attribute `outputContexts?: Context[]` which then is used like so:
```
const sessionContext =_get(this, 'outputContexts').find((context: Context) => {
```
causing an exception to be thrown, if it's undefined.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed