### PR TITLE
🐛Fixes error when stopping the session

### DIFF
--- a/jovo-platforms/jovo-platform-twilioautopilot/src/core/AutopilotResponse.ts
+++ b/jovo-platforms/jovo-platform-twilioautopilot/src/core/AutopilotResponse.ts
@@ -107,27 +107,14 @@ export class AutopilotResponse implements JovoResponse {
     return this.setSessionAttributes(sessionData);
   }
 
-  isTell(speechText?: string | string[]): boolean {
+  isTell(): boolean {
     const hasListenAction = this.actions.some((action) => {
       return action.listen;
     });
     // is ask()!
     if (hasListenAction) return false;
 
-    const sayAction = this.actions.find((action) => {
-      return action.say;
-    });
-
-    // no speech output in response
-    if (!sayAction) return false;
-
-    if (Array.isArray(speechText)) {
-      for (const speech of speechText) {
-        if (AutopilotSpeechBuilder.toSSML(speech) === sayAction.say) return true;
-      }
-    }
-
-    return AutopilotSpeechBuilder.toSSML(speechText as string) === sayAction.say;
+    return true;
   }
 
   isAsk(speechText?: string | string[]): boolean {


### PR DESCRIPTION
## Proposed changes
When trying to end a conversation with Autopilot, the core AutopilotResponse.ts file will invoke the hasSessionEnded(), which then calls (with no arguments) to the method isTell(), which expects 1 argument, speechText: string.

Since the method hasSessionEnded() didn't send any arguments, the logic will eventually crash with the following message:

<img width="1680" alt="Screen Shot 2020-03-28 at 4 37 17 PM" src="https://user-images.githubusercontent.com/12286824/77835460-6e2cc800-7112-11ea-9166-a10ab1989516.png">

To end a conversation with autopilot, the actions array simply has to miss this item:
```
{
listen: true
}
```

For more information about listen, check this link https://www.twilio.com/docs/autopilot/actions/listen

<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed