### PR TITLE
Adding viewport info for alexaRequests

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
@@ -252,18 +252,6 @@ export class AlexaRequest implements JovoRequest {
         return device;
     }
 
-    getScreenResolution(alexaRequest: AlexaRequest): string {
-        // console.log(alexaRequest);
-        let device = '';
-
-        const viewPort = _get(alexaRequest, 'context.Viewport');
-        if (viewPort) {
-
-            device = _get(viewPort, 'pixelWidth') + 'x' + _get(viewPort, 'pixelHeight');
-        }
-
-        return device;
-    }
 
     getSessionId(): string | undefined {
         if (this.session) {

--- a/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
@@ -76,21 +76,19 @@ export interface System {
 }
 
 export interface Viewport {
-    experiences: Experiences;
-    shape: string;
+    experiences: Experience [];
+    shape: 'RECTANGLE' | 'ROUND';
     pixelWidth: number;
     pixelHeight: number;
     dpi: number;
     currentPixelWidth: number;
     currentPixelHeight: number;
-    touch?: TouchMethods;
-    keyboard?: InputMechanisms;
-    video?: Codecs;
+
+    touch?: TouchMethod [];
+    keyboard?: InputMechanism [];
+    video?: {codecs: string[];};
 }
 
-export interface Experiences {
-    [index: number]: Experience;
-}
 
 export interface Experience {
     arcMinuteWidth: number;
@@ -99,17 +97,9 @@ export interface Experience {
     canResize: boolean;
 }
 
-export interface TouchMethods {
-    [index: number]: string;
-}
+export type TouchMethod = 'SINGLE';
+export type InputMechanism = 'DIRECTION';
 
-export interface InputMechanisms {
-    [index: number]: string;
-}
-
-export interface Codecs {
-    [index: number]: string;
-}
 
 export interface Device {
     deviceId: string;
@@ -247,8 +237,6 @@ export class AlexaRequest implements JovoRequest {
                 device = 'Alexa Large Hub' ;//'Echo Show 2nd gen';
             }
         }
-        console.log("Device in method = " + device);
-
         return device;
     }
 

--- a/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
@@ -1,8 +1,7 @@
 import { Input, JovoRequest, SessionData, Inputs, SessionConstants } from "jovo-core";
 import _get = require('lodash.get');
 import _set = require('lodash.set');
-import * as util from 'util';
-import { Interface } from "readline";
+
 
 export interface SessionAttributes {
     [key: string]: any; //tslint:disable-line
@@ -18,7 +17,7 @@ export interface Session {
 
 export interface Context {
     System: System;
-    Viewport: Viewport;
+    Viewport?: Viewport;
     AudioPlayer: {
         token: string;
         offsetInMilliseconds: number;
@@ -84,9 +83,9 @@ export interface Viewport {
     dpi: number;
     currentPixelWidth: number;
     currentPixelHeight: number;
-    touch: TouchMethods;
-    keyboard: InputMechanisms;
-    video: Codecs;
+    touch?: TouchMethods;
+    keyboard?: InputMechanisms;
+    video?: Codecs;
 }
 
 export interface Experiences {
@@ -213,17 +212,15 @@ export class AlexaRequest implements JovoRequest {
     // JovoRequest implementation
 
     getAlexaDevice(): string {
-        // console.log(alexaRequest);
-        console.log("viewport : " + util.inspect(this.context!.Viewport));
         let device = 'Echo - voice only';
 
         if (this.context && this.context.Viewport ) {
 
-            device = "Unknow Device with Screen "+ this.context!.Viewport.pixelWidth + 'x' + this.context!.Viewport.pixelHeight;
+            device = "Unknow Device with Screen "+ this.context.Viewport.pixelWidth + 'x' + this.context.Viewport.pixelHeight;
 
             if (this.context.Viewport.pixelWidth === 480 &&
-                this.context!.Viewport.pixelHeight === 480 &&
-                this.context!.Viewport.shape==='ROUND') {
+                this.context.Viewport.pixelHeight === 480 &&
+                this.context.Viewport.shape==='ROUND') {
             device = 'Alexa Small Hub'; //'Echo Spot';
         }
             if (this.context.Viewport.pixelWidth === 1280 &&

--- a/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/core/AlexaRequest.ts
@@ -226,27 +226,27 @@ export class AlexaRequest implements JovoRequest {
                 this.context!.Viewport.shape==='ROUND') {
             device = 'Alexa Small Hub'; //'Echo Spot';
         }
-            if (this.context!.Viewport.pixelWidth === 1280 &&
-                this.context!.Viewport.pixelHeight === 720 &&
-                this.context!.Viewport.shape==='RECTANGLE') {
+            if (this.context.Viewport.pixelWidth === 1280 &&
+                this.context.Viewport.pixelHeight === 720 &&
+                this.context.Viewport.shape==='RECTANGLE') {
                 device = 'Alexa HD Ready TV';
             }
-            if (this.context!.Viewport.pixelWidth === 1920 &&
-                this.context!.Viewport.pixelHeight === 1080 && 
-                this.context!.Viewport.shape==='RECTANGLE') {
+            if (this.context.Viewport.pixelWidth === 1920 &&
+                this.context.Viewport.pixelHeight === 1080 && 
+                this.context.Viewport.shape==='RECTANGLE') {
                 device = 'Alexa Extra Large TV'; //'Full HD TV';
             }
 
 
-            if (this.context!.Viewport.pixelWidth === 1024 &&
-                this.context!.Viewport.pixelHeight === 600 &&
-                this.context!.Viewport.shape==='RECTANGLE') {
+            if (this.context.Viewport.pixelWidth === 1024 &&
+                this.context.Viewport.pixelHeight === 600 &&
+                this.context.Viewport.shape==='RECTANGLE') {
                 device = 'Alexa Medium Hub'; //'Echo Show 1st gen';
             }
 
-            if (this.context!.Viewport.pixelWidth === 1280 &&
-                this.context!.Viewport.pixelHeight === 800 &&
-                this.context!.Viewport.shape==='RECTANGLE') {
+            if (this.context.Viewport.pixelWidth === 1280 &&
+                this.context.Viewport.pixelHeight === 800 &&
+                this.context.Viewport.shape==='RECTANGLE') {
                 device = 'Alexa Large Hub' ;//'Echo Show 2nd gen';
             }
         }


### PR DESCRIPTION
## Proposed changes
Added viewport interfaces for typescript + getAlexaDevice method, which gives back device description (according to alexaskill test page: small hub, large hub...)   

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed