### PR TITLE
Remove this.endSession in V2 docs on intents

### DIFF
--- a/docs/basic-concepts/routing/intents.md
+++ b/docs/basic-concepts/routing/intents.md
@@ -236,13 +236,6 @@ END() {
  },
 ```
 
-If you want to end the session without saying anything, use the following:
-
-```javascript
-this.endSession();
-```
-
-
 #### getEndReason
 
 It is helpful to find out why a session ended. Use getEndReason inside the `'END'` intent to receive more information. This currently only works for Amazon Alexa.


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
If I understand correctly from [these docs](https://github.com/jovotech/jovo-framework/blob/0883d307d99351274f5bb54de08fc17ffc105b01/docs/getting-started/installation/v1-migration.md#L269), there is no longer any need to call `this.endSession` in the `END` event. This PR removes it from the docs.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed