### PR TITLE
🐛 Added log event message cast to string

### DIFF
--- a/jovo-core/src/util/Log.ts
+++ b/jovo-core/src/util/Log.ts
@@ -171,7 +171,7 @@ export class Logger {
       logLevel: LogLevel.DEBUG,
       trackRequest: false,
       write: (logEvent: LogEvent, breakline = true) => {
-        const msg = logEvent.msg || '';
+        const msg = String(logEvent.msg) || '';
         if (logEvent.isFormat) {
           process.stdout.write(msg);
         } else {


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Mongo database was throwing errors and one of the parameters in error object was `code` which was of type `number`. Because of that function `addConsoleAppender` in `Log.js` file was throwing this exception: 

```
TypeError: msg.split is not a function
      at Object.write (/../node_modules/jovo-core/dist/src/Log.js:135:45)
      ...
```

It was happening, because Number doesn't have `split` function, so I made sure that log event message is always of type `string`, by casting it.

After casting, I again was able to see exceptions thrown by my code,  instead of the one thrown by `addConsoleAppender` function.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed