### PR TITLE
🐛✨ Facebook Messenger - Improvements/Bugfixes

### DIFF
--- a/jovo-platforms/jovo-platform-facebookmessenger/src/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/Interfaces.ts
@@ -1,5 +1,7 @@
 import { QuickReplyContentType } from './Enums';
 
+export type ApiVersion = 'v5.0' | 'v6.0';
+
 export interface MessengerBotEntry {
   id: string;
   time: number;

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
@@ -6,7 +6,6 @@ import { Message } from './responses/Message';
 export { FacebookMessenger, Config } from './FacebookMessenger';
 
 export const BASE_URL = 'https://graph.facebook.com';
-export const BASE_PATH = '/v5.0/me';
 
 declare module 'jovo-core/dist/src/core/Jovo' {
   export interface Jovo {

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
@@ -1,6 +1,4 @@
-import { EnumRequestType, HandleRequest, Plugin, SpeechBuilder } from 'jovo-core';
-import _get = require('lodash.get');
-import _set = require('lodash.set');
+import { EnumRequestType, HandleRequest, Plugin } from 'jovo-core';
 import {
   FacebookMessenger,
   MessengerBot,
@@ -9,6 +7,7 @@ import {
   MessengerBotUser,
   TextMessage,
 } from '..';
+import _get = require('lodash.get');
 
 export class FacebookMessengerCore implements Plugin {
   private launchPayload?: string;

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/responses/Message.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/responses/Message.ts
@@ -1,19 +1,19 @@
 import { AxiosRequestConfig, HttpService } from 'jovo-core';
-import { BASE_PATH, BASE_URL, IdentityData } from '..';
+import { ApiVersion, BASE_URL, IdentityData } from '..';
 
 export abstract class Message {
   protected constructor(readonly recipient: IdentityData) {}
 
-  send(pageAccessToken: string): Promise<any> {
-    return HttpService.request(this.getConfig(pageAccessToken));
+  send(pageAccessToken: string, version: ApiVersion): Promise<any> {
+    return HttpService.request(this.getConfig(pageAccessToken, version));
   }
 
-  protected getPath(pageAccessToken: string): string {
-    return `${BASE_PATH}/messages?access_token=${pageAccessToken}`;
+  protected getPath(pageAccessToken: string, version: ApiVersion): string {
+    return `/${version}/me/messages?access_token=${pageAccessToken}`;
   }
 
-  protected getConfig(pageAccessToken: string): AxiosRequestConfig {
-    const url = BASE_URL + this.getPath(pageAccessToken);
+  protected getConfig(pageAccessToken: string, version: ApiVersion): AxiosRequestConfig {
+    const url = BASE_URL + this.getPath(pageAccessToken, version);
     return {
       url,
       method: 'POST',

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/AttachmentMessage.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/AttachmentMessage.ts
@@ -1,7 +1,15 @@
 import * as FormData from 'form-data';
 import { createReadStream } from 'fs';
 import { HttpService } from 'jovo-core';
-import { AttachmentType, BASE_URL, IdentityData, Message, QuickReply, TextQuickReply } from '../..';
+import {
+  ApiVersion,
+  AttachmentType,
+  BASE_URL,
+  IdentityData,
+  Message,
+  QuickReply,
+  TextQuickReply,
+} from '../..';
 
 export interface AttachmentMessageFile {
   path: string;
@@ -24,13 +32,13 @@ export class AttachmentMessage extends Message {
     super(recipient);
   }
 
-  send(pageAccessToken: string): Promise<any> {
+  send(pageAccessToken: string, version: ApiVersion): Promise<any> {
     const isFile = this.isFileData();
     const isUrl = this.isUrlData();
     const isAttachmentId = this.isAttachmentIdData();
 
     if (isFile) {
-      return this.sendFile(pageAccessToken);
+      return this.sendFile(pageAccessToken, version);
     }
 
     const data = {
@@ -55,13 +63,13 @@ export class AttachmentMessage extends Message {
       (data.message.attachment.payload as any).attachment_id = this.options.data.toString();
     }
 
-    const config = this.getConfig(pageAccessToken);
+    const config = this.getConfig(pageAccessToken, version);
     config.data = data;
 
     return HttpService.request(config);
   }
 
-  private sendFile(pageAccessToken: string) {
+  private sendFile(pageAccessToken: string, version: ApiVersion) {
     const message = {
       attachment: {
         type: this.options.type,
@@ -84,8 +92,7 @@ export class AttachmentMessage extends Message {
       contentType: mimeType || undefined,
     });
 
-    const url = `${BASE_URL}${this.getPath(pageAccessToken)}`;
-
+    const url = `${BASE_URL}${this.getPath(pageAccessToken, version)}`;
     return HttpService.post(url, form, { headers: form.getHeaders() });
   }
 


### PR DESCRIPTION
## Proposed changes
`FacebookMessenger` now has a `version` parameter for the config that determines which version of the Facebook-API should be used. By default `v6.0` will be used.
Additionally, an error was fixed that caused verification to fail due to a missing `pageAccessToken`.
The `pageAccessToken` is not needed for verification.

Related to #715 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed