### PR TITLE
🐛 Fix FacebookMessenger bug

### DIFF
--- a/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/AttachmentMessage.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/AttachmentMessage.ts
@@ -41,17 +41,19 @@ export class AttachmentMessage extends Message {
       return this.sendFile(pageAccessToken, version);
     }
 
+    const quickReplies = this.options.quickReplies
+      ? this.options.quickReplies.map((quickReply) => {
+          return typeof quickReply === 'string' ? new TextQuickReply(quickReply) : quickReply;
+        })
+      : undefined;
+
     const data = {
       message: {
         attachment: {
           payload: {},
           type: this.options.type,
         },
-        quick_replies: this.options.quickReplies
-          ? this.options.quickReplies.map((quickReply) => {
-              return typeof quickReply === 'string' ? new TextQuickReply(quickReply) : quickReply;
-            })
-          : undefined,
+        quick_replies: quickReplies?.length ? quickReplies : undefined,
       },
       recipient: this.recipient,
     };

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/TextMessage.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/responses/messages/TextMessage.ts
@@ -23,12 +23,14 @@ export class TextMessage extends Message {
   constructor(readonly recipient: IdentityData, options: TextMessageOptions) {
     super(recipient);
 
+    const quickReplies = options.quickReplies
+      ? options.quickReplies.map((quickReply) => {
+          return typeof quickReply === 'string' ? new TextQuickReply(quickReply) : quickReply;
+        })
+      : undefined;
+
     this.message = {
-      quick_replies: options.quickReplies
-        ? options.quickReplies.map((quickReply) => {
-            return typeof quickReply === 'string' ? new TextQuickReply(quickReply) : quickReply;
-          })
-        : undefined,
+      quick_replies: quickReplies?.length ? quickReplies : undefined,
       text: MessengerBotSpeechBuilder.removeSSML(options.text),
     };
     this.message_type = options.messageType || MessageType.Response;


### PR DESCRIPTION
## Proposed changes
The API threw an error if an empty quick_replies-array was sent.
Therefore, no quick-replies will be sent when the array is empty.


## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed