### PR TITLE
:alien: Fix deprecated MongoDb Constructor

### DIFF
--- a/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
+++ b/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
@@ -1,4 +1,4 @@
-import {BaseApp, Db, ErrorCode, JovoError, PluginConfig} from 'jovo-core';
+import { BaseApp, Db, ErrorCode, JovoError, PluginConfig } from 'jovo-core';
 import _get = require('lodash.get');
 import _merge = require('lodash.merge');
 import { MongoClient } from 'mongodb';
@@ -39,14 +39,14 @@ export class MongoDb implements Db {
         }
     }
     async initClient() {
-        if(!this.client && this.config.uri) {
+        if (!this.client && this.config.uri) {
             this.client = await this.getConnectedMongoClient(this.config.uri);
         }
 
     }
 
     async getConnectedMongoClient(uri: string): Promise<MongoClient> {
-        return MongoClient.connect(uri, { useNewUrlParser: true });
+        return MongoClient.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
     }
 
     errorHandling() {


### PR DESCRIPTION
## Proposed changes
The Server Discovery and Monitoring engine from the MongoDb Integration is deprecated. To use the new version, a new field ```useUnifiedTopology: true``` is required in the constructor.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed