### PR TITLE
💥✨Adjusted State Handling to prevent leaving active Conversational Components

### DIFF
--- a/jovo-framework/src/index.ts
+++ b/jovo-framework/src/index.ts
@@ -153,6 +153,15 @@ declare module 'jovo-core/dist/src/Jovo' {
         };
 
         /**
+         * Checks if the given state contains the name of a initialized component.
+         * @private
+         * @param {string | undefined} state
+         * @return {void}
+         * @throws {JovoError}
+         */
+        checkStateForInitializedComponentName(state: string | undefined): void;
+
+        /**
          * Returns the active components root state value.
          * @return {string | undefined}
          */

--- a/jovo-framework/src/index.ts
+++ b/jovo-framework/src/index.ts
@@ -91,8 +91,9 @@ declare module 'jovo-core/dist/src/Jovo' {
          * @public
          * @param {string} state name of state
          * @param {string} intent name of intent
+         * @param {boolean} [validate=true] state validation toggle
          */
-        toStateIntent(state: string | undefined, intent: string): Promise<void>;
+        toStateIntent(state: string | undefined, intent: string, validate?: boolean): Promise<void>;
 
         /**
          * Jumps from the inside of a state to a global intent
@@ -150,14 +151,6 @@ declare module 'jovo-core/dist/src/Jovo' {
         $activeComponents: {
             [ key: string ]: ComponentPlugin
         };
-
-        triggerStateValidation: boolean;
-
-        /**
-         * Checks if the given state contains the name of a initialized component.
-         * @throws {JovoError}
-         */
-        checkStateForInitializedComponentName(state: string | undefined) : void;
 
         /**
          * Returns the active components root state value.

--- a/jovo-framework/src/index.ts
+++ b/jovo-framework/src/index.ts
@@ -94,15 +94,6 @@ declare module 'jovo-core/dist/src/Jovo' {
          */
         toStateIntent(state: string | undefined, intent: string): Promise<void>;
 
-
-        /**
-         * Jumps to state intent without any state validation.
-         * @private
-         * @param {string} state name of state
-         * @param {string} intent name of intent
-         */
-        internalToStateIntent(state: string | undefined, intent: string): Promise<void>;
-
         /**
          * Jumps from the inside of a state to a global intent
          * @public
@@ -160,12 +151,20 @@ declare module 'jovo-core/dist/src/Jovo' {
             [ key: string ]: ComponentPlugin
         };
 
+        triggerStateValidation: boolean;
+
         /**
-         * Returns root state value stored in the request session.
+         * Checks if the given state contains the name of a initialized component.
+         * @throws {JovoError}
+         */
+        checkStateForInitializedComponentName(state: string | undefined) : void;
+
+        /**
+         * Returns the active components root state value.
          * @return {string | undefined}
          */
-        getRootState(): string | undefined;
-
+        getActiveComponentsRootState(): string | undefined;
+        
         /**
          * Returns the active component.
          * @return {string | undefined}

--- a/jovo-framework/src/index.ts
+++ b/jovo-framework/src/index.ts
@@ -96,6 +96,14 @@ declare module 'jovo-core/dist/src/Jovo' {
 
 
         /**
+         * Jumps to state intent without any state validation.
+         * @private
+         * @param {string} state name of state
+         * @param {string} intent name of intent
+         */
+        internalToStateIntent(state: string | undefined, intent: string): Promise<void>;
+
+        /**
          * Jumps from the inside of a state to a global intent
          * @public
          * @param {string} intent name of intent
@@ -152,8 +160,19 @@ declare module 'jovo-core/dist/src/Jovo' {
             [ key: string ]: ComponentPlugin
         };
 
+        /**
+         * Returns root state value stored in the request session.
+         * @return {string | undefined}
+         */
+        getRootState(): string | undefined;
+
+        /**
+         * Returns the active component.
+         * @return {string | undefined}
+         */
+        getActiveComponent(): Component | undefined;
+
         sendComponentResponse(response: ComponentResponse): Promise<void>;
-        // getActiveComponent(): Component; TODO
     }
 }
 

--- a/jovo-framework/src/middleware/Handler.ts
+++ b/jovo-framework/src/middleware/Handler.ts
@@ -369,6 +369,8 @@ export class Handler implements Plugin {
                 : this.getRoute().path;
             this.$plugins.Router.route = route;
             Log.verbose(` toStateIntent: ${state}.${intent}`);
+
+            this.triggerStateValidation = true;
             return Handler.applyHandle(this, route, true);
         };
 

--- a/jovo-framework/src/middleware/Handler.ts
+++ b/jovo-framework/src/middleware/Handler.ts
@@ -337,8 +337,21 @@ export class Handler implements Plugin {
         ): Promise<any> {
             // tslint:disable-line
             this.triggeredToIntent = true;
+
+            const componentSessionStack: Array<[string, ComponentSessionData]> = this.$session.$data[SessionConstants.COMPONENT];
+            if(componentSessionStack != null && componentSessionStack.length > 0) {
+                const activeComponentSessionData: [string, ComponentSessionData] = componentSessionStack[componentSessionStack.length - 1];
+                const activeComponent = this.$components[activeComponentSessionData[0]];
+
+                if(state !== activeComponent.name) {
+                    Log.verbose(` Changing component state to: ${state}`);
+                    state =  `${activeComponent.name}.${state}`;
+                }
+            } else {
+                Log.verbose(` Changing state to: ${state}`);
+            }
+
             this.setState(state);
-            Log.verbose(` Changing state to: ${state}`);
 
             const route = Router.intentRoute(
                 this.$handlers,
@@ -433,9 +446,21 @@ export class Handler implements Plugin {
          */
         Jovo.prototype.toStatelessIntent = async function (intent: string) {
             this.triggeredToIntent = true;
-            this.removeState();
+
+            const componentSessionStack: Array<[string, ComponentSessionData]> = this.$session.$data[SessionConstants.COMPONENT];
+            if(componentSessionStack != null && componentSessionStack.length > 0) {
+                const activeComponentSessionData: [string, ComponentSessionData] = componentSessionStack[componentSessionStack.length - 1];
+                const activeComponent = this.$components[activeComponentSessionData[0]];
+
+                Log.verbose(` Removing state from component. (${activeComponent.name})`);
+                Log.verbose(` toStatelessIntent: ${intent}`);
+                this.setState(activeComponent.name);
+                return this.toStateIntent(activeComponent.name, intent);
+            }
+
             Log.verbose(` Removing state.`);
             Log.verbose(` toStatelessIntent: ${intent}`);
+            this.removeState();
             return this.toStateIntent(undefined, intent);
         };
 
@@ -445,6 +470,16 @@ export class Handler implements Plugin {
          * @return {Jovo}
          */
         Jovo.prototype.followUpState = function (state: string) {
+            const componentSessionStack: Array<[string, ComponentSessionData]> = this.$session.$data[SessionConstants.COMPONENT];
+            if(componentSessionStack != null && componentSessionStack.length > 0) {
+                const activeComponentSessionData: [string, ComponentSessionData] = componentSessionStack[componentSessionStack.length - 1];
+                const activeComponent = this.$components[activeComponentSessionData[0]];
+
+                if(state !== activeComponent.name) {
+                    state =  `${activeComponent.name}.${state}`;
+                }
+            }
+
             return this.setState(state);
         };
 

--- a/jovo-framework/src/middleware/Handler.ts
+++ b/jovo-framework/src/middleware/Handler.ts
@@ -210,30 +210,6 @@ export class Handler implements Plugin {
         }
     }
 
-    /**
-     * Checks if the given state contains the name of a initialized component.
-     * @param {Jovo} jovo
-     * @param {string | undefined} state
-     * @return {void}
-     * @throws {JovoError}
-     */
-    static checkStateForInitializedComponentName(jovo: Jovo, state: string | undefined): void {
-        if (state && jovo.$components) {
-            const components: string[] = Object.keys(jovo.$components);
-            const matched: string[] = state.split('.').filter(s => components.includes(s));
-
-            if (matched.length > 0) {
-                throw new JovoError(
-                    `Can not use component names as states. Please rename the following states: ${matched.join(', ')}`,
-                    ErrorCode.ERR,
-                    'jovo-framework',
-                    'The used state contains at least one component name.',
-                    'Use this.delegate() or rename the listed states to prevent interference.'
-                );
-            }
-        }
-    };
-
 
     install(app: BaseApp) {
         app.middleware('before.router')!.use((handleRequest: HandleRequest) => {
@@ -350,6 +326,30 @@ export class Handler implements Plugin {
         Jovo.prototype.$handlers = undefined;
 
         /**
+         * Checks if the given state contains the name of a initialized component.
+         * @private
+         * @param {string | undefined} state
+         * @return {void}
+         * @throws {JovoError}
+         */
+        Jovo.prototype.checkStateForInitializedComponentName = function (state: string | undefined): void {
+            if (state && this.$components) {
+                const components: string[] = Object.keys(this.$components);
+                const matched: string[] = state.split('.').filter(s => components.includes(s));
+
+                if (matched.length > 0) {
+                    throw new JovoError(
+                        `Can not use component names as states. Please rename the following states: ${matched.join(', ')}`,
+                        ErrorCode.ERR,
+                        'jovo-framework',
+                        'The used state contains at least one component name.',
+                        'Use this.delegate() or rename the listed states to prevent interference.'
+                    );
+                }
+            }
+        };
+
+        /**
          * Jumps to state intent in the order state > unhandled > error
          * @public
          * @param {string} state name of state
@@ -366,7 +366,7 @@ export class Handler implements Plugin {
 
             // Check for Component State Validation
             if(validate === true) {
-                Handler.checkStateForInitializedComponentName(this, state);
+                this.checkStateForInitializedComponentName(state);
 
                 const componentState = this.getActiveComponentsRootState();
                 if (componentState && state) {
@@ -533,7 +533,7 @@ export class Handler implements Plugin {
          * @return {Jovo}
          */
         Jovo.prototype.followUpState = function (state: string) {
-            Handler.checkStateForInitializedComponentName(this, state);
+            this.checkStateForInitializedComponentName(state);
 
             const componentState = this.getActiveComponentsRootState();
             if (componentState) {


### PR DESCRIPTION
## Proposed changes
Added "active component" checks to `toStateIntent`, `toStatelessIntent` & `followUpState` to prevent leaving the conversational component handler when using those "state" related methods.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
_Not sure if it can really be called a breaking change because component are still in development_

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
I don't think so, because from a user standpoint I assumed to stay inside my component when using states. 
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
All existing test are running fine for me