### PR TITLE
Added configuration options to PulseLabs plugin

### DIFF
--- a/jovo-integrations/jovo-plugin-pulselabs/README.md
+++ b/jovo-integrations/jovo-plugin-pulselabs/README.md
@@ -41,7 +41,7 @@ You can pass additional configuration options as below:
 
 ```js
 
-app.use( new PulseLabs({ apiKey: 'yourApiKey' , timeout: 2000, debug: true }) );
+app.use( new PulseLabs({ apiKey: 'yourApiKey' , options: { timeout: 2000, debug: true } }) );
 ```
 
 ***debug*** - ```boolean``` logs helpful debugging information

--- a/jovo-integrations/jovo-plugin-pulselabs/README.md
+++ b/jovo-integrations/jovo-plugin-pulselabs/README.md
@@ -17,12 +17,12 @@
 </p>
 <br/>
 
-# Jovo Pulse Labs Plugin
+# Jovo PulseLabs Plugin
 
 Install package:
 
 ```sh
-npm install jovo-plugin-pulselabs
+npm install jovo-plugin-pulselabs --save
 ```
 
 Add the plugin to your `app.js` file:
@@ -34,3 +34,16 @@ const { PulseLabs } = require ('jovo-plugin-pulselabs');
 
 app.use( new PulseLabs({ apiKey: 'yourApiKey' }) );
 ```
+
+# Configuring additional options
+
+You can pass additional configuration options as below:
+
+```js
+
+app.use( new PulseLabs({ apiKey: 'yourApiKey' , timeout: 2000, debug: true }) );
+```
+
+***debug*** - ```boolean``` logs helpful debugging information
+<br/>
+***timeout*** - ```number``` timeouts requests after given milliseconds

--- a/jovo-integrations/jovo-plugin-pulselabs/package.json
+++ b/jovo-integrations/jovo-plugin-pulselabs/package.json
@@ -15,6 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "jovo-core": "^2.2.8",
+    "lodash.merge": "^4.6.1",
     "pulselabs-recorder": "^1.0.2"
   },
   "devDependencies": {

--- a/jovo-integrations/jovo-plugin-pulselabs/package.json
+++ b/jovo-integrations/jovo-plugin-pulselabs/package.json
@@ -15,8 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "jovo-core": "^2.2.8",
-    "lodash.merge": "^4.6.1",
-    "pulselabs-recorder": "^1.0.1"
+    "pulselabs-recorder": "^1.0.2"
   },
   "devDependencies": {
     "@types/es6-promise": "^3.3.0",

--- a/jovo-integrations/jovo-plugin-pulselabs/src/PulseLabs.ts
+++ b/jovo-integrations/jovo-plugin-pulselabs/src/PulseLabs.ts
@@ -1,21 +1,23 @@
 import { BaseApp, HandleRequest, Plugin, PluginConfig } from 'jovo-core';
-import _merge = require('lodash.merge');
 import PulseLabsRecorder = require('pulselabs-recorder');
 
 export interface Config extends PluginConfig {
     apiKey: string;
+    debug?: boolean;
+    timeout?: number;
 }
 
 export class PulseLabs implements Plugin {
-    config: Config = {
-        apiKey: ''
-    };
+
     pulse: PulseLabsRecorder;
-    constructor(config?: Config) {
-        if (config) {
-            this.config = _merge(this.config, config);
-        }
-        this.pulse = PulseLabsRecorder.init(this.config.apiKey);
+
+    constructor(config: Config) {
+        const initOptions = {
+            debug: config.debug,
+            integrationType: 'Jovo',
+            timeout: config.timeout
+        };
+        this.pulse = PulseLabsRecorder.init(config.apiKey, initOptions);
     }
 
     install(app: BaseApp) {

--- a/jovo-integrations/jovo-plugin-pulselabs/src/PulseLabs.ts
+++ b/jovo-integrations/jovo-plugin-pulselabs/src/PulseLabs.ts
@@ -1,23 +1,31 @@
 import { BaseApp, HandleRequest, Plugin, PluginConfig } from 'jovo-core';
+import _merge = require('lodash.merge');
 import PulseLabsRecorder = require('pulselabs-recorder');
 
 export interface Config extends PluginConfig {
     apiKey: string;
-    debug?: boolean;
-    timeout?: number;
+    options?: {
+      debug?: boolean;
+      timeout?: number;
+    }
 }
 
 export class PulseLabs implements Plugin {
-
+    config: Config = {
+      apiKey: '',
+      options: {
+        debug: false,
+        timeout: 2000
+      }
+    };
     pulse: PulseLabsRecorder;
 
-    constructor(config: Config) {
-        const initOptions = {
-            debug: config.debug,
-            integrationType: 'Jovo',
-            timeout: config.timeout
-        };
-        this.pulse = PulseLabsRecorder.init(config.apiKey, initOptions);
+    constructor(config?: Config) {
+        if(config) {
+            this.config = _merge(this.config, config)
+        }
+        const initOptions = {...this.config.options, 'integrationType': 'Jovo'};
+        this.pulse = PulseLabsRecorder.init(this.config.apiKey, initOptions);
     }
 
     install(app: BaseApp) {


### PR DESCRIPTION
## Proposed changes
Currently the configuration options that can be passed to PulseLabs plugin accepts only apiKey. This change allows the user to pass additional configuration options like debug and timeout. Also passing integration type `Jovo`  to pulselabs SDK.
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed