### PR TITLE
fixed removing shouldEndSession in showVideo call

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/modules/Display.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/modules/Display.ts
@@ -96,7 +96,7 @@ export class Display implements Plugin {
                 directives.push(_get(output, 'Alexa.VideoApp'));
                 _set(response, 'response.directives', directives);
 
-                if (_get(response, 'response.shouldEndSession')) {
+                if (response && response.response && response.response.hasOwnProperty("shouldEndSession")) {
                     delete response.response.shouldEndSession;
                 }
 


### PR DESCRIPTION
## Proposed changes
Update showVideo method to properly remove shouldEndSession property.
Since shouldEndSession is a boolean property, when the value was False it was not being removed from the output. Alexa does not accept shouldEndSession appearing at all on video responses.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x ] All new and existing tests passed