### PR TITLE
EventEmitter typing issue

### DIFF
--- a/jovo-core/src/Extensible.ts
+++ b/jovo-core/src/Extensible.ts
@@ -16,7 +16,7 @@ export interface ExtensibleConfig extends PluginConfig {
 /**
  * Allows a class to use plugins
  */
-export abstract class Extensible extends EventEmitter implements Plugin {
+export abstract class Extensible extends EventEmitter.EventEmitter implements Plugin {
 	config: ExtensibleConfig = {
 		enabled: true,
 		plugin: {}


### PR DESCRIPTION
## Proposed changes
Currently when using Jovo in a typescript project the following error is thrown on compilation
`node_modules/jovo-core/dist/src/Extensible.d.ts(12,50): error TS2507: Type 'typeof internal' is not a constructor function type.`
This change prevents this type error. Projects and tests still run identically with this change.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed