### PR TITLE
♻️ Refactored all async install methods

### DIFF
--- a/jovo-core/src/core/Platform.ts
+++ b/jovo-core/src/core/Platform.ts
@@ -14,6 +14,7 @@ export abstract class Platform<
     super(config);
     this.actionSet = new ActionSet(
       [
+        'setup',
         '$init',
         '$request',
         '$session',

--- a/jovo-integrations/jovo-asr-gcloud/src/GCloudAsr.ts
+++ b/jovo-integrations/jovo-asr-gcloud/src/GCloudAsr.ts
@@ -6,6 +6,7 @@ import {
   EnumRequestType,
   ErrorCode,
   Extensible,
+  HandleRequest,
   HttpService,
   Jovo,
   JovoError,
@@ -42,7 +43,7 @@ export class GCloudAsr implements Plugin {
     return this.constructor.name;
   }
 
-  async install(parent: Extensible) {
+  install(parent: Extensible) {
     if (!(parent instanceof Platform)) {
       throw new JovoError(
         `'${this.name}' has to be an immediate plugin of a platform!`,
@@ -58,8 +59,11 @@ export class GCloudAsr implements Plugin {
       );
     }
 
+    parent.middleware('setup')!.use(this.setup.bind(this));
     parent.middleware('$asr')!.use(this.asr.bind(this));
+  }
 
+  async setup(handleRequest: HandleRequest) {
     const jwtClient = await this.initializeJWT();
     if (jwtClient) {
       await jwtClient.authorize();

--- a/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
@@ -55,7 +55,7 @@ export class GoogleSheetsCMS extends BaseCmsPlugin {
     this.actionSet = new ActionSet(['retrieve'], this);
   }
 
-  async install(app: BaseApp) {
+  install(app: BaseApp) {
     super.install(app);
     this.baseApp = app;
     app.middleware('setup')!.use(this.retrieveSpreadsheetData.bind(this));

--- a/jovo-integrations/jovo-db-cosmosdb/src/CosmosDb.ts
+++ b/jovo-integrations/jovo-db-cosmosdb/src/CosmosDb.ts
@@ -7,8 +7,8 @@ export class CosmosDb extends MongoDb {
     super(config);
   }
 
-  async install(app: BaseApp) {
-    await super.install(app);
+  install(app: BaseApp) {
+    super.install(app);
     if (_get(app.config, 'db.default')) {
       if (_get(app.config, 'db.default') === 'CosmosDb') {
         app.$db = this;

--- a/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
+++ b/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
@@ -27,7 +27,7 @@ export class MongoDb implements Db {
     }
   }
 
-  async install(app: BaseApp) {
+  install(app: BaseApp) {
     this.errorHandling();
 
     if (_get(app.config, 'db.default')) {
@@ -38,6 +38,7 @@ export class MongoDb implements Db {
       app.$db = this;
     }
   }
+
   async initClient() {
     if (!this.client && this.config.uri) {
       this.client = await this.getConnectedMongoClient(this.config.uri);

--- a/jovo-integrations/jovo-nlu-dialogflow/src/DialogflowNlu.ts
+++ b/jovo-integrations/jovo-nlu-dialogflow/src/DialogflowNlu.ts
@@ -61,7 +61,7 @@ export class DialogflowNlu extends Extensible implements Plugin {
     return this.constructor.name;
   }
 
-  async install(parent: Extensible) {
+  install(parent: Extensible) {
     if (!(parent instanceof Platform)) {
       throw new JovoError(
         `'${this.name}' has to be an immediate plugin of a platform!`,
@@ -69,12 +69,16 @@ export class DialogflowNlu extends Extensible implements Plugin {
         this.name,
       );
     }
+
+    parent.middleware('setup')!.use(this.setup.bind(this));
     parent.middleware('after.$init')!.use(this.afterInit.bind(this));
     parent.middleware('$nlu')!.use(this.nlu.bind(this));
     parent.middleware('$inputs')!.use(this.inputs.bind(this));
 
     this.parentName = (parent as Plugin).name || parent.constructor.name;
+  }
 
+  async setup(handleRequest: HandleRequest) {
     const jwtClient = await this.initializeJWT();
     if (jwtClient) {
       await jwtClient.authorize();

--- a/jovo-platforms/jovo-platform-core/src/CorePlatform.ts
+++ b/jovo-platforms/jovo-platform-core/src/CorePlatform.ts
@@ -42,6 +42,7 @@ export class CorePlatform extends Platform<CorePlatformRequest, CorePlatformResp
 
     this.actionSet = new ActionSet(
       [
+        'setup',
         '$init',
         '$request',
         '$session',

--- a/jovo-platforms/jovo-platform-twilioautopilot/src/Autopilot.ts
+++ b/jovo-platforms/jovo-platform-twilioautopilot/src/Autopilot.ts
@@ -33,6 +33,7 @@ export class Autopilot extends Platform<AutopilotRequest, AutopilotResponse> {
 
     this.actionSet = new ActionSet(
       [
+        'setup',
         '$init',
         '$request',
         '$session',


### PR DESCRIPTION
The `install`-method of `Extensible` has never been async, therefore the `setup` middleware should be used to initialize things asynchronously.

## Proposed changes
Always use the `setup`-Middleware for plugins to load data asynchronously.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed