### PR TITLE
Correct link to Unhandled anchor on Intents page

### DIFF
--- a/docs/basic-concepts/routing/intents.md
+++ b/docs/basic-concepts/routing/intents.md
@@ -90,7 +90,7 @@ You can learn more about Jovo standard intents in the following sections:
 * [NEW_USER Intent](#new_user-intent)
 * [ON_REQUEST Intent](#on_request-intent)
 * [END Intent](#end-intent)
-* [Unhandled Intent](#unhandled-intent)
+* [Unhandled Intent](#unhandled)
 
 ### LAUNCH
 


### PR DESCRIPTION
## Proposed changes
The Intents page currently has a link pointing to a non-existent anchor for `Unhandled`. This PR points to the correct anchor

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] ~I have added tests to cover my changes~
- [ ] ~All new and existing tests passed~