### PR TITLE
Fix GoogleActionSpeechBuilder.addAudio() to match docs+implementation+common sense

### DIFF
--- a/jovo-platforms/jovo-platform-googleassistant/package.json
+++ b/jovo-platforms/jovo-platform-googleassistant/package.json
@@ -20,11 +20,13 @@
     "lodash.merge": "^4.6.1",
     "lodash.sample": "^4.2.1",
     "lodash.set": "^4.3.2",
+    "lodash.zip": "^4.2.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "@types/lodash.clonedeep": "^4.5.6",
+    "@types/lodash.zip": "^4.2.6",
     "@types/node": "^10.3.1",
     "googleapis": "^37.0.0",
     "jest": "^24.9.0",

--- a/jovo-platforms/jovo-platform-googleassistant/src/core/GoogleActionSpeechBuilder.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/src/core/GoogleActionSpeechBuilder.ts
@@ -1,3 +1,5 @@
+import _sample = require('lodash.sample');
+import _zip = require('lodash.zip');
 
 import {SpeechBuilder} from "jovo-core";
 import {GoogleAction} from "./GoogleAction";
@@ -9,26 +11,30 @@ export class GoogleActionSpeechBuilder extends SpeechBuilder {
     /**
      * Adds audio tag to speech
      * @public
-     * @param {string} url secure url to audio
-     * @param {string} text
+     * @param {string | string[]} url secure url to audio
+     * @param {string | string[]} text
      * @param {boolean} condition
      * @param {number} probability
      * @return {SpeechBuilder}
      */
-    addAudio(url: string, text = '', condition?: boolean, probability?: number) {
+    addAudio(url: string | string[], text?: string | string[], condition?: boolean, probability?: number) {
         // gets random element from array if url
         // is of type array
-        if (Array.isArray(url)) {
-            const rand = Math.floor(Math.random() * url.length);
-            url = url[rand];
+        if (Array.isArray(url) && Array.isArray(text) && text.length === url.length) {
             // takes the same index from the text array
-            if (!text) {
-                text = url;
-            } else {
-                text = text[rand];
+            [url, text] = (_sample(_zip(url, text)) as string[]);
+        } else {
+            if (Array.isArray(url)) {
+                url = (_sample(url) as string);
+            }
+            if (Array.isArray(text)) {
+                text = (_sample(text) as string);
             }
         }
-        return this.addText('<audio src="' + url + '">' + text + '</audio>', condition, probability);
+        if (!text) {
+            text = '';
+        }
+        return this.addText('<audio src="' + url + '"' + ((text.length > 0) ? '>' + text + '</audio>' : '/>'), condition, probability);
     }
 
     /**

--- a/jovo-platforms/jovo-platform-googleassistant/test/GoogleActionSpeechBuilder.test.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/test/GoogleActionSpeechBuilder.test.ts
@@ -1,0 +1,18 @@
+import {GoogleActionSpeechBuilder} from "../src/core/GoogleActionSpeechBuilder";
+
+test('test audio tag', () => {
+    const jovo = {};
+    // @ts-ignore
+    const sb = new GoogleActionSpeechBuilder(jovo);
+    sb.addAudio('https://url.to/audio.mp3');
+    expect(sb.toString()).toEqual('<audio src="https://url.to/audio.mp3"/>');
+});
+
+
+test('test audio tag with array', () => {
+    const jovo = {};
+    // @ts-ignore
+    const sb = new GoogleActionSpeechBuilder(jovo);
+    sb.addAudio(['https://url.to/audio.mp3', 'https://url.to/audio2.mp3']);
+    expect(sb.toString()).toMatch(/^(<audio src=\"https:\/\/url\.to\/audio2?\.mp3\")/);
+});


### PR DESCRIPTION
## Proposed changes
This changeset adds tests for GoogleActionSpeechBuilder and fixes the following issues:
* wrong type declaration on url parameter
* when text is not given, assume empty text, don't substitute it by url
* crash when `url` is an array but `text` is not
* corrupt output when `url` is not an array but `text` is
* when text is empty, output XML-compliant self-closing tag (but this will mask away bug #583) as AlexaSpeechBuilder already does.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed