### PR TITLE
🐛 Add request samples for Dialogflow requests

### DIFF
--- a/jovo-platforms/jovo-platform-dialogflow/sample-request-json/v2/dialogflow/DefaultWelcomeIntent.json
+++ b/jovo-platforms/jovo-platform-dialogflow/sample-request-json/v2/dialogflow/DefaultWelcomeIntent.json
@@ -1,0 +1,18 @@
+{
+  "responseId": "ba004821-5bbc-4bf9-8fa0-9c83bfb248e6",
+  "queryResult": {
+    "queryText": "WELCOME",
+    "parameters": {},
+    "allRequiredParamsPresent": true,
+    "intent": {
+      "name": "projects/newagent-904be/agent/intents/2c0f131a-8b4e-4cd7-8902-f618a1315895",
+      "displayName": "Default Welcome Intent"
+    },
+    "intentDetectionConfidence": 1,
+    "languageCode": "en"
+  },
+  "originalDetectIntentRequest": {
+    "payload": {}
+  },
+  "session": "projects/newagent-904be/agent/sessions/1526414104011"
+}

--- a/jovo-platforms/jovo-platform-dialogflow/sample-request-json/v2/dialogflow/HelpIntent.json
+++ b/jovo-platforms/jovo-platform-dialogflow/sample-request-json/v2/dialogflow/HelpIntent.json
@@ -1,0 +1,19 @@
+{
+  "responseId": "ba004821-5bbc-4bf9-8fa0-9c83bfb248e6",
+  "queryResult": {
+    "queryText": "help",
+    "parameters": {},
+    "allRequiredParamsPresent": true,
+    "outputContexts": [],
+    "intent": {
+      "name": "projects/newagent-904be/agent/intents/2c0f131a-8b4e-4cd7-8902-f618a1315895",
+      "displayName": "HelpIntent"
+    },
+    "intentDetectionConfidence": 1,
+    "languageCode": "en"
+  },
+  "originalDetectIntentRequest": {
+    "payload": {}
+  },
+  "session": "projects/newagent-904be/agent/sessions/1526414104011"
+}

--- a/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequestBuilder.ts
+++ b/jovo-platforms/jovo-platform-dialogflow/src/core/DialogflowRequestBuilder.ts
@@ -20,6 +20,10 @@ const samples: {[key: string]: {[key: string]: string} | string} = {
         'OnPermissionNotification': 'OnPermissionNotification.json',
         'CompletePurchase': 'CompletePurchase.json',
         'OnPlace': 'OnPlace.json'
+    },
+    'dialogflow': {
+        'DefaultWelcomeIntent': 'DefaultWelcomeIntent.json',
+        'HelpIntent': 'HelpIntent.json',
     }
 };
 


### PR DESCRIPTION
## Proposed changes
This PR is adding two request samples to the DialogflowRequestBuilder used in the Test Suite.
It allows the Test Suite to invoke a launch intent or a generic intent when using a pure Dialogflow agent rather than an integration or GoogleAssistant.

Rather than amending the current `google` samples which are actually GoogleAssistent json requests, this PR is adding a new set for `dialogflow` which is the platform type returned by a pure Dialogflow agent.

This pr will fix #563  

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed