### PR TITLE
Components: parse stateBeforeDelegate in delegate()

### DIFF
--- a/docs/advanced-concepts/components/using-components.md
+++ b/docs/advanced-concepts/components/using-components.md
@@ -120,6 +120,7 @@ Name | Description | Value | Required
 `options` | The options for the delegation | `object` | Yes
 `options.onCompletedIntent` | The name of the intent to which the component should route to as soon as it finished the task | `string` | Yes
 `options.data` | The data object will be filled by the component with the data it is supposed to collect. For example, the `ScheduleMeeting` component would need the users email to finish its task.. It offers the possibility to provide data you've already collected, so the component doesn't have to ask for it again. See more [here](#parsing-existing-data) | `object` | No
+`options.stateBeforeDelegate` | The state to which the framework will route back to after the component is finished | `string` | No
 
 ```js
 // @language=javascript

--- a/jovo-core/src/plugins/Component.ts
+++ b/jovo-core/src/plugins/Component.ts
@@ -41,6 +41,7 @@ interface ConstructorOptions {
 interface DelegationOptions {
   data?: ComponentData;
   onCompletedIntent: string;
+  stateBeforeDelegate?: string;
 }
 
 interface Response {

--- a/jovo-core/src/plugins/Handler.ts
+++ b/jovo-core/src/plugins/Handler.ts
@@ -405,7 +405,7 @@ export class Handler implements Plugin {
         {
           data: options.data || {},
           onCompletedIntent: options.onCompletedIntent,
-          stateBeforeDelegate: this.getState(),
+          stateBeforeDelegate: options.stateBeforeDelegate || this.getState(),
         },
       ]);
 


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Adds the ability to parse the `stateBeforeDelegate` property in the delegation options.
## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed