### PR TITLE
Fixing a bug in server.js that breaks the express server

### DIFF
--- a/jovo-framework/src/server.ts
+++ b/jovo-framework/src/server.ts
@@ -36,7 +36,7 @@ verifiedServer.listen = function () {
 
         const httpServer = http.createServer(this);
         // @ts-ignore
-        return server.listen.apply(httpServer, arguments); // eslint-disable-line
+        return httpServer.listen.apply(httpServer, arguments); // eslint-disable-line
     } catch (error) {
         if (error.code === 'MODULE_NOT_FOUND') {
             Log.warn();


### PR DESCRIPTION
I upgraded to the latest version of jovo and suddenly nothing worked so I did some investigating and realised there was a mistake in the server.js. It was using the non-verified server in the verified server listen function so nothing with express worked.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed