### PR TITLE
♻️ ✨ Refactor Facebook Messenger platform - asynchronous Responses

### DIFF
--- a/examples/javascript/05_facebookmessenger/hello-world/src/app.js
+++ b/examples/javascript/05_facebookmessenger/hello-world/src/app.js
@@ -38,8 +38,6 @@ app.setHandler({
 	},
 
 	MyNameIsIntent() {
-		console.log(this.$request.getInputs());
-
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
 	}
 });

--- a/examples/javascript/05_facebookmessenger/quick-replies/src/app.js
+++ b/examples/javascript/05_facebookmessenger/quick-replies/src/app.js
@@ -4,10 +4,10 @@
 // APP INITIALIZATION
 // ------------------------------------------------------------------
 
-const { App } = require('jovo-framework');
+const { App, Log } = require('jovo-framework');
 const {
 	FacebookMessenger,
-	TextQuickReply
+	TextQuickReply,
 } = require('jovo-platform-facebookmessenger');
 const { JovoDebugger } = require('jovo-plugin-debugger');
 const { FileDb } = require('jovo-db-filedb');
@@ -16,12 +16,12 @@ const { DialogflowNlu } = require('jovo-nlu-dialogflow');
 const app = new App();
 
 const messenger = new FacebookMessenger({
-	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN
+	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN,
 });
 
 messenger.use(
 	new DialogflowNlu({
-		credentialsFile: '../credentials.json'
+		credentialsFile: '../credentials.json',
 	})
 );
 
@@ -45,17 +45,9 @@ app.setHandler({
 		}
 	},
 
-	MyNameIsIntent() {
-		console.log(this.$request.getInputs());
-
+	async MyNameIsIntent() {
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
-		if (this.$messengerBot) {
-			this.$messengerBot.showText({
-				text: 'Is there anything else I can do for you?',
-				quickReplies: ['Exit']
-			});
-		}
-	}
+	},
 });
 
 module.exports.app = app;

--- a/examples/javascript/05_facebookmessenger/sender-actions/src/app.js
+++ b/examples/javascript/05_facebookmessenger/sender-actions/src/app.js
@@ -4,10 +4,10 @@
 // APP INITIALIZATION
 // ------------------------------------------------------------------
 
-const { App } = require('jovo-framework');
+const { App, Log } = require('jovo-framework');
 const {
 	FacebookMessenger,
-	SenderActionType
+	SenderActionType,
 } = require('jovo-platform-facebookmessenger');
 const { JovoDebugger } = require('jovo-plugin-debugger');
 const { FileDb } = require('jovo-db-filedb');
@@ -16,19 +16,19 @@ const { DialogflowNlu } = require('jovo-nlu-dialogflow');
 const app = new App();
 
 const messenger = new FacebookMessenger({
-	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN
+	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN,
 });
 
 messenger.use(
 	new DialogflowNlu({
-		credentialsFile: '../credentials.json'
+		credentialsFile: '../credentials.json',
 	})
 );
 
 app.use(messenger, new JovoDebugger(), new FileDb());
 
 function delay(amountInMs) {
-	return new Promise(resolve => {
+	return new Promise((resolve) => {
 		setTimeout(() => {
 			resolve();
 		}, amountInMs);
@@ -45,21 +45,23 @@ app.setHandler({
 	},
 
 	async HelloWorldIntent() {
-		if(this.$messengerBot) {
-			await this.$messengerBot.showAction(SenderActionType.MarkSeen);
-			await delay(100);
-			await this.$messengerBot.showAction(SenderActionType.TypingOn);
-			await delay(1000);
-			await this.$messengerBot.showAction(SenderActionType.TypingOff);
+		if (this.$messengerBot) {
+			try {
+				await this.$messengerBot.showAction(SenderActionType.MarkSeen);
+				await delay(100);
+				await this.$messengerBot.showAction(SenderActionType.TypingOn);
+				await delay(1000);
+				await this.$messengerBot.showAction(SenderActionType.TypingOff);
+			} catch (e) {
+				Log.error((e.response && e.response.data) || e.message);
+			}
 		}
 		this.ask("Hello World! What's your name?", 'Please tell me your name.');
 	},
 
 	MyNameIsIntent() {
-		console.log(this.$request.getInputs());
-
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
-	}
+	},
 });
 
 module.exports.app = app;

--- a/examples/javascript/05_facebookmessenger/templates/src/app.js
+++ b/examples/javascript/05_facebookmessenger/templates/src/app.js
@@ -4,13 +4,13 @@
 // APP INITIALIZATION
 // ------------------------------------------------------------------
 
-const { App } = require('jovo-framework');
+const { App, Log } = require('jovo-framework');
 const {
 	FacebookMessenger,
 	ButtonType,
 	PostbackButton,
 	MediaType,
-	stringifyFacebookDate
+	stringifyFacebookDate,
 } = require('jovo-platform-facebookmessenger');
 const { JovoDebugger } = require('jovo-plugin-debugger');
 const { FileDb } = require('jovo-db-filedb');
@@ -19,12 +19,12 @@ const { DialogflowNlu } = require('jovo-nlu-dialogflow');
 const app = new App();
 
 const messenger = new FacebookMessenger({
-	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN
+	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN,
 });
 
 messenger.use(
 	new DialogflowNlu({
-		credentialsFile: '../credentials.json'
+		credentialsFile: '../credentials.json',
 	})
 );
 
@@ -39,88 +39,89 @@ app.setHandler({
 		return this.toIntent('HelloWorldIntent');
 	},
 
-	HelloWorldIntent() {
-		this.ask("Hello World! What's your name?", 'Please tell me your name.');
-
+	async HelloWorldIntent() {
 		if (this.$messengerBot) {
-			this.$messengerBot.showGenericTemplate({
-				elements: [
-					{
-						title: 'Title',
-						subtitle: 'Subtitle',
-						image_url: 'https://via.placeholder.com/100',
-						default_action: {
-							type: ButtonType.Link,
-							url: 'https://example.com'
+			try {
+				await this.$messengerBot.showGenericTemplate({
+					elements: [
+						{
+							title: 'Title',
+							subtitle: 'Subtitle',
+							image_url: 'https://via.placeholder.com/100',
+							default_action: {
+								type: ButtonType.Link,
+								url: 'https://example.com',
+							},
+							buttons: [
+								new PostbackButton('Action 1'),
+								new PostbackButton('Action 2'),
+							],
 						},
-						buttons: [
-							new PostbackButton('Action 1'),
-							new PostbackButton('Action 2')
-						]
-					}
-				]
-			});
+					],
+				});
 
-			// this.$messengerBot.showButtonTemplate({
-			// 	text: 'Example',
-			// 	buttons: [new PostbackButton('Action 1'), new PostbackButton('Action 2')]
-			// });
+				// await this.$messengerBot.showButtonTemplate({
+				// 	text: 'Example',
+				// 	buttons: [new PostbackButton('Action 1'), new PostbackButton('Action 2')]
+				// });
 
-			// this.$messengerBot.showMediaTemplate({
-			// 	elements: [
-			// 		{
-			// 			media_type: MediaType.Image,
-			// 			url: 'https://www.facebook.com/<username>/photos/<num-id>',
-			// 			buttons: [new PostbackButton('Action')]
-			// 		}
-			// 	]
-			// });
+				// await this.$messengerBot.showMediaTemplate({
+				// 	elements: [
+				// 		{
+				// 			media_type: MediaType.Image,
+				// 			url: 'https://www.facebook.com/<username>/photos/<num-id>',
+				// 			buttons: [new PostbackButton('Action')]
+				// 		}
+				// 	]
+				// });
 
-			// this.$messengerBot.showReceiptTemplate({
-			// 	recipient_name: 'Some Name',
-			// 	order_number: 'uniqueOrderId',
-			// 	currency: 'EUR',
-			// 	payment_method: 'Visa',
-			// 	summary: {
-			// 		total_cost: 14.99
-			// 	}
-			// });
+				// await this.$messengerBot.showReceiptTemplate({
+				// 	recipient_name: 'Some Name',
+				// 	order_number: 'uniqueOrderId',
+				// 	currency: 'EUR',
+				// 	payment_method: 'Visa',
+				// 	summary: {
+				// 		total_cost: 14.99
+				// 	}
+				// });
 
-			// this.$messengerBot.showAirlineTemplate({
-			// 	intro_message: 'Some Message',
-			// 	locale: 'en_US',
-			// 	boarding_pass: [
-			// 		{
-			// 			passenger_name: 'Some Name',
-			// 			pnr_number: 'uniquePassengerId',
-			// 			logo_image_url: 'https://via.placeholder.com/100',
-			// 			flight_info: {
-			// 				flight_number: '1A',
-			// 				departure_airport: {
-			// 					terminal: 'B',
-			// 					gate: '24',
-			// 					airport_code: 'TXL',
-			// 					city: 'Berlin'
-			// 				},
-			// 				arrival_airport: {
-			// 					airport_code: 'RNG',
-			// 					city: 'SomeCity'
-			// 				},
-			// 				flight_schedule: {
-			// 					departure_time: stringifyFacebookDate(new Date())
-			// 				}
-			// 			}
-			// 		}
-			// 	]
-			// });
+				// await this.$messengerBot.showAirlineTemplate({
+				// 	intro_message: 'Some Message',
+				// 	locale: 'en_US',
+				// 	boarding_pass: [
+				// 		{
+				// 			passenger_name: 'Some Name',
+				// 			pnr_number: 'uniquePassengerId',
+				// 			logo_image_url: 'https://via.placeholder.com/100',
+				// 			flight_info: {
+				// 				flight_number: '1A',
+				// 				departure_airport: {
+				// 					terminal: 'B',
+				// 					gate: '24',
+				// 					airport_code: 'TXL',
+				// 					city: 'Berlin'
+				// 				},
+				// 				arrival_airport: {
+				// 					airport_code: 'RNG',
+				// 					city: 'SomeCity'
+				// 				},
+				// 				flight_schedule: {
+				// 					departure_time: stringifyFacebookDate(new Date())
+				// 				}
+				// 			}
+				// 		}
+				// 	]
+				// });
+			} catch (e) {
+				Log.error((e.response && e.response.data) || e.message);
+			}
 		}
+		this.ask("Hello World! What's your name?", 'Please tell me your name.');
 	},
 
 	MyNameIsIntent() {
-		console.log(this.$request.getInputs());
-
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
-	}
+	},
 });
 
 module.exports.app = app;

--- a/examples/typescript/05_facebookmessenger/quick-replies/src/app.ts
+++ b/examples/typescript/05_facebookmessenger/quick-replies/src/app.ts
@@ -2,7 +2,7 @@ import { FileDb } from 'jovo-db-filedb';
 import { App } from 'jovo-framework';
 import {
 	FacebookMessenger,
-	TextQuickReply
+	TextQuickReply,
 } from 'jovo-platform-facebookmessenger';
 
 import { JovoDebugger } from 'jovo-plugin-debugger';
@@ -11,12 +11,12 @@ import { DialogflowNlu } from 'jovo-nlu-dialogflow';
 const app = new App();
 
 const messenger = new FacebookMessenger({
-	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN
+	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN,
 });
 
 messenger.use(
 	new DialogflowNlu({
-		credentialsFile: '../../credentials.json'
+		credentialsFile: '../../credentials.json',
 	})
 );
 
@@ -31,16 +31,12 @@ app.setHandler({
 		this.ask("Hello World! What's your name?", 'Please tell me your name.');
 		this.$messengerBot
 			?.setQuickReplies([new TextQuickReply('John'), 'Jack', 'Anna'])
-			.addQuickReply('More');
+			?.addQuickReply('More');
 	},
 
 	MyNameIsIntent() {
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
-		this.$messengerBot?.showText({
-			text: 'Is there anything else I can do for you?',
-			quickReplies: ['Exit']
-		});
-	}
+	},
 });
 
 export { app };

--- a/examples/typescript/05_facebookmessenger/sender-actions/src/app.ts
+++ b/examples/typescript/05_facebookmessenger/sender-actions/src/app.ts
@@ -1,5 +1,5 @@
 import { FileDb } from 'jovo-db-filedb';
-import { App } from 'jovo-framework';
+import { App, Log } from 'jovo-framework';
 import {
 	FacebookMessenger,
 	SenderActionType
@@ -36,11 +36,15 @@ app.setHandler({
 	},
 
 	async HelloWorldIntent() {
-		await this.$messengerBot?.showAction(SenderActionType.MarkSeen);
-		await delay(100);
-		await this.$messengerBot?.showAction(SenderActionType.TypingOn);
-		await delay(1000);
-		await this.$messengerBot?.showAction(SenderActionType.TypingOff);
+		try {
+			await this.$messengerBot?.showAction(SenderActionType.MarkSeen);
+			await delay(100);
+			await this.$messengerBot?.showAction(SenderActionType.TypingOn);
+			await delay(1000);
+			await this.$messengerBot?.showAction(SenderActionType.TypingOff);
+		} catch (e) {
+			Log.error(e.response?.data || e.message);
+		}
 		this.ask("Hello World! What's your name?", 'Please tell me your name.');
 	},
 

--- a/examples/typescript/05_facebookmessenger/templates/src/app.ts
+++ b/examples/typescript/05_facebookmessenger/templates/src/app.ts
@@ -1,25 +1,23 @@
 import { FileDb } from 'jovo-db-filedb';
-import { App } from 'jovo-framework';
+import { App, Log } from 'jovo-framework';
+import { DialogflowNlu } from 'jovo-nlu-dialogflow';
 import {
 	ButtonType,
 	FacebookMessenger,
-	MediaType,
 	PostbackButton,
-	stringifyFacebookDate
 } from 'jovo-platform-facebookmessenger';
 
 import { JovoDebugger } from 'jovo-plugin-debugger';
-import { DialogflowNlu } from 'jovo-nlu-dialogflow';
 
 const app = new App();
 
 const messenger = new FacebookMessenger({
-	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN
+	pageAccessToken: process.env.FB_MESSENGER_PAGE_ACCESS_TOKEN,
 });
 
 messenger.use(
 	new DialogflowNlu({
-		credentialsFile: '../../credentials.json'
+		credentialsFile: '../../credentials.json',
 	})
 );
 
@@ -30,81 +28,87 @@ app.setHandler({
 		return this.toIntent('HelloWorldIntent');
 	},
 
-	HelloWorldIntent() {
+	async HelloWorldIntent() {
+		try {
+			await this.$messengerBot?.showGenericTemplate({
+				elements: [
+					{
+						title: 'Title',
+						subtitle: 'Subtitle',
+						image_url: 'https://via.placeholder.com/100',
+						default_action: {
+							type: ButtonType.Link,
+							url: 'https://example.com',
+						},
+						buttons: [
+							new PostbackButton('Action 1'),
+							new PostbackButton('Action 2'),
+						],
+					},
+				],
+			});
+
+			// await this.$messengerBot?.showButtonTemplate({
+			// 	text: 'Example',
+			// 	buttons: [new PostbackButton('Action 1'), new PostbackButton('Action 2')]
+			// });
+
+			// await this.$messengerBot?.showMediaTemplate({
+			// 	elements: [
+			// 		{
+			// 			media_type: MediaType.Image,
+			// 			url: 'https://www.facebook.com/<username>/photos/<num-id>',
+			// 			buttons: [new PostbackButton('Action')]
+			// 		}
+			// 	]
+			// });
+
+			// await this.$messengerBot?.showReceiptTemplate({
+			// 	recipient_name: 'Some Name',
+			// 	order_number: 'uniqueOrderId',
+			// 	currency: 'EUR',
+			// 	payment_method: 'Visa',
+			// 	summary: {
+			// 		total_cost: 14.99
+			// 	}
+			// });
+
+			// await this.$messengerBot?.showAirlineTemplate({
+			// 	intro_message: 'Some Message',
+			// 	locale: 'en_US',
+			// 	boarding_pass: [
+			// 		{
+			// 			passenger_name: 'Some Name',
+			// 			pnr_number: 'uniquePassengerId',
+			// 			logo_image_url: 'https://via.placeholder.com/100',
+			// 			flight_info: {
+			// 				flight_number: '1A',
+			// 				departure_airport: {
+			// 					terminal: 'B',
+			// 					gate: '24',
+			// 					airport_code: 'TXL',
+			// 					city: 'Berlin'
+			// 				},
+			// 				arrival_airport: {
+			// 					airport_code: 'RNG',
+			// 					city: 'SomeCity'
+			// 				},
+			// 				flight_schedule: {
+			// 					departure_time: stringifyFacebookDate(new Date())
+			// 				}
+			// 			}
+			// 		}
+			// 	]
+			// });
+		} catch (e) {
+			Log.error(e.response?.data || e.message);
+		}
 		this.ask("Hello World! What's your name?", 'Please tell me your name.');
-
-		this.$messengerBot?.showGenericTemplate({
-			elements: [
-				{
-					title: 'Title',
-					subtitle: 'Subtitle',
-					image_url: 'https://via.placeholder.com/100',
-					default_action: { type: ButtonType.Link, url: 'https://example.com' },
-					buttons: [
-						new PostbackButton('Action 1'),
-						new PostbackButton('Action 2')
-					]
-				}
-			]
-		});
-
-		// this.$messengerBot?.showButtonTemplate({
-		// 	text: 'Example',
-		// 	buttons: [new PostbackButton('Action 1'), new PostbackButton('Action 2')]
-		// });
-
-		// this.$messengerBot?.showMediaTemplate({
-		// 	elements: [
-		// 		{
-		// 			media_type: MediaType.Image,
-		// 			url: 'https://www.facebook.com/<username>/photos/<num-id>',
-		// 			buttons: [new PostbackButton('Action')]
-		// 		}
-		// 	]
-		// });
-
-		// this.$messengerBot?.showReceiptTemplate({
-		// 	recipient_name: 'Some Name',
-		// 	order_number: 'uniqueOrderId',
-		// 	currency: 'EUR',
-		// 	payment_method: 'Visa',
-		// 	summary: {
-		// 		total_cost: 14.99
-		// 	}
-		// });
-
-		// this.$messengerBot?.showAirlineTemplate({
-		// 	intro_message: 'Some Message',
-		// 	locale: 'en_US',
-		// 	boarding_pass: [
-		// 		{
-		// 			passenger_name: 'Some Name',
-		// 			pnr_number: 'uniquePassengerId',
-		// 			logo_image_url: 'https://via.placeholder.com/100',
-		// 			flight_info: {
-		// 				flight_number: '1A',
-		// 				departure_airport: {
-		// 					terminal: 'B',
-		// 					gate: '24',
-		// 					airport_code: 'TXL',
-		// 					city: 'Berlin'
-		// 				},
-		// 				arrival_airport: {
-		// 					airport_code: 'RNG',
-		// 					city: 'SomeCity'
-		// 				},
-		// 				flight_schedule: {
-		// 					departure_time: stringifyFacebookDate(new Date())
-		// 				}
-		// 			}
-		// 		}
-		// 	]
-		// });
 	},
 
 	MyNameIsIntent() {
 		this.tell('Hey ' + this.$inputs.name.value + ', nice to meet you!');
-	}
+	},
 });
 
 export { app };

--- a/jovo-platforms/jovo-platform-facebookmessenger/README.md
+++ b/jovo-platforms/jovo-platform-facebookmessenger/README.md
@@ -154,6 +154,38 @@ export = {
 };
 ```
 
+### Disable synchronous response
+By default, `tell` and `ask` generate a message that will be sent shortly before responding to the initial request.
+As a consequence, this message will **always** be the **last** message sent.
+
+If you do not like this behavior, you can disable it by setting the `shouldIgnoreSynchronousResponse`-property to `true` in the configuration: 
+
+```javascript
+// @language=javascript
+
+// src/config.js
+
+module.exports = {
+	platform: {
+		FacebookMessenger: {
+			shouldIgnoreSynchronousResponse: true
+		}
+	}
+};
+
+// @language=typescript
+
+// src/config.ts
+
+export = {
+	platform: {
+		FacebookMessenger: {
+			shouldIgnoreSynchronousResponse: true
+		}
+	}
+};
+```
+
 ## Introduction to Messenger Specific Features
 
 You can access the `messengerBot` object like this:
@@ -179,11 +211,15 @@ For the basic concept, take a look here: [Docs: Basic Concepts > Output](https:/
 
 Facebook Messenger does not support reprompts. Any reprompt passed to `ask` will be ignored.
 
-### Multiple Messages
+### Asynchronous Responses
 
-Facebook Messenger allows sending multiple messages.
+Facebook Messenger allows sending multiple messages asynchronously. 
 
-Read more about sending messages [here](https://developers.facebook.com/docs/messenger-platform/send-messages).
+All asynchronous methods for sending messages return a `AxiosResponse`. It is recommended to wrap these call in a `try-catch`-block to catch possible errors thrown by the API. 
+
+> **INFO**: The message that results from calling `tell` or `ask` will be the last message sent! This behavior can be disabled, read more [here](#Disable-synchronous-response).
+
+You can read more about sending messages [here](https://developers.facebook.com/docs/messenger-platform/send-messages).
 
 ### Overwrite default-output
 
@@ -224,13 +260,13 @@ The following example shows how to send a text-message:
 
 ```javascript
 // @language=javascript
-if (this.$messengerBot) this.$messengerBot.showText({ text: 'text' });
+if (this.$messengerBot) await this.$messengerBot.showText({ text: 'text' });
 
 // @language=typescript
-this.$messengerBot?.showText({ text: 'text' });
+await this.$messengerBot?.showText({ text: 'text' });
 ```
 
-> **INFO**: The text-message that was created by calling `tell` or `ask` will always be the first message to be displayed. Even if the `text`-method was called first.
+> **INFO**: The message that was created by calling `tell` or `ask` will **always** be the **last** message to be displayed. Even if the `showText`-method was called after. Read more about disabling that behavior [here](#Disable-synchronous-response).
 
 #### Text Message Options
 
@@ -239,16 +275,16 @@ When calling the `text`-method an object with the following properties can be pa
 | property     | type                                  | description                                                              |
 | ------------ | ------------------------------------- | ------------------------------------------------------------------------ |
 | text         | `string`                              | _Required_. The text that will be displayed                              |
-| quickReplies | <code>QuickReply &#124; string</code> | _Optional_. Quick-Replies that will be shown below the text.             |
+| quickReplies | <code>Array<QuickReply &#124; string></code> | _Optional_. Quick-Replies that will be shown below the text.             |
 | messageType  | `MessageType`                         | _Optional_. The type of the message. Defaults to `MessageType.Response`. |
 
 ### Sending Quick Replies
 
-Quick-replies can be sent by passing the `quickReplies` property to the options of the `text`- or `attachment`-method:
+Quick-replies can be sent by passing the `quickReplies` property to the options of the `showText`- or `showAttachment`-method:
 
 ```javascript
 // @language=javascript
-this.$messengerBot.showText({
+await this.$messengerBot.showText({
 	text: 'someText',
 	quickReplies: [
 		{ content_type: QuickReplyContentType.Text, title: 'someTitle' },
@@ -257,7 +293,7 @@ this.$messengerBot.showText({
 });
 
 // @language=typescript
-this.$messengerBot?.showText({
+await this.$messengerBot?.showText({
 	text: 'someText',
 	quickReplies: [
 		{ content_type: QuickReplyContentType.Text, title: 'someTitle' },
@@ -305,7 +341,7 @@ Facebook Messenger allows sending attachments, which includes audio, videos, ima
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showAttachment({
+	await this.$messengerBot.showAttachment({
 		type: AttachmentType.File,
 		data: {
 			fileName: 'displayFileName',
@@ -314,7 +350,7 @@ if (this.$messengerBot)
 	});
 
 // @language=typescript
-this.$messengerBot?.showAttachment({
+await this.$messengerBot?.showAttachment({
 	type: AttachmentType.File,
 	data: {
 		fileName: 'displayFileName',
@@ -331,7 +367,7 @@ Read more about sending attachments [here](https://developers.facebook.com/docs/
 | ------------ | ----------------------------------------------- | ------------------------------------------------------------------ |
 | type         | `AttachmentType`                                | _Required_. The type of the attachment.                            |
 | data         | <code>Buffer &#124; string &#124; number</code> | _Required_. The data to be sent with the attachment.               |
-| quickReplies | `QuickReply[]`                                  | _Optional_. Quick-Replies that will be shown below the attachment. |
+| quickReplies | <code>Array<QuickReply &#124; string></code>                                  | _Optional_. Quick-Replies that will be shown below the attachment. |
 | isReusable   | `boolean`                                       | _Optional_. Determines whether the resource is reusable.           |
 
 ### Sending an Action
@@ -349,10 +385,10 @@ The following actions are supported:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showAction(SenderActionType.TypingOn);
+	await this.$messengerBot.showAction(SenderActionType.TypingOn);
 
 // @language=typescript
-this.$messengerBot?.showAction(SenderActionType.TypingOn);
+await this.$messengerBot?.showAction(SenderActionType.TypingOn);
 ```
 
 Read more [here](https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions).
@@ -370,7 +406,7 @@ The following example shows how to send a generic template:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showGenericTemplate({
+	await this.$messengerBot.showGenericTemplate({
 		elements: [
 			{
 				title: 'someTitle'
@@ -379,7 +415,7 @@ if (this.$messengerBot)
 	});
 
 // @language=typescript
-this.$messengerBot?.showGenericTemplate({
+await this.$messengerBot?.showGenericTemplate({
 	elements: [
 		{
 			title: 'someTitle'
@@ -397,13 +433,13 @@ The following example shows how to send a button template:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showButtonTemplate({
+	await this.$messengerBot.showButtonTemplate({
 		text: 'someText',
 		buttons: [new PostbackButton('someTitle', 'somePayload')]
 	});
 
 // @language=typescript
-this.$messengerBot?.showButtonTemplate({
+await this.$messengerBot?.showButtonTemplate({
 	text: 'someText',
 	buttons: [new PostbackButton('someTitle', 'somePayload')]
 });
@@ -418,7 +454,7 @@ The following example shows how to send a media template:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showMediaTemplate({
+	await this.$messengerBot.showMediaTemplate({
 		elements: [
 			{
 				media_type: MediaType.Image,
@@ -429,7 +465,7 @@ if (this.$messengerBot)
 	});
 
 // @language=typescript
-this.$messengerBot.showMediaTemplate({
+await this.$messengerBot.showMediaTemplate({
 	elements: [
 		{
 			media_type: MediaType.Image,
@@ -449,7 +485,7 @@ The following example shows how to send a receipt template:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showReceiptTemplate({
+	await this.$messengerBot.showReceiptTemplate({
 		recipient_name: 'someName',
 		order_number: 'someId',
 		currency: 'EUR',
@@ -460,7 +496,7 @@ if (this.$messengerBot)
 	});
 
 // @language=typescript
-this.$messengerBot?.showReceiptTemplate({
+await this.$messengerBot?.showReceiptTemplate({
 	recipient_name: 'someName',
 	order_number: 'someId',
 	currency: 'EUR',
@@ -480,7 +516,7 @@ The following example shows how to send an airline template:
 ```javascript
 // @language=javascript
 if (this.$messengerBot)
-	this.$messengerBot.showAirlineTemplate({
+	await this.$messengerBot.showAirlineTemplate({
 		intro_message: 'someMessage',
 		locale: 'someLocale',
 		boarding_pass: [
@@ -509,7 +545,7 @@ if (this.$messengerBot)
 	});
 
 // @language=typescript
-this.$messengerBot?.showAirlineTemplate({
+await this.$messengerBot?.showAirlineTemplate({
 	intro_message: 'someMessage',
 	locale: 'someLocale',
 	boarding_pass: [

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -273,22 +273,18 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
     const messengerBot = handleRequest.jovo;
     await this.middleware('$response')!.run(messengerBot);
 
-    const messages: Message[] = _get(messengerBot, '$response.messages', []);
-    const pageAccessToken = _get(
-      handleRequest.jovo.$config,
-      'plugin.FacebookMessenger.pageAccessToken',
-      '',
-    );
-
-    for (const message of messages) {
-      message
-        .send(pageAccessToken, this.config.version!)
-        .then((res: AxiosResponse<any>) => {
-          Log.debug(res.data);
-        })
-        .catch((e: AxiosError) => {
-          Log.error(`Error while sending message:\n${e}`);
-        });
+    const message: Message | undefined = _get(messengerBot, '$response.message', undefined);
+    if (message) {
+      const pageAccessToken = _get(
+        handleRequest.jovo.$config,
+        'plugin.FacebookMessenger.pageAccessToken',
+        '',
+      );
+      try {
+        await message.send(pageAccessToken, this.config.version || DEFAULT_VERSION);
+      } catch (e) {
+        Log.error(e.response?.data);
+      }
     }
   }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -44,6 +44,7 @@ export interface GreetingElement {
 
 export interface Config extends ExtensibleConfig {
   shouldOverrideAppHandle?: boolean;
+  shouldIgnoreSynchronousResponse?: boolean;
   greeting?: UpdateConfig<GreetingElement[]>;
   launch?: UpdateConfig<string>;
   pageAccessToken?: string;
@@ -60,6 +61,7 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
 
   config: Config = {
     shouldOverrideAppHandle: true,
+    shouldIgnoreSynchronousResponse: false,
     greeting: {
       updateOnSetup: false,
     },
@@ -274,7 +276,7 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
     await this.middleware('$response')!.run(messengerBot);
 
     const message: Message | undefined = _get(messengerBot, '$response.message', undefined);
-    if (message) {
+    if (message && this.config.shouldIgnoreSynchronousResponse !== true) {
       const pageAccessToken = _get(
         handleRequest.jovo.$config,
         'plugin.FacebookMessenger.pageAccessToken',

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/Interfaces.ts
@@ -1,6 +1,6 @@
 import { QuickReplyContentType } from './Enums';
 
-export type ApiVersion = 'v5.0' | 'v6.0';
+export type ApiVersion = 'v5.0' | 'v6.0' | 'v7.0' | 'v8.0' | string;
 
 export interface MessengerBotEntry {
   id: string;
@@ -51,4 +51,9 @@ export interface UserProfile {
   profile_pic?: string;
   locale?: string;
   id: string;
+}
+
+export interface SendMessageResponse {
+  recipient_id: string;
+  message_id: string;
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
@@ -1,4 +1,12 @@
-import { AudioData, BaseApp, HandleRequest, Host, Jovo, SpeechBuilder } from 'jovo-core';
+import {
+  AudioData,
+  AxiosResponse,
+  BaseApp,
+  HandleRequest,
+  Host,
+  Jovo,
+  SpeechBuilder,
+} from 'jovo-core';
 import _get = require('lodash.get');
 import _set = require('lodash.set');
 import {
@@ -23,10 +31,10 @@ import {
   ReceiptTemplatePayload,
   SenderAction,
   SenderActionType,
+  SendMessageResponse,
   TemplateType,
   TextMessage,
   TextMessageOptions,
-  TextQuickReply,
 } from '..';
 import { MessengerBotSpeechBuilder } from './MessengerBotSpeechBuilder';
 import { MessengerBotUser } from './MessengerBotUser';
@@ -40,7 +48,6 @@ export class MessengerBot extends Jovo {
     this.$speech = new MessengerBotSpeechBuilder(this);
     this.$reprompt = new MessengerBotSpeechBuilder(this);
     this.$user = new MessengerBotUser(this);
-    _set(this.$output, 'FacebookMessenger.Messages', []);
   }
 
   getDeviceId(): string | undefined {
@@ -127,74 +134,83 @@ export class MessengerBot extends Jovo {
     return this;
   }
 
-  showText(options: TextMessageOptions): MessengerBot {
+  async showText(options: TextMessageOptions): Promise<AxiosResponse<SendMessageResponse>> {
     const message = new TextMessage({ id: this.$user.getId()! }, { ...options });
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showAttachment(options: AttachmentMessageOptions): MessengerBot {
+  async showAttachment(
+    options: AttachmentMessageOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const message = new AttachmentMessage({ id: this.$user.getId()! }, options);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showAirlineTemplate(options: AirlineTemplateOptions): MessengerBot {
+  async showAirlineTemplate(
+    options: AirlineTemplateOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const payload: AirlineTemplatePayload = {
       ...options,
       template_type: TemplateType.Airline,
     };
     const message = new AirlineTemplate({ id: this.$user.getId()! }, payload);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showButtonTemplate(options: ButtonTemplateOptions): MessengerBot {
+  async showButtonTemplate(
+    options: ButtonTemplateOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const payload: ButtonTemplatePayload = {
       ...options,
       template_type: TemplateType.Button,
     };
     const message = new ButtonTemplate({ id: this.$user.getId()! }, payload);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showGenericTemplate(options: GenericTemplateOptions): MessengerBot {
+  async showGenericTemplate(
+    options: GenericTemplateOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const payload: GenericTemplatePayload = {
       ...options,
       template_type: TemplateType.Generic,
     };
     const message = new GenericTemplate({ id: this.$user.getId()! }, payload);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showMediaTemplate(options: MediaTemplateOptions): MessengerBot {
+  async showMediaTemplate(
+    options: MediaTemplateOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const payload: MediaTemplatePayload = {
       ...options,
       template_type: TemplateType.Media,
     };
     const message = new MediaTemplate({ id: this.$user.getId()! }, payload);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  showReceiptTemplate(options: ReceiptTemplateOptions): MessengerBot {
+  async showReceiptTemplate(
+    options: ReceiptTemplateOptions,
+  ): Promise<AxiosResponse<SendMessageResponse>> {
     const payload: ReceiptTemplatePayload = {
       ...options,
       template_type: TemplateType.Receipt,
     };
     const message = new ReceiptTemplate({ id: this.$user.getId()! }, payload);
-    this.$output.FacebookMessenger.Messages.push(message);
-    return this;
+    return message.send(this.pageAccessToken, this.version);
   }
 
-  async showAction(action: SenderActionType): Promise<boolean> {
+  async showAction(action: SenderActionType): Promise<AxiosResponse<SendMessageResponse>> {
     const message = new SenderAction({ id: this.$user.getId()! }, action);
+    return message.send(this.pageAccessToken, this.version);
+  }
 
-    const pageAccessToken = _get(this.$config, 'plugin.FacebookMessenger.pageAccessToken', '');
-    const version = _get(this.$config, 'plugin.FacebookMessenger.version', DEFAULT_VERSION);
-    const result = await message.send(pageAccessToken, version);
-    return !!result;
+  get version(): string {
+    return _get(this.$config, 'plugin.FacebookMessenger.version', DEFAULT_VERSION);
+  }
+
+  get pageAccessToken(): string {
+    return _get(this.$config, 'plugin.FacebookMessenger.pageAccessToken', '');
   }
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
@@ -6,7 +6,7 @@ import { Message } from './responses/Message';
 export { FacebookMessenger, Config } from './FacebookMessenger';
 
 export const BASE_URL = 'https://graph.facebook.com';
-export const DEFAULT_VERSION: ApiVersion = 'v6.0';
+export const DEFAULT_VERSION: ApiVersion = 'v8.0';
 
 declare module 'jovo-core/dist/src/core/Jovo' {
   export interface Jovo {
@@ -25,7 +25,7 @@ interface AppFacebookMessengerConfig {
 declare module 'jovo-core/dist/src/Interfaces' {
   export interface Output {
     FacebookMessenger: {
-      Messages: Message[];
+      Message?: Message;
       Overwrite?: {
         Text?: string;
         QuickReplies?: QuickReply[];
@@ -34,6 +34,7 @@ declare module 'jovo-core/dist/src/Interfaces' {
   }
 
   export interface AppPlatformConfig extends AppFacebookMessengerConfig {}
+
   export interface ExtensiblePluginConfigs extends AppFacebookMessengerConfig {}
 }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
@@ -6,7 +6,7 @@ import {
   MessengerBotRequest,
   MessengerBotResponse,
   MessengerBotUser,
-  TextMessage,
+  TextMessage
 } from '..';
 
 export class FacebookMessengerCore implements Plugin {
@@ -86,26 +86,19 @@ export class FacebookMessengerCore implements Plugin {
     const tell = _get(output, 'tell');
     if (tell) {
       const text = setText || tell.speech.toString();
-      const textMessage = new TextMessage(
+      response.message = new TextMessage(
         { id: messengerBot.$user.getId()! },
         { text, quickReplies: overWriteQuickReplies },
       );
-      response.messages.push(textMessage);
     }
 
     const ask = _get(output, 'ask');
     if (ask) {
       const text = setText || ask.speech.toString();
-      const textMessage = new TextMessage(
+      response.message = new TextMessage(
         { id: messengerBot.$user.getId()! },
         { text, quickReplies: overWriteQuickReplies },
       );
-      response.messages.push(textMessage);
-    }
-
-    const messages = _get(output, 'FacebookMessenger.Messages');
-    if (messages && messages.length > 0) {
-      response.messages.push(...messages);
     }
   }
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/responses/Message.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/responses/Message.ts
@@ -1,10 +1,10 @@
-import { AxiosRequestConfig, HttpService } from 'jovo-core';
-import { ApiVersion, BASE_URL, IdentityData } from '..';
+import { AxiosRequestConfig, AxiosResponse, HttpService } from 'jovo-core';
+import { ApiVersion, BASE_URL, IdentityData, SendMessageResponse } from '..';
 
 export abstract class Message {
   protected constructor(readonly recipient: IdentityData) {}
 
-  send(pageAccessToken: string, version: ApiVersion): Promise<any> {
+  send(pageAccessToken: string, version: ApiVersion): Promise<AxiosResponse<SendMessageResponse>> {
     return HttpService.request(this.getConfig(pageAccessToken, version));
   }
 
@@ -21,9 +21,6 @@ export abstract class Message {
         'Content-Type': 'application/json',
       },
       data: this,
-      validateStatus: (status: number) => {
-        return true;
-      },
     };
   }
 }


### PR DESCRIPTION
## Proposed changes
Facebook Messenger allows sending multiple messages, therefore it makes sense to change the way the platform works to immediately send the request. 

⚠️ Breaking Changes:
- The signatures of the `show`-methods except for the quick-reply-related methods have changed to return a `Promise<AxiosResponse<SendMessageResponse>` instead of `MessengerBot`
- The message that is the result of calling `tell` or `ask` will now **always** be the **last** message to be sent.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed