### PR TITLE
Fixed Dialogflow Session Attributes Issues

### DIFF
--- a/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
@@ -223,7 +223,7 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
 
         const sessionId = _get(this, 'session');
         let sessionAttributes: any = {}; // tslint:disable-line
-        const sessionContext =_get(this, 'queryResult.outputContexts').find((context: Context) => {
+        const sessionContext =_get(this, 'queryResult.outputContexts', []).find((context: Context) => {
             return context.name.startsWith(`${sessionId}/contexts/_jovo_session_`);
         });
 
@@ -240,8 +240,8 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
 
     setSessionAttributes(attributes: SessionData): this { // tslint:disable-line
         const sessionId = _get(this, 'session');
-        const sessionContext: Context =_get(this, 'queryResult.outputContexts').find((context: Context) => {
-            return context.name === `${sessionId}/contexts/session`;
+        const sessionContext: Context =_get(this, 'queryResult.outputContexts', []).find((context: Context) => {
+            return context.name.startsWith(`${sessionId}/contexts/_jovo_session_`);
         });
 
         if (sessionContext) {

--- a/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
@@ -155,7 +155,7 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
 
     addSessionAttribute(key: string, value: any): this { // tslint:disable-line
         const sessionId = _get(this, 'session');
-        const sessionContext: Context =_get(this, 'queryResult.outputContexts').find((context: Context) => {
+        const sessionContext: Context =_get(this, 'queryResult.outputContexts', []).find((context: Context) => {
             return context.name.startsWith(`${sessionId}/contexts/_jovo_session_`);
         });
 
@@ -323,7 +323,7 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
 
     setState(state: string): this {
         const sessionId = _get(this, 'session');
-        const sessionContext: Context =_get(this, 'queryResult.outputContexts').find((context: Context) => {
+        const sessionContext: Context =_get(this, 'queryResult.outputContexts', []).find((context: Context) => {
             return context.name.startsWith(`${sessionId}/contexts/_jovo_session_`);
         });
 


### PR DESCRIPTION
## Proposed changes
Calling getSessionAttribute on the initial request throws this error:
```
TypeError: Cannot read property 'find' of undefined
    at DialogflowRequest.getSessionAttributes (/Users/zmorga386/projects/chuck/entrypoint/node_modules/jovo-platform-dialogflow/dist/src/core/DialogflowRequest.js:161:72)
```
This pr adds a fallback value of an empty array to all of the lodash get calls for outputContext in DialogflowRequest, and also fixes an incorrect find body.


## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed