### PR TITLE
Updated Firestore database integration to accept an already initialized instance in the constructor

### DIFF
--- a/docs/integrations/databases/firestore.md
+++ b/docs/integrations/databases/firestore.md
@@ -2,9 +2,8 @@
 
 Learn how to store user specific data of your Alexa Skills and Google Actions to Google Cloud Firestore.
 
-- [Google Cloud Firestore](#google-cloud-firestore)
-  - [Introduction](#introduction)
-  - [Configuration](#configuration)
+* [Introduction](#introduction)
+* [Configuration](#configuration)
 
 > Tutorial: [Deploy to Google Cloud](https://www.jovo.tech/tutorials/deploy-to-google-cloud)
 

--- a/docs/integrations/databases/firestore.md
+++ b/docs/integrations/databases/firestore.md
@@ -58,7 +58,7 @@ admin.initializeApp();
 let db = admin.firestore();
 
 // Enable DB after app initialization
-app.use(new Firestore(db));
+app.use(new Firestore({}, db));
 
 // @language=typescript
 
@@ -72,7 +72,7 @@ admin.initializeApp();
 const db = admin.firestore();
 
 // Enable DB after app initialization
-app.use(new Firestore(db));
+app.use(new Firestore({}, db));
 ```
 
 Inside your `config.js` file you have to set your `credential` and your `databaseURL`. You can also optionally set the collection name (default is `UserData`):

--- a/docs/integrations/databases/firestore.md
+++ b/docs/integrations/databases/firestore.md
@@ -2,8 +2,9 @@
 
 Learn how to store user specific data of your Alexa Skills and Google Actions to Google Cloud Firestore.
 
-* [Introduction](#introduction)
-* [Configuration](#configuration)
+- [Google Cloud Firestore](#google-cloud-firestore)
+  - [Introduction](#introduction)
+  - [Configuration](#configuration)
 
 > Tutorial: [Deploy to Google Cloud](https://www.jovo.tech/tutorials/deploy-to-google-cloud)
 
@@ -41,6 +42,38 @@ import { Firestore } from 'jovo-db-firestore';
 
 // Enable DB after app initialization
 app.use(new Firestore());
+```
+
+If you are using Firestore in other parts of your application and already have an intialized instance, you can just pass that into the constructor as well. This is especially helpful when using Firebase Cloud Functions. When deploying your code to Firebase Cloud Functions you don't need to provide the databaseURL and credential in the config.js file and you won't have the error related to the initializeApp method being called twice on the firebase-admin instance.
+
+```javascript
+// @language=javascript
+
+// src/app.js
+
+const { Firestore } = require('jovo-db-firestore');
+
+// Firebase admin and firestore initialization code
+const admin = require('firebase-admin');
+admin.initializeApp();
+let db = admin.firestore();
+
+// Enable DB after app initialization
+app.use(new Firestore(db));
+
+// @language=typescript
+
+// src/app.ts
+
+import { Firestore } from 'jovo-db-firestore';
+
+// Firebase admin and firestore initialization code
+import * as admin from 'firebase-admin';
+admin.initializeApp();
+const db = admin.firestore();
+
+// Enable DB after app initialization
+app.use(new Firestore(db));
 ```
 
 Inside your `config.js` file you have to set your `credential` and your `databaseURL`. You can also optionally set the collection name (default is `UserData`):

--- a/jovo-integrations/jovo-db-firestore/src/Firestore.ts
+++ b/jovo-integrations/jovo-db-firestore/src/Firestore.ts
@@ -20,7 +20,7 @@ export class Firestore implements Db {
     firebaseAdmin?: any; // tslint:disable-line
     firestore?: firebase.firestore.Firestore;
 
-    constructor(firestore?: firebase.firestore.Firestore, config?: Config) {
+    constructor(config?: Config, firestore?: firebase.firestore.Firestore, ) {
         if(firestore){
             this.firestore = firestore;
         }

--- a/jovo-integrations/jovo-db-firestore/src/Firestore.ts
+++ b/jovo-integrations/jovo-db-firestore/src/Firestore.ts
@@ -20,7 +20,10 @@ export class Firestore implements Db {
     firebaseAdmin?: any; // tslint:disable-line
     firestore?: firebase.firestore.Firestore;
 
-    constructor(config?: Config) {
+    constructor(firestore?: firebase.firestore.Firestore, config?: Config) {
+        if(firestore){
+            this.firestore = firestore;
+        }
         if (config) {
             this.config = _merge(this.config, config);
         }
@@ -35,8 +38,10 @@ export class Firestore implements Db {
             app.$db = this;
         }
 
-        this.initializeFirebaseAdmin();
-        this.initializeFirestore(this.firebaseAdmin);
+        if(!this.firestore) {
+            this.initializeFirebaseAdmin();
+            this.initializeFirestore(this.firebaseAdmin);
+        }
     }
 
     initializeFirebaseAdmin() {
@@ -87,7 +92,7 @@ export class Firestore implements Db {
             );
         }
 
-        if (!this.config.credential) {
+        if (!this.firestore && !this.config.credential) {
             throw new JovoError(
                 'Service account credential has to be set',
                 ErrorCode.ERR_PLUGIN,
@@ -98,7 +103,7 @@ export class Firestore implements Db {
             );
         }
 
-        if (!this.config.databaseURL) {
+        if (!this.firestore && !this.config.databaseURL) {
             throw new JovoError(
                 'databaseURL has to be set',
                 ErrorCode.ERR_PLUGIN,


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
I ran into two issues when using the Firestore database integration when hosting the code in Firebase Cloud Functions:
1. I needed to use Firestore in my own code outside of the user data storage and retrieval since my application uses Firestore as a backend database as well. Because of that I had to initialize the firebase-admin and Firestore db before the DB integration. This caused an error because the initializeApp function on firebase-admin was being called twice. Once by my code and then again by the Firestore database integration.
2. Since I host my jovo project as a Firebase Cloud Function in the same project as Firestore database, I don't need to provide the databaseURL or credentials during the firebase-admin initialization. However the current Jovo Firestore database integration requires both of these parameters no matter where the code is hosted.

By extending the Firestore class to accept an already initialized instance if Firestore created in other code, I was able to address both of these issues. I think this functionality can be helpful and can prevent users from running into the kind of error listed on the https://www.jovo.tech/docs/databases/firestore documentation page comment.
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed