### PR TITLE
🐛 Fixed ExpressJS bug

### DIFF
--- a/jovo-framework/src/hosts/ExpressJS.ts
+++ b/jovo-framework/src/hosts/ExpressJS.ts
@@ -41,7 +41,7 @@ export class ExpressJS implements Host {
   setResponse(obj: any) {
     // tslint:disable-line
     return new Promise<void>((resolve) => {
-      if (!this.res.headersSent) {
+      if (this.res.headersSent === false) {
         this.res.json(obj);
       }
       resolve();
@@ -49,7 +49,7 @@ export class ExpressJS implements Host {
   }
 
   fail(error: Error) {
-    if (!this.res.headersSent) {
+    if (this.res.headersSent === false) {
       const responseObj: any = {
         // tslint:disable-line
         code: 500,

--- a/jovo-framework/src/hosts/ExpressJS.ts
+++ b/jovo-framework/src/hosts/ExpressJS.ts
@@ -41,13 +41,15 @@ export class ExpressJS implements Host {
   setResponse(obj: any) {
     // tslint:disable-line
     return new Promise<void>((resolve) => {
-      this.res.json(obj);
+      if (!this.res.headersSent) {
+        this.res.json(obj);
+      }
       resolve();
     });
   }
 
   fail(error: Error) {
-    if (this.res.headersSent === false) {
+    if (!this.res.headersSent) {
       const responseObj: any = {
         // tslint:disable-line
         code: 500,


### PR DESCRIPTION
## Proposed changes
The ExpressJS-Host did not have any logic that would check if `fail` was called before `setResponse`, which was leading to the error that the log was spammed with something like `header were sent already`.  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed