### PR TITLE
🔥 Replace `googleapis` with `google-auth-library`

### DIFF
--- a/jovo-platforms/jovo-platform-googlebusiness/README.md
+++ b/jovo-platforms/jovo-platform-googlebusiness/README.md
@@ -21,7 +21,7 @@ Learn how to build your Google Business Messages bot with the Jovo Framework.
 Install the module:
 
 ```sh
-$ npm install jovo-platform-gogolebusiness --save
+$ npm install jovo-platform-googlebusiness --save
 ```
 
 Import the installed module, initialize and add it to the `app` object:

--- a/jovo-platforms/jovo-platform-googlebusiness/package.json
+++ b/jovo-platforms/jovo-platform-googlebusiness/package.json
@@ -16,7 +16,7 @@
   "author": "jovotech",
   "license": "Apache-2.0",
   "dependencies": {
-    "googleapis": "^42.0.0",
+    "google-auth-library": "^5.5.1",
     "jovo-core": "^3.0.18",
     "lodash.merge": "^4.6.2"
   },

--- a/jovo-platforms/jovo-platform-googlebusiness/src/services/GoogleBusinessAPI.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/services/GoogleBusinessAPI.ts
@@ -1,4 +1,4 @@
-import { google } from 'googleapis';
+import { JWT } from 'google-auth-library';
 import { AxiosRequestConfig, ErrorCode, HttpService, JovoError, Method } from 'jovo-core';
 
 import { GoogleServiceAccount } from '../Interfaces';
@@ -23,7 +23,7 @@ export class GoogleBusinessAPI {
 
   static async getApiAccessToken(serviceAccount: GoogleServiceAccount) {
     try {
-      const jwtClient = new google.auth.JWT(
+      const jwtClient = new JWT(
         serviceAccount.client_email,
         undefined,
         serviceAccount.private_key,


### PR DESCRIPTION
## Proposed changes
Replace the dependency `googleapis` with `google-auth-library`, because only a single export of the auth library is used.
Drastically reduces package size.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed