### PR TITLE
 🐛 Fixes multiple bugs of the Airtable integration

### DIFF
--- a/docs/integrations/cms/airtable.md
+++ b/docs/integrations/cms/airtable.md
@@ -71,6 +71,7 @@ module.exports = {
                     name: '<name>',
                     table: '<tableName>',
                     type: '<TableType>',
+                    order: ['UserId', 'Name', 'Location'],
                     selectOptions: {
                         fields: ['UserId', 'Name', 'Location']
                         sort: [
@@ -104,6 +105,7 @@ const config = {
                     name: '<name>',
                     table: '<tableName>',
                     type: '<TableType>',
+                    order: ['UserId', 'Name', 'Location'],
                     selectOptions: {
                         fields: ['UserId', 'Name', 'Location']
                         sort: [
@@ -130,7 +132,8 @@ Name | Description | Value | Required
 `tables` | Contains information about the tables of your base | `object[]` | Yes
 `tables.name` | The name which you will use to access the table: `this.$cms.name` | `string` | Yes
 `tables.table` | The name you've given the table in your base | `string` | Yes
-`tables.type` | The table type you want to use. Default: `default` | `string` - either `default`, `responses`, `keyvalue` or `objectarray` | Nos
+`tables.type` | The table type you want to use. Default: `default` | `string` - either `default`, `responses`, `keyvalue` or `objectarray` | No
+`tables.order` | To ensure that the values we retrieve from the Airtable API are in the correct order, you can specify an array of strings representing the order of columns, e.g. the value at index 0 of the array should be the title of the first column. This is especially important if you plan on using the default sheet type (2 dimensional array)| `string[]` | No
 `tables.selectOptions` | Allows you to specify how the data should be retrieved from your table | `object` | No
 `tables.selectOptions.fields` | Specify the fields (columns) that should be retrieved. If you decide to not retrieve the primary column of your table, keep in mind that in that case the last column of your table will be put in the first place of the array | `string[]` | No
 `tables.selectOptions.filterByFormula` | A [formula](https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference) used to filter records. The formula will be evaluated for each record, and if the result is not `0`, `false`, `""`, `NaN`, `[]`, or `#Error!` the record will be included in the response | `string` | No

--- a/jovo-integrations/jovo-cms-airtable/src/@types/airtable/index.d.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/@types/airtable/index.d.ts
@@ -1,34 +1,33 @@
 declare module 'airtable' {
+    class Airtable {
+        constructor(options?: Airtable.AirtableOptions);
+        base(baseId: string): Airtable.Base;
+    }
+    namespace Airtable {
+        interface AirtableOptions {
+            apiKey?: string;
+            endpointUrl?: string;
+            apiVersion?: string;
+            allowUnauthorizedSsl?: boolean;
+            noRetryIfRateLimited?: boolean;
+            requestTimeout?: number;
+        }
+    
+        interface Base {
+            (tableName: string): Table;
+        }
+    
+        interface Table {        
+            select(param: object): Query;
+        }
+    
+        interface Query {        
+            eachPage(
+                pageCallback: (records: object[], fetchNextPage: () => void) => void,
+                done: (err: Error) => void
+            ): void;
+        }
+    }
     export = Airtable;
 }
 
-// tslint:disable
-declare class Airtable {
-    constructor(opt: object);
-
-    Base: Base;
-    Table: Table;
-
-    base(baseId: string): Base['baseFn'];
-}
-
-declare class Base {
-    constructor(airtable: Airtable, baseId: string);
-
-    baseFn(table: string): Table
-
-    table(tableName: string): Table;
-}
-
-declare class Table {
-    constructor(base: Base, tableId: string, tableName: string);
-
-    select(param: object): Query;
-}
-
-declare class Query {
-    constructor(table: Table, params: object);
-
-    eachPage(pageCallback: (records: object[], fetchNextPage: () => void) => void, done: (err: Error) => void): void;
-}
-// tslint:enable

--- a/jovo-integrations/jovo-cms-airtable/src/AirtableCMS.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/AirtableCMS.ts
@@ -113,15 +113,23 @@ export class AirtableCMS extends BaseCmsPlugin {
                          * To maintain the same structure as the jovo-cms-googlesheets integration, the data will be converted to an array of arrays
                          */
 
-                            // push keys first as that's the first row of the table and put the last key at the first spot of the array.
+                        // push keys first as that's the first row of the table
                         const record = _get(records[ 0 ], 'fields');
                         let keys = Object.keys(record);
                         keys = this.shiftLastItemToFirstIndex(keys);
                         arr.push(keys);
 
-                        records.forEach((r: object) => {
+                        records.forEach((r: any) => {
                             // push each records values
-                            let values = Object.values(_get(r, 'fields'));
+                            let values: string[] = [];
+                            /**
+                             * Airtable doesn't parse key & value of a cell without a value
+                             * Replace missing key/value pairs with empty strings
+                             */
+                            keys.forEach((key) => {
+                                const value = r.fields[key] || '';
+                                values.push(value);
+                            });
                             values = this.shiftLastItemToFirstIndex(values);
                             arr.push(values);
                         });

--- a/jovo-integrations/jovo-cms-airtable/src/AirtableCMS.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/AirtableCMS.ts
@@ -112,13 +112,13 @@ export class AirtableCMS extends BaseCmsPlugin {
 
                         // push keys first as that's the first row of the table
                         const record = _get(records[ 0 ], 'fields');
-                        let keys = loadOptions.order || Object.keys(record);
+                        const keys = loadOptions.order || Object.keys(record);
 
                         arr.push(keys);
 
                         records.forEach((r: any) => {
                             // push each records values
-                            let values: string[] = [];
+                            const values: string[] = [];
                             /**
                              * Airtable doesn't parse key & value of a cell without a value
                              * Replace missing key/value pairs with empty strings

--- a/jovo-integrations/jovo-cms-airtable/src/DefaultTable.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/DefaultTable.ts
@@ -86,8 +86,8 @@ export class DefaultTable implements Plugin {
         }
         const loadOptions = {
             order: this.config.order,
-            table: this.config.table,
-            selectOptions: this.config.selectOptions
+            selectOptions: this.config.selectOptions,
+            table: this.config.table
         };
 
         const values = await this.cms.loadTableData(loadOptions);

--- a/jovo-integrations/jovo-cms-airtable/src/DefaultTable.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/DefaultTable.ts
@@ -10,9 +10,11 @@ import _merge = require('lodash.merge');
 import { AirtableCMS } from './AirtableCMS';
 
 export interface AirtableTable extends PluginConfig {
+    caching?: boolean;
     name?: string;
-    type?: string;
+    order?: string[], // correct order of columns, i.e. index 0 should be first column of table
     table?: string;
+    type?: string;
     selectOptions?: {
         // documentation for selectOptions here: https://www.jovo.tech/docs/cms/airtable#configuration
         fields?: string[];
@@ -21,13 +23,14 @@ export interface AirtableTable extends PluginConfig {
         sort?: object[];
         view?: string;
     };
-    caching?: boolean;
+
 }
 
 export class DefaultTable implements Plugin {
     config: AirtableTable = {
         caching: true,
         enabled: true,
+        order: [],
         selectOptions: {
             view: 'Grid view',
         },
@@ -81,8 +84,13 @@ export class DefaultTable implements Plugin {
                 'https://www.jovo.tech/docs/cms/airtable#configuration',
             ));
         }
+        const loadOptions = {
+            order: this.config.order,
+            table: this.config.table,
+            selectOptions: this.config.selectOptions
+        };
 
-        const values = await this.cms.loadTableData(this.config.selectOptions, this.config.table);
+        const values = await this.cms.loadTableData(loadOptions);
 
         if (values) {
             this.parse(handleRequest, values);

--- a/jovo-integrations/jovo-cms-airtable/src/ResponsesTable.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/ResponsesTable.ts
@@ -156,7 +156,9 @@ export class ResponsesTable extends DefaultTable {
      * @param {string} index 
      */
     moveValueToIndexX(array: any[][], value: any, index: number) {
-        if (array.length < 1) return;
+        if (array.length < 1) {
+            return;
+        }
 
         const headers: string[] = array[0];
         const currentIndexOfKey = headers.indexOf(value);

--- a/jovo-integrations/jovo-cms-airtable/src/ResponsesTable.ts
+++ b/jovo-integrations/jovo-cms-airtable/src/ResponsesTable.ts
@@ -50,7 +50,7 @@ export class ResponsesTable extends DefaultTable {
         };
     }
 
-    parse(handleRequest: HandleRequest, values: any[]) {  // tslint:disable-line
+    parse(handleRequest: HandleRequest, values: any[][]) {  // tslint:disable-line
         const name = this.config.name;
 
         if (!name) {
@@ -63,6 +63,15 @@ export class ResponsesTable extends DefaultTable {
                 'https://www.jovo.tech/docs/cms/airtable#configuration',
             );
         }
+
+        /**
+         * The 2-dimensional array might not have the same order as the airtable base, i.e.
+         * the value at index 0 does not necessarily have to be from the 1st column.
+         * The response sheet expects the `key` property (1st column) to be at index 0,
+         * so we move it (1st dimension array), and all of its values (2nd dimension array)
+         * to index 0 of each of their arrays.
+         */
+        this.moveValueToIndexX(values, 'key', 0);
 
         const headers: string[] = values[ 0 ];
         const platforms = handleRequest.app.getAppTypes();
@@ -138,5 +147,27 @@ export class ResponsesTable extends DefaultTable {
         }
 
         handleRequest.app.$cms[ name ] = resources;
+    }
+
+    /**
+     * Moves `value` to `index` for every arr in the 2 dimensional `array`
+     * @param {any[][]} array 
+     * @param {any} value 
+     * @param {string} index 
+     */
+    moveValueToIndexX(array: any[][], value: any, index: number) {
+        if (array.length < 1) return;
+
+        const headers: string[] = array[0];
+        const currentIndexOfKey = headers.indexOf(value);
+
+        array.forEach((arr) => {
+            // move value to desired index
+            arr.splice(index, 0, arr[currentIndexOfKey]);
+            // arr length was increased by 1, i.e. key shifted one to the right
+            const newIndexOfKey = currentIndexOfKey + 1;
+            // delete value from previous index
+            arr.splice(newIndexOfKey, 1);
+        });
     }
 }

--- a/jovo-integrations/jovo-cms-airtable/test/DefaultTable.test.ts
+++ b/jovo-integrations/jovo-cms-airtable/test/DefaultTable.test.ts
@@ -139,8 +139,7 @@ describe('DefaultTable.retrieve', () => {
         const defaultTable = new DefaultTable({ table: 'table', name: 'test', selectOptions: {} });
         defaultTable.install(airtableCMS);
 
-        airtableCMS.loadTableData =
-            (selectOptions: object, table: string) => new Promise((res, rej) => res({}));
+        airtableCMS.loadTableData = jest.fn().mockResolvedValue({});
 
         expect(handleRequest.app.$cms.test).toBeUndefined();
 

--- a/jovo-integrations/jovo-cms-airtable/tsconfig.json
+++ b/jovo-integrations/jovo-cms-airtable/tsconfig.json
@@ -13,7 +13,6 @@
       "resolveJsonModule": true
     },
     "include": [
-      "**/*.d.ts",
       "src/**/*",
       "test/**/*"
     ],


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
🐛 Fixes empty cells being ignored when fetching data

The airtable.js library ignores empty cells of each record and doesn't provide their keys either. That resulted in the arrays being created from each record to be different in size, depending on the number of empty cells. To mitigate that, we now set the value of empty cells to be an empty string. That also fixes the issue of values being shifted to the wrong index.

🐛 Fixes bug with module's types and order of properties

The type bug prevented typescript projects using the integration from compiling. Besides that, Airtable API doesn't provide the table data in correct order, which this commit fixes by adding a config option called order, that allows the user to specify the order themselves. The framework handles that issue for the ResponseTable in the background

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed