### PR TITLE
Add _JOVO_TEXT_ to return non SSML text

### DIFF
--- a/jovo-platforms/jovo-platform-bixby/README.md
+++ b/jovo-platforms/jovo-platform-bixby/README.md
@@ -85,6 +85,12 @@ structure (JovoResponse) {
     max (One)
   }
 
+  property(_JOVO_TEXT_) {
+    type(JovoText)
+    min (Optional)
+    max (One)
+  }
+
   property (_JOVO_LAYOUT_) {
     type(JovoLayout)
     min (Optional)
@@ -310,10 +316,16 @@ Inside `primitives/`, you will find three primitive concepts.
 
 - `<lang>`
 - `<audio>`
+- `<say-as>`
+- `<s>`
+- `<p>`
+- `<sub>`
 
 > Learn more about using SSML with Bixby [here](https://bixbydevelopers.com/dev/docs/reference/ref-topics/ssml).
 
 > Learn more about the Jovo SpeechBuilder [here](https://www.jovo.tech/docs/output/speechbuilder).
+
+`JovoText` same as JovoSpeech but with SSML removed.
 
 `JovoState` describes the current state of your voice app.
 
@@ -362,7 +374,7 @@ Note that your own properties must be optional and of cardinality `One`.
 
 #### JovoResponse
 
-`JovoResponse` is a structure for the response object, which allows communication between your capsule and your Jovo app. It features all yet available functionality as properties, such as speech output `_JOVO_SPEECH_` of type `JovoSpeech`, `_JOVO_LAYOUT` for adding layouts to your capsule and `_JOVO_SESSION_DATA_` for session data.
+`JovoResponse` is a structure for the response object, which allows communication between your capsule and your Jovo app. It features all yet available functionality as properties, such as speech SSML output `_JOVO_SPEECH_` of type `JovoSpeech`, text output `_JOVO_TEXT_` of type `JovoText`, `_JOVO_LAYOUT` for adding layouts to your capsule and `_JOVO_SESSION_DATA_` for session data.
 
 ```bxb
 structure (JovoResponse) {
@@ -382,6 +394,12 @@ structure (JovoResponse) {
 
   property(_JOVO_SPEECH_) {
     type(JovoSpeech)
+    min (Optional)
+    max (One)
+  }
+
+  property(_JOVO_TEXT_) {
+    type(JovoText)
     min (Optional)
     max (One)
   }

--- a/jovo-platforms/jovo-platform-bixby/src/core/BixbyCore.ts
+++ b/jovo-platforms/jovo-platform-bixby/src/core/BixbyCore.ts
@@ -1,4 +1,4 @@
-import { Plugin, HandleRequest, EnumRequestType, JovoError, ErrorCode } from 'jovo-core';
+import { Plugin, HandleRequest, EnumRequestType, JovoError, ErrorCode, SpeechBuilder } from 'jovo-core';
 import _get from 'lodash.get';
 import _set from 'lodash.set';
 
@@ -77,11 +77,17 @@ export class BixbyCore implements Plugin {
     const tell = _get(output, 'Bixby.tell') || _get(output, 'tell');
     if (tell) {
       _set(capsule.$response, '_JOVO_SPEECH_', tell.speech);
+
+      const text =  tell.speech ? SpeechBuilder.removeSSML(tell.speech) : '';
+      _set(capsule.$response, '_JOVO_TEXT_', text);
     }
 
     const ask = _get(output, 'Bixby.ask') || _get(output, 'ask');
     if (ask) {
       _set(capsule.$response, '_JOVO_SPEECH_', ask.speech);
+
+      const text =  ask.speech ? SpeechBuilder.removeSSML(ask.speech) : '';
+      _set(capsule.$response, '_JOVO_TEXT_', text);
     }
 
     if (capsule.$session && capsule.$session.$data) {

--- a/jovo-platforms/jovo-platform-bixby/src/core/BixbyResponse.ts
+++ b/jovo-platforms/jovo-platform-bixby/src/core/BixbyResponse.ts
@@ -5,6 +5,7 @@ import { Response, SessionData } from './Interfaces';
 export class BixbyResponse implements JovoResponse {
   _JOVO_SESSION_DATA_?: SessionData;
   _JOVO_SPEECH_?: string;
+  _JOVO_TEXT_?: string;
   _JOVO_AUDIO_?: string;
   // tslint:disable:no-any
   _JOVO_LAYOUT_?: { [key: string]: any };
@@ -41,11 +42,12 @@ export class BixbyResponse implements JovoResponse {
   }
 
   getSpeechPlain(): string | undefined {
-    throw new Error('Method not implemented.');
+    return this._JOVO_TEXT_;
   }
 
   getRepromptPlain(): string | undefined {
-    throw new Error('Method not implemented.');
+    // TODO: implement reprompt
+    return this._JOVO_TEXT_;
   }
 
   getSessionAttributes(): SessionData | undefined {

--- a/jovo-platforms/jovo-platform-bixby/src/core/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-bixby/src/core/Interfaces.ts
@@ -37,6 +37,7 @@ export interface SessionData {
 
 export interface Response {
   _JOVO_SPEECH_: string;
+  _JOVO_TEXT_: string;
   _JOVO_SESSION_DATA_: SessionData;
   _JOVO_AUDIO_?: {};
 }


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Besides `_JOVO_SPEECH_` that contains SSML, the response needs to include text only for display. So, add `_JOVO_TEXT_` to the response.

Usage:

```
result-view {
  match {
    JovoResponse (response)
  }

  message {
    if (exists(response._JOVO_TEXT_) && exists(response._JOVO_SPEECH_)) {
      template("#{value (response._JOVO_TEXT_)}") {
          speech ("#{value (response._JOVO_SPEECH_)}")
      }
    }
  }
}
```


## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed