### PR TITLE
🐛 Fix isNewSession for Dialogflow platform

### DIFF
--- a/jovo-platforms/jovo-platform-dialogflow/src/DialogflowAgent.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/DialogflowAgent.ts
@@ -50,7 +50,7 @@ export class DialogflowAgent extends Jovo {
      * @return {boolean}
      */
     isNewSession(): boolean {
-        return true;
+        return this.$request!.isNewSession();
     }
 
 

--- a/jovo-platforms/jovo-platform-dialogflow/src/DialogflowCore.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/DialogflowCore.ts
@@ -124,6 +124,15 @@ export class DialogflowCore implements Plugin {
             return !context.name.startsWith(sessionContextPrefix) && context.lifespanCount && context.lifespanCount > 0;
         });
 
+        // add ask context
+        if (output.ask) {
+            newOutputContexts.push({
+                name: `${request.session}/contexts/_jovo_ask_${Util.randomStr(5)}`,
+                lifespanCount: 1,
+                parameters: { ask: true }
+            });
+        }
+
         // add jovo session context
         if (Object.keys(dialogflowAgent.$session.$data).length > 0) {
             newOutputContexts.push({
@@ -132,6 +141,7 @@ export class DialogflowCore implements Plugin {
                 parameters: dialogflowAgent.$session.$data
             });
         }
+
         if (dialogflowAgent.$output.Dialogflow && dialogflowAgent.$output.Dialogflow.OutputContexts) {
 
             for (let i = 0; i < dialogflowAgent.$output.Dialogflow.OutputContexts.length; i++) {
@@ -158,11 +168,10 @@ export class DialogflowCore implements Plugin {
         }
 
         (dialogflowAgent.$response as DialogflowResponse).outputContexts = newOutputContexts;
+
         if (_get(output, 'Dialogflow.Payload')) {
             _set(dialogflowAgent.$response, 'payload', _get(output, 'Dialogflow.Payload'));
         }
-
-
 
     }
 

--- a/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
@@ -93,8 +93,8 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
         if (typeof _get(this.originalDetectIntentRequest, 'payload.isNewSession') === 'function') {
             return this.originalDetectIntentRequest.payload.isNewSession();
         }
-        const sessionContext: Context | undefined = this.getSessionContext();
-        return typeof sessionContext === 'undefined';
+        const askContext: Context | undefined = this.getAskContext();
+        return typeof askContext === 'undefined';
     }
 
     getIntentName() {
@@ -107,6 +107,7 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
         }
         return this;
     }
+
     /**
      * Returns session context of request
      */
@@ -119,6 +120,20 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
             });
         }
     }
+
+    /**
+     * Returns ask context of request
+     */
+    getAskContext(): Context | undefined {
+        const sessionId = this.session;
+
+        if (this.queryResult && this.queryResult.outputContexts) {
+            return this.queryResult.outputContexts.find((context: Context) => {
+                return context.name.startsWith(`${sessionId}/contexts/_jovo_ask_`);
+            });
+        }
+    }
+
     toJSON(): DialogflowRequestJSON {
         // copy all fields from `this` to an empty object and return in
         return Object.assign({}, this);

--- a/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequest.ts
@@ -93,7 +93,8 @@ export class DialogflowRequest<T extends JovoRequest = JovoRequest> implements J
         if (typeof _get(this.originalDetectIntentRequest, 'payload.isNewSession') === 'function') {
             return this.originalDetectIntentRequest.payload.isNewSession();
         }
-        return true;
+        const sessionContext: Context | undefined = this.getSessionContext();
+        return typeof sessionContext === 'undefined';
     }
 
     getIntentName() {


### PR DESCRIPTION
## Proposed changes
Currently the `isNewSession` method of a Dialogflow Agent is returning `true` for every request.

This fix will actually inspect the `outputContext` of the request to check whether the `_jovo_session_` context is present.
This will happen only when the `payload` doesn't contain an `isNewSession` method itself.

The fix should resolve #536 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed