### PR TITLE
Access reminder events with ON_EVENT

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/modules/SkillEvent.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/modules/SkillEvent.ts
@@ -19,7 +19,8 @@ export class SkillEvent implements Plugin {
   uninstall(alexa: Alexa) {}
   type(alexaSkill: AlexaSkill) {
     const alexaRequest = alexaSkill.$request as AlexaRequest;
-    if (_get(alexaRequest, 'request.type').substring(0, 15) === 'AlexaSkillEvent') {
+    if (_get(alexaRequest, 'request.type').substring(0, 15) === 'AlexaSkillEvent'
+         || _get(alexaRequest, 'request.type').substring(0, 9) === 'Reminders') {
       alexaSkill.$type = {
         type: EnumAlexaRequestType.ON_EVENT,
         subType: _get(alexaRequest, 'request.type'),


### PR DESCRIPTION
Proposed changes
Right now you cant access reminder events with ON_EVENT and Jovo errors out on the request since the type is not handled.

Maybe we want this with a new event like ON_REMINDER_EVENT? That may require more changes and updates to documentation though and I'm not sure it's needed.

https://developer.amazon.com/docs/smapi/alexa-reminders-api-reference.html#reminderstarted

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed