### PR TITLE
✨ Implement asynchronous responses for GoogleBusiness

### DIFF
--- a/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
@@ -32,15 +32,18 @@ export interface GoogleBusinessSuggestionRequest extends GoogleBusinessBaseReque
   };
 }
 
-export interface BaseResponse {
-  name: string;
+export interface ResponseOptions {
+  suggestions?: Suggestion[];
+  fallback?: string;
+}
+
+
+export interface BaseResponse extends ResponseOptions {
   messageId: string;
   representative: {
     displayName?: string;
     representativeType: 'REPRESENTATIVE_TYPE_UNSPECIFIED' | 'BOT' | 'HUMAN';
   };
-  suggestions?: Suggestion[];
-  fallback?: string;
 }
 
 export type Suggestion = SuggestedReply | SuggestActionUrl | SuggestActionDial;

--- a/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
@@ -1,10 +1,12 @@
+export type EntryPoint = 'ENTRY_POINT_UNSPECIFIED' | 'PLACESHEET' | 'MAPS';
+
 export interface GoogleBusinessBaseRequest {
   agent: string;
   conversationId: string;
   customAgentId: string;
   requestId: string;
   context?: {
-    entryPoint: 'ENTRY_POINT_UNSPECIFIED' | 'PLACESHEET' | 'MAPS';
+    entryPoint: EntryPoint;
     placeId: string;
     userInfo: {
       displayName: string;
@@ -22,13 +24,15 @@ export interface GoogleBusinessMessageRequest extends GoogleBusinessBaseRequest 
   };
 }
 
+export type SuggestionType = 'UNKNOWN' | 'ACTION' | 'REPLY';
+
 export interface GoogleBusinessSuggestionRequest extends GoogleBusinessBaseRequest {
   suggestionResponse: {
     message: string;
     postbackData: string;
     createTime: string; // RFC3339 UTC "Zulu" format
     text: string;
-    suggestionType: 'UNKNOWN' | 'ACTION' | 'REPLY';
+    suggestionType: SuggestionType;
   };
 }
 
@@ -37,12 +41,13 @@ export interface ResponseOptions {
   fallback?: string;
 }
 
+export type RepresentativeType = 'REPRESENTATIVE_TYPE_UNSPECIFIED' | 'BOT' | 'HUMAN';
 
 export interface BaseResponse extends ResponseOptions {
   messageId: string;
   representative: {
     displayName?: string;
-    representativeType: 'REPRESENTATIVE_TYPE_UNSPECIFIED' | 'BOT' | 'HUMAN';
+    representativeType: RepresentativeType;
   };
 }
 
@@ -95,8 +100,11 @@ export interface CarouselCardResponse extends BaseResponse {
   };
 }
 
+export type CardWidth = 'CARD_WIDTH_UNSPECIFIED' | 'SMALL' | 'MEDIUM';
+export type CardHeight = 'HEIGHT_UNSPECIFIED' | 'SHORT' | 'MEDIUM' | 'TALL';
+
 export interface CarouselCard {
-  cardWidth: 'CARD_WIDTH_UNSPECIFIED' | 'SMALL' | 'MEDIUM';
+  cardWidth: CardWidth;
   cardContents: Card[];
 }
 
@@ -104,7 +112,7 @@ export interface Card {
   title?: string;
   description?: string;
   media?: {
-    height: 'HEIGHT_UNSPECIFIED' | 'SHORT' | 'MEDIUM' | 'TALL';
+    height: CardHeight;
     contentInfo: {
       fileUrl: string;
       thumbnailUrl?: string;

--- a/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/Interfaces.ts
@@ -107,7 +107,7 @@ export interface Card {
     height: 'HEIGHT_UNSPECIFIED' | 'SHORT' | 'MEDIUM' | 'TALL';
     contentInfo: {
       fileUrl: string;
-      thumbnailUrl: string;
+      thumbnailUrl?: string;
       forceRefresh?: boolean;
       altText: string;
     };

--- a/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessBot.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessBot.ts
@@ -1,7 +1,14 @@
-import { BaseApp, HandleRequest, Host, Jovo, Log } from 'jovo-core';
+import { BaseApp, HandleRequest, Host, Jovo, Log, Util } from 'jovo-core';
 
 import { GoogleBusiness } from '../GoogleBusiness';
-import { ResponseOptions, Suggestion } from '../Interfaces';
+import {
+  BaseResponse,
+  GoogleServiceAccount,
+  ResponseOptions,
+  Suggestion,
+  TextResponse,
+} from '../Interfaces';
+import { GoogleBusinessAPI } from '../services/GoogleBusinessAPI';
 import { GoogleBusinessRequest } from './GoogleBusinessRequest';
 import { GoogleBusinessResponse } from './GoogleBusinessResponse';
 import { GoogleBusinessSpeechBuilder } from './GoogleBusinessSpeechBuilder';
@@ -92,5 +99,32 @@ export class GoogleBusinessBot extends Jovo {
   setFallback(fallback: string): this {
     this.$output.GoogleBusiness.Fallback = fallback;
     return this;
+  }
+
+  async showText(text: string, options: ResponseOptions = {}): Promise<void> {
+    const data: TextResponse = {
+      ...this.makeBaseResponse(),
+      ...options,
+      text,
+    };
+    await GoogleBusinessAPI.sendResponse({
+      data,
+      serviceAccount: this.serviceAccount!,
+      sessionId: this.$request!.getSessionId()!,
+    });
+  }
+
+  makeBaseResponse(): BaseResponse {
+    const messageId = Util.randomStr(12);
+    return {
+      messageId,
+      representative: {
+        representativeType: 'BOT',
+      },
+    };
+  }
+
+  private get serviceAccount(): GoogleServiceAccount | undefined {
+    return this.$config.plugin?.GoogleBusiness.serviceAccount;
   }
 }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessBot.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessBot.ts
@@ -1,7 +1,7 @@
 import { BaseApp, HandleRequest, Host, Jovo, Log } from 'jovo-core';
 
-import { Config, GoogleBusiness } from '../GoogleBusiness';
-import { Suggestion } from '../Interfaces';
+import { GoogleBusiness } from '../GoogleBusiness';
+import { ResponseOptions, Suggestion } from '../Interfaces';
 import { GoogleBusinessRequest } from './GoogleBusinessRequest';
 import { GoogleBusinessResponse } from './GoogleBusinessResponse';
 import { GoogleBusinessSpeechBuilder } from './GoogleBusinessSpeechBuilder';
@@ -52,7 +52,7 @@ export class GoogleBusinessBot extends Jovo {
   }
 
   getDeviceId(): string | undefined {
-    Log.warn('Google Business Messages doesn\'t provide a device ID');
+    Log.warn(`Google Business Messages doesn't provide a device ID`);
     return;
   }
 
@@ -86,6 +86,11 @@ export class GoogleBusinessBot extends Jovo {
 
   addSuggestionChips(suggestions: Suggestion[]): this {
     this.$output.GoogleBusiness.Suggestions = suggestions;
+    return this;
+  }
+
+  setFallback(fallback: string): this {
+    this.$output.GoogleBusiness.Fallback = fallback;
     return this;
   }
 }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/index.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/index.ts
@@ -35,6 +35,7 @@ declare module 'jovo-core/dist/src/Interfaces' {
       Suggestions?: Suggestion[];
       Carousel?: CarouselCard;
       StandaloneCard?: StandaloneCard;
+      Fallback?: string;
     };
   }
 }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/index.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/index.ts
@@ -17,15 +17,8 @@ declare module 'jovo-core/dist/src/core/Jovo' {
 
 declare module './core/GoogleBusinessBot' {
   interface GoogleBusinessBot {
-    /**
-     * Adds carousel to response
-     * @public
-     * @see https://developers.google.com/business-communications/business-messages/guides/build/send#rich-card-carousels
-     * @param {CarouselCard} carousel
-     * @return {GoogleBusinessBot}
-     */
-    showCarousel(carousel: CarouselCard): this;
-    showStandaloneCard(card: StandaloneCard): this;
+    showCarousel(carousel: CarouselCard, fallback?: string): Promise<void>;
+    showStandaloneCard(card: StandaloneCard, fallback?: string): Promise<void>;
   }
 }
 

--- a/jovo-platforms/jovo-platform-googlebusiness/src/modules/Cards.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/modules/Cards.ts
@@ -1,7 +1,5 @@
-import { Plugin, Util } from 'jovo-core';
+import { Plugin } from 'jovo-core';
 import { GoogleBusinessBot } from '../core/GoogleBusinessBot';
-import { GoogleBusinessRequest } from '../core/GoogleBusinessRequest';
-import { GoogleBusinessResponse } from '../core/GoogleBusinessResponse';
 import { GoogleBusiness } from '../GoogleBusiness';
 import {
   CarouselCard,
@@ -9,61 +7,44 @@ import {
   StandaloneCard,
   StandaloneCardResponse,
 } from '../Interfaces';
+import { GoogleBusinessAPI } from '../services/GoogleBusinessAPI';
 
 export class Cards implements Plugin {
   install(googleBusiness: GoogleBusiness) {
-    googleBusiness.middleware('$output')!.use(this.output.bind(this));
-
-    /**
-     * Adds carousel to response
-     * @public
-     * @see https://developers.google.com/business-communications/business-messages/guides/build/send#rich-card-carousels
-     * @param {CarouselCard} carousel
-     * @return {GoogleBusinessBot}
-     */
-    GoogleBusinessBot.prototype.showCarousel = function (carousel: CarouselCard) {
-      this.$output.GoogleBusiness.Carousel = carousel;
-      return this;
-    };
-
-    GoogleBusinessBot.prototype.showStandaloneCard = function (card: StandaloneCard) {
-      this.$output.GoogleBusiness.StandaloneCard = card;
-      return this;
-    };
-  }
-
-  async output(googleBusinessBot: GoogleBusinessBot) {
-    // might have been initialized by GoogleBusinessCore.ts already
-    if (!googleBusinessBot.$response) {
-      googleBusinessBot.$response = new GoogleBusinessResponse();
-    }
-    const response = googleBusinessBot.$response as GoogleBusinessResponse;
-
-    if (!response.response) {
-      const request = googleBusinessBot.$request as GoogleBusinessRequest;
-      const messageId = Util.randomStr(12);
-
-      response.response = {
-        messageId,
-        name: `conversations/${request.getSessionId()}/messages/${messageId}`,
-        representative: {
-          representativeType: 'BOT',
+    GoogleBusinessBot.prototype.showCarousel = async function (
+      carousel: CarouselCard,
+      fallback?: string,
+    ) {
+      const data: CarouselCardResponse = {
+        ...this.makeBaseResponse(),
+        fallback,
+        richCard: {
+          carouselCard: carousel,
         },
       };
-    }
+      await GoogleBusinessAPI.sendResponse({
+        data,
+        serviceAccount: this.$config.plugin!.GoogleBusiness.serviceAccount,
+        sessionId: this.$request!.getSessionId()!,
+      });
+    };
 
-    const carousel = googleBusinessBot.$output.GoogleBusiness.Carousel;
-    if (carousel) {
-      (response.response as CarouselCardResponse).richCard = {
-        carouselCard: carousel,
+    GoogleBusinessBot.prototype.showStandaloneCard = async function (
+      card: StandaloneCard,
+      fallback?: string,
+    ) {
+      const data: StandaloneCardResponse = {
+        ...this.makeBaseResponse(),
+        fallback,
+        richCard: {
+          standaloneCard: card,
+        },
       };
-    }
-
-    const standaloneCard = googleBusinessBot.$output.GoogleBusiness.StandaloneCard;
-    if (standaloneCard) {
-      (response.response as StandaloneCardResponse).richCard = {
-        standaloneCard,
-      };
-    }
+      await GoogleBusinessAPI.sendResponse({
+        data,
+        serviceAccount: this.$config.plugin!.GoogleBusiness.serviceAccount,
+        sessionId: this.$request!.getSessionId()!,
+      });
+    };
   }
 }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
@@ -34,7 +34,7 @@ export class GoogleBusinessCore implements Plugin {
   async request(googleBusinessBot: GoogleBusinessBot) {
     if (!googleBusinessBot.$host) {
       throw new JovoError(
-        "Couldn't access $host object",
+        `Couldn't access $host object`,
         ErrorCode.ERR_PLUGIN,
         'jovo-platform-googlebusiness',
         'The $host object is necessary to initialize both $request and $user',

--- a/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
@@ -93,5 +93,10 @@ export class GoogleBusinessCore implements Plugin {
     if (suggestions) {
       response.response.suggestions = suggestions;
     }
+
+    const fallback = output.GoogleBusiness.Fallback;
+    if(fallback) {
+      response.response.fallback = fallback;
+    }
   }
 }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
@@ -34,7 +34,7 @@ export class GoogleBusinessCore implements Plugin {
   async request(googleBusinessBot: GoogleBusinessBot) {
     if (!googleBusinessBot.$host) {
       throw new JovoError(
-        'Couldn\'t access $host object',
+        "Couldn't access $host object",
         ErrorCode.ERR_PLUGIN,
         'jovo-platform-googlebusiness',
         'The $host object is necessary to initialize both $request and $user',
@@ -61,18 +61,10 @@ export class GoogleBusinessCore implements Plugin {
       googleBusinessBot.$response = new GoogleBusinessResponse();
     }
     const response = googleBusinessBot.$response as GoogleBusinessResponse;
-    const request = googleBusinessBot.$request as GoogleBusinessRequest;
-    const messageId = Util.randomStr(12);
 
     // might have been initialized by Cards.ts already
     if (!response.response) {
-      response.response = {
-        messageId,
-        name: `conversations/${request.getSessionId()}/messages/${messageId}`,
-        representative: {
-          representativeType: 'BOT',
-        },
-      };
+      response.response = googleBusinessBot.makeBaseResponse();
     }
 
     if (Object.keys(output).length === 0) {
@@ -95,7 +87,7 @@ export class GoogleBusinessCore implements Plugin {
     }
 
     const fallback = output.GoogleBusiness.Fallback;
-    if(fallback) {
+    if (fallback) {
       response.response.fallback = fallback;
     }
   }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/modules/GoogleBusinessCore.ts
@@ -62,7 +62,6 @@ export class GoogleBusinessCore implements Plugin {
     }
     const response = googleBusinessBot.$response as GoogleBusinessResponse;
 
-    // might have been initialized by Cards.ts already
     if (!response.response) {
       response.response = googleBusinessBot.makeBaseResponse();
     }

--- a/jovo-platforms/jovo-platform-googlebusiness/src/services/GoogleBusinessAPI.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/services/GoogleBusinessAPI.ts
@@ -1,10 +1,48 @@
 import { JWT } from 'google-auth-library';
 import { AxiosRequestConfig, ErrorCode, HttpService, JovoError, Method } from 'jovo-core';
 
-import { GoogleServiceAccount } from '../Interfaces';
+import { BaseResponse, GoogleServiceAccount } from '../Interfaces';
+
+export interface ApiCallOptions {
+  endpoint: string;
+  method?: Method;
+  path: string;
+  serviceAccount: GoogleServiceAccount;
+  data: BaseResponse;
+}
+
+export interface SendResponseOptions<T extends BaseResponse> {
+  sessionId: string;
+  serviceAccount: GoogleServiceAccount;
+  data: T;
+}
 
 export class GoogleBusinessAPI {
-  static async apiCall(options: ApiCallOptions) {
+  static async sendResponse<T extends BaseResponse = BaseResponse>({
+    data,
+    sessionId,
+    serviceAccount,
+  }: SendResponseOptions<T>) {
+    const options: ApiCallOptions = {
+      data,
+      endpoint: 'https://businessmessages.googleapis.com/v1',
+      path: `/conversations/${sessionId}/messages`,
+      serviceAccount,
+    };
+    try {
+      return this.apiCall<T>(options);
+    } catch (e) {
+      throw new JovoError(
+        'Could not send response!',
+        ErrorCode.ERR_PLUGIN,
+        this.constructor.name,
+        e.response?.data || e.message || e,
+        `Status: ${e.response?.status}`,
+      );
+    }
+  }
+
+  static async apiCall<T = any>(options: ApiCallOptions) {
     const token = await this.getApiAccessToken(options.serviceAccount);
 
     const url = options.endpoint + options.path;
@@ -18,7 +56,7 @@ export class GoogleBusinessAPI {
       url,
     };
 
-    return HttpService.request(config);
+    return HttpService.request<T>(config);
   }
 
   static async getApiAccessToken(serviceAccount: GoogleServiceAccount) {
@@ -39,12 +77,4 @@ export class GoogleBusinessAPI {
       );
     }
   }
-}
-
-export interface ApiCallOptions {
-  endpoint: string;
-  method?: Method;
-  path: string;
-  serviceAccount: GoogleServiceAccount;
-  data: any; // tslint-disable-line
 }


### PR DESCRIPTION
## Proposed changes
The `GoogleBusiness`-platform is now capable of sending multiple responses asynchronously. 
Now, it is possible to answer with multiple messages to a single request.

- Implemented the method `showText` to immediately send a text message.
- ⚠️ Changed the behavior of `showCarousel` and `showStandaloneCard` to immediately send their respective rich-card.


Additionally, a method `setFallback` was implemented which allows setting a `fallback`-value for the response. For more information about the `fallback`-value, take a look [here](https://developers.google.com/business-communications/business-messages/guides/build/send#fallback_strategy).

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed