### PR TITLE
Fixed dialogflow session attributes issue

### DIFF
--- a/jovo-platforms/jovo-platform-dialogflow/src/DialogflowCore.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/DialogflowCore.ts
@@ -16,7 +16,7 @@ export class DialogflowCore implements Plugin {
 
     config: Config = {
         enabled: true,
-        sessionContextId: 'session',
+        sessionContextId: '_jovo_session_',
 
     };
 
@@ -79,10 +79,10 @@ export class DialogflowCore implements Plugin {
     session(dialogflowAgent: DialogflowAgent)  {
         const dialogflowRequest = dialogflowAgent.$request as DialogflowRequest;
         const sessionId = _get(dialogflowRequest, 'session');
-
+        const sessionKey = `${sessionId}/contexts/${this.config.sessionContextId}`;
         if (_get(dialogflowRequest, 'queryResult.outputContexts')) {
             const sessionContext =_get(dialogflowRequest, 'queryResult.outputContexts').find((context: any) => { // tslint:disable-line
-                return context.name === `${sessionId}/contexts/${this.config.sessionContextId}`;
+                return context.name.startsWith(sessionKey);
             });
 
             if (sessionContext) {
@@ -116,7 +116,7 @@ export class DialogflowCore implements Plugin {
 
         const outputContexts = request.queryResult.outputContexts || [];
 
-        const sessionContextPrefix = `${request.session}/contexts/_jovo_session_`;
+        const sessionContextPrefix = `${request.session}/contexts/${this.config.sessionContextId}`;
 
 
         // remove non-jovo contexts


### PR DESCRIPTION
## Proposed changes
Currently in the Dialogflow plugin there is a discrepancy in the naming of the session attributed output context. The getter uses the config sessionId field, while the setter uses a hardcoded "_jovo_session_". I changed the setter to use the config field, and changed the config fields default from value from "session" to "_jovo_session_".

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed