### PR TITLE
:sparkles: Add KeyObject sheet type to GoogleSheet CMS integration

### DIFF
--- a/docs/integrations/cms/google-sheets.md
+++ b/docs/integrations/cms/google-sheets.md
@@ -11,6 +11,7 @@ Learn how to use Google Sheets as CMS for your Alexa Skills and Google Actions.
   * [Responses](#responses)
   * [KeyValue](#keyvalue)
   * [ObjectArray](#objectarray)
+  * [KeyObject](#keyobject)
 * [Defining your own Sheet Type](#defining-your-own-sheet-type)
 * [Advanced Features](#advanced-features)
   * [Caching](#caching)
@@ -368,6 +369,123 @@ Access the array using:
 
 ```javascript
 this.$cms.sheetName
+```
+
+### KeyObject
+
+The sheet type `KeyObject` is an extension of the [KeyValue](#keyvalue) type where rather than assigning a single value to each key, an object is assigned.
+For each row in the spreadsheet, the first cell is used as key, and the remaining cells in the row are converted to values of the nested object with the first row of the spreadsheet specifying the keys.
+
+You can define the range (which columns to access) in your config, default is 'A:C':
+
+```javascript
+// @language=javascript
+
+// src/config.js
+
+module.exports = {
+	cms: {
+		GoogleSheetsCMS: {
+			// ...
+
+			sheets: [
+				{
+					name: '<YourSheetName>',
+					type: 'KeyObject',
+					range: 'A:D'
+				}
+			]
+		}
+	}
+
+	// ...
+};
+
+// @language=typescript
+
+// src/config.ts
+
+const config = {
+	cms: {
+		GoogleSheetsCMS: {
+			// ...
+
+			sheets: [
+				{
+					name: '<YourSheetName>',
+					type: 'KeyObject',
+					range: 'A:D'
+				}
+			]
+		}
+	}
+
+	// ...
+};
+```
+
+Here's an example sheet:
+
+| Key    | Symbol | Price   | Volume   |
+| :----- | :----- | :------ | :------- |
+| apple  | AAPL   | 263.19  | 26032213 |
+| google | GOOG   | 1303.02 | 15893292 |
+
+And here's the object you will receive:
+
+```javascript
+{
+    apple: {
+        symbol: 'AAPL',
+        price: '263.19',
+        volume: '26032213',
+    },
+    google: {
+        symbol: 'GOOG',
+        price: '1303.02',
+        volume: '15893292',
+    },
+}
+```
+
+Access the object using:
+
+```javascript
+this.$cms.sheetName.key;
+```
+
+and the nested object using:
+
+```javascript
+this.$cms.sheetName.key.second_key;
+
+// e.g. this.$cms.sheetName.apple.price
+```
+
+**Please Note:** When a cell in the spreadsheet is empty it will be converted to an `undefined` value:
+
+Here's an example sheet with empty cells:
+
+| Key   | Name  | Surname | Address                 |
+| :---- | :---- | :------ | :---------------------- |
+| alice | Alice | White   |                         |
+| bob   | Bob   | Smith   | Newark, New Jersey, USA |
+
+here's the object you will receive:
+
+```javascript
+{
+    alice: {
+        name: 'Alice',
+        surname: 'White',
+        address: undefined,
+    },
+    bob: {
+        name: 'Bob',
+        surname: 'Smith',
+        address: 'Newark, New Jersey, USA',
+    },
+}
 ```
 
 ## Defining your own Sheet Type

--- a/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
@@ -20,6 +20,7 @@ const readdir = util.promisify(fs.readdir);
 const readFile = util.promisify(fs.readFile);
 const exists = util.promisify(fs.exists);
 import { DefaultSheet, GoogleSheetsSheet } from './DefaultSheet';
+import { KeyObjectSheet } from './KeyObjectSheet';
 import { KeyValueSheet } from './KeyValueSheet';
 import { ObjectArraySheet } from './ObjectArraySheet';
 import { ResponsesSheet } from './ResponsesSheet';
@@ -60,6 +61,7 @@ export class GoogleSheetsCMS extends BaseCmsPlugin {
 
     const defaultSheetMap: { [key: string]: any } = {
       default: DefaultSheet,
+      keyobject: KeyObjectSheet,
       keyvalue: KeyValueSheet,
       objectarray: ObjectArraySheet,
       responses: ResponsesSheet,

--- a/jovo-integrations/jovo-cms-googlesheets/src/KeyObjectSheet.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/KeyObjectSheet.ts
@@ -1,0 +1,52 @@
+import { ErrorCode, HandleRequest, JovoError } from 'jovo-core';
+import _merge = require('lodash.merge');
+import _set = require('lodash.set');
+
+import { DefaultSheet, GoogleSheetsSheet } from './DefaultSheet';
+
+export interface Config extends GoogleSheetsSheet {}
+
+export class KeyObjectSheet extends DefaultSheet {
+  config: Config = {
+    enabled: true,
+    range: 'A:C',
+  };
+
+  constructor(config?: Config) {
+    super(config);
+    if (config) {
+      this.config = _merge(this.config, config);
+    }
+  }
+
+  parse(handleRequest: HandleRequest, values: any[]) {
+    // tslint:disable-line
+    const entity = this.config.entity || this.config.name;
+
+    if (!entity) {
+      throw new JovoError(
+        'entity has to be set.',
+        ErrorCode.ERR_PLUGIN,
+        'jovo-cms-googlesheets',
+        `The sheet's name has to be defined in your config.js file.`,
+        undefined,
+        'https://www.jovo.tech/docs/cms/google-sheets#configuration',
+      );
+    }
+
+    const fullObject = {};
+
+    const attributes = values[0];
+
+    for (let i = 1; i < values.length; i++) {
+      const dataset = {};
+      for (let j = 1; j < values[i].length; j++) {
+        const v = values[i][j] && values[i][j].length ? values[i][j] : undefined;
+        _set(dataset, `${attributes[j]}`, v);
+      }
+      _set(fullObject, `${values[i][0]}`, dataset);
+    }
+
+    handleRequest.app.$cms[entity] = fullObject;
+  }
+}

--- a/jovo-integrations/jovo-cms-googlesheets/src/index.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/index.ts
@@ -3,6 +3,7 @@ export { KeyValueSheet } from './KeyValueSheet';
 export { DefaultSheet } from './DefaultSheet';
 export { ResponsesSheet } from './ResponsesSheet';
 export { ObjectArraySheet } from './ObjectArraySheet';
+export { KeyObjectSheet } from './KeyObjectSheet';
 
 declare module 'jovo-core/dist/src/Cms' {
   interface Cms {

--- a/jovo-integrations/jovo-cms-googlesheets/test/KeyObjectSheet.test.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/test/KeyObjectSheet.test.ts
@@ -1,0 +1,71 @@
+import { HandleRequest } from 'jovo-core';
+
+import { KeyObjectSheet } from '../src/';
+import { MockHandleRequest } from './mockObj/mockHR';
+
+let handleRequest: HandleRequest;
+beforeEach(() => {
+  handleRequest = new MockHandleRequest();
+});
+
+describe('KeyObjectSheet.constructor()', () => {
+  test('without config', () => {
+    const keyObjectSheet = new KeyObjectSheet();
+    expect(keyObjectSheet.config.range).toMatch('A:C');
+  });
+
+  test('with config', () => {
+    const keyObjectSheet = new KeyObjectSheet({
+      range: 'A:Z',
+    });
+    expect(keyObjectSheet.config.range).toMatch('A:Z');
+  });
+});
+
+describe('KeyObjectSheet.parse()', () => {
+  test('should throw error if entity is not set', () => {
+    const keyObjectSheet = new KeyObjectSheet();
+
+    expect(() => keyObjectSheet.parse(handleRequest, [])).toThrow('entity has to be set.');
+  });
+
+  test('with empty array', () => {
+    const keyObjectSheet = new KeyObjectSheet({
+      name: 'test',
+    });
+
+    expect(handleRequest.app.$cms.test).toBeUndefined();
+    keyObjectSheet.parse(handleRequest, []);
+    expect(handleRequest.app.$cms.test).toStrictEqual({});
+  });
+
+  test('with valid values', () => {
+    const keyObjectSheet = new KeyObjectSheet({
+      name: 'test',
+    });
+
+    expect(handleRequest.app.$cms.test).toBeUndefined();
+    keyObjectSheet.parse(handleRequest, [
+      ['main_keys', 'attribute1', 'attribute2'],
+      ['key1', 'value1', 'value2'],
+    ]);
+    expect(handleRequest.app.$cms.test).toStrictEqual({
+      key1: { attribute1: 'value1', attribute2: 'value2' },
+    });
+  });
+
+  test('with some empty values', () => {
+    const keyObjectSheet = new KeyObjectSheet({
+      name: 'test',
+    });
+
+    expect(handleRequest.app.$cms.test).toBeUndefined();
+    keyObjectSheet.parse(handleRequest, [
+      ['main_keys', 'attribute1', 'attribute2'],
+      ['key1', undefined, ''],
+    ]);
+    expect(handleRequest.app.$cms.test).toStrictEqual({
+      key1: { attribute1: undefined, attribute2: undefined },
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
This change adds a new spreadsheet type to the GoogleSheet CMS integration allowing a user to define sheets with 1 level nested objects.

See documentation for more info.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed