### PR TITLE
:sparkles: Added support for random hints

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/index.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/index.ts
@@ -386,7 +386,7 @@ declare module './core/AlexaSkill' {
          * @param {*} text
          * @return {AlexaSkill}
          */
-        showHint(text: string): this;
+        showHint(text: string | string[]): this;
 
 
         /**

--- a/jovo-platforms/jovo-platform-alexa/src/modules/Display.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/modules/Display.ts
@@ -1,6 +1,7 @@
 import _get = require('lodash.get');
 import _set = require('lodash.set');
 import _merge = require('lodash.merge');
+import _sample = require('lodash.sample');
 
 import {EnumRequestType, Plugin} from 'jovo-core';
 import {AlexaSkill} from "../core/AlexaSkill";
@@ -37,9 +38,9 @@ export class Display implements Plugin {
          * @param {*} text
          * @return {AlexaSkill}
          */
-        AlexaSkill.prototype.showHint = function(text: string) {
+        AlexaSkill.prototype.showHint = function(text: string | string[]) {
             _set(this.$output, 'Alexa.DisplayHint',
-                new DisplayHintDirective(text)
+                new DisplayHintDirective(Array.isArray(text) ? _sample(text)! : text)
             );
             return this;
         };


### PR DESCRIPTION
With this change it is possible to use an array of hints that will be shown using the `showHint` function like it is done with `addText`. Now this function accepts a string or an array of strings, this way extra dynamism is added to the Skill.

## Proposed changes
<!--- Describe your changes in detail -->
The declaration and definition of the function `showHint` had been changed to support either a simple string or an array of strings. The implementation had been taken from the `addText` one.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

*Notes: Seems there are no previous tests for the current `showHint` implementation. Also seems that I can't update the documentation myself. Please, advice and thank you very much in advanced.*