### PR TITLE
Add getPermissionIsCardThrown

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/index.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/index.ts
@@ -409,5 +409,6 @@ declare module './core/AlexaSkill' {
     hasPermissionAccepted(): boolean;
     hasPermissionDenied(): boolean;
     hasPermissionNotAnswered(): boolean;
+    getPermissionIsCardThrown(): boolean;
   }
 }

--- a/jovo-platforms/jovo-platform-alexa/src/modules/AskFor.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/modules/AskFor.ts
@@ -49,6 +49,10 @@ export class AskFor implements Plugin {
     AlexaSkill.prototype.hasPermissionNotAnswered = function () {
       return _get(this.$request, 'request.payload.status') === 'NOT_ANSWERED';
     };
+
+    AlexaSkill.prototype.getPermissionIsCardThrown = function () {
+      return _get(this.$request, 'request.payload.isCardThrown');
+    };
   }
   uninstall(alexa: Alexa) {}
   type(alexaSkill: AlexaSkill) {


### PR DESCRIPTION
## Proposed changes
The following Alexa doc includes the isCardThrown as part of the Connections.Response:
[Send a Connections.SendRequest directive](https://developer.amazon.com/en-US/docs/alexa/smapi/voice-permissions-for-reminders.html#send-a-connectionssendrequest-directive)

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed