### PR TITLE
🐛 Fixed Lambda-bug

### DIFF
--- a/jovo-framework/src/hosts/Lambda.ts
+++ b/jovo-framework/src/hosts/Lambda.ts
@@ -21,12 +21,12 @@ export class Lambda implements Host {
 
   hasWriteFileAccess = false;
 
+  // tslint:disable-next-line:no-any
   constructor(event: any, context: any, callback: Function) {
-    // tslint:disable-line
     this.event = event;
     this.context = context;
     this.callback = callback;
-    if (event.body) {
+    if (typeof event.body !== 'undefined') {
       this.isApiGateway = true;
       this.$request = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
     } else {
@@ -47,7 +47,7 @@ export class Lambda implements Host {
     return new Promise<void>((resolve) => {
       if (this.isApiGateway) {
         this.callback(null, {
-          body: JSON.stringify(obj),
+          body: typeof obj === 'object' ? JSON.stringify(obj) : obj,
           headers: this.responseHeaders,
           isBase64Encoded: false,
           statusCode: 200,


### PR DESCRIPTION
## Proposed changes
Currently, a `null` body-value will automatically cause ApiGateway to not be detected. This means the response will be sent back differently than expected. 
Additionally, the response-value should not get stringified except it's an object.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed