### PR TITLE
🐛 Fixed bug related to JovoWebClientVue

### DIFF
--- a/jovo-clients/jovo-client-web-vue/src/JovoWebClientVue.ts
+++ b/jovo-clients/jovo-client-web-vue/src/JovoWebClientVue.ts
@@ -31,7 +31,6 @@ export class JovoWebClientVue {
     this.$assistant = new JovoWebClient(url, config);
     this.$events = [];
     this.setupListeners();
-    this.$assistant.start();
   }
 
   get instance(): JovoWebClient {
@@ -60,6 +59,15 @@ export class JovoWebClientVue {
 
   set config(config: Config) {
     this.$assistant.$config = config;
+  }
+
+  // Has to be called synchronously in a click handler due to safari's handling of audio
+  start() {
+    return this.$assistant.start();
+  }
+
+  stop() {
+    return this.$assistant.stop();
   }
 
   // tslint:disable-next-line:no-any


### PR DESCRIPTION
## Proposed changes
Moved `start` from constructor to a method. 
`start` of the plugin will have to be called before anything else.
Additionally, `start` is required to be called from a click-handler in order to properly work on Safari.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed