### PR TITLE
🐛 Fix saving of user-session-id

### DIFF
--- a/jovo-framework/src/middleware/user/JovoUser.ts
+++ b/jovo-framework/src/middleware/user/JovoUser.ts
@@ -367,7 +367,7 @@ export class JovoUser implements Plugin {
       }
       handleRequest.jovo.$user.$session = sessionData;
       if (this.config.sessionData && this.config.sessionData.data) {
-        handleRequest.jovo.$session.$data = { ...handleRequest.jovo.$user.$session?.$data };
+        handleRequest.jovo.$session.$data = { ...(handleRequest.jovo.$user.$session?.$data || {}) };
       }
     }
 
@@ -439,8 +439,9 @@ export class JovoUser implements Plugin {
         userData.session.$data = handleRequest.jovo.$user.$session.$data;
       }
 
-      if (this.config.sessionData.id) {
-        userData.session.id = handleRequest.jovo.$user.$session.id;
+      const sessionId = handleRequest.jovo.$request?.getSessionId();
+      if (this.config.sessionData.id && sessionId) {
+        userData.session.id = sessionId;
       }
 
       if (handleRequest.jovo.$output.tell) {

--- a/jovo-platforms/jovo-platform-googlebusiness/src/GoogleBusiness.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/GoogleBusiness.ts
@@ -117,7 +117,6 @@ export class GoogleBusiness extends Platform<GoogleBusinessRequest, GoogleBusine
 
     await this.middleware('$request')!.run(handleRequest.jovo);
     await this.middleware('$type')!.run(handleRequest.jovo);
-    await this.middleware('$session')!.run(handleRequest.jovo);
 
     if (this.config.handlers) {
       handleRequest.app.config.handlers = _merge(
@@ -140,11 +139,6 @@ export class GoogleBusiness extends Platform<GoogleBusinessRequest, GoogleBusine
     if (handleRequest.jovo?.constructor.name !== GoogleBusiness.appType) {
       return Promise.resolve();
     }
-    if (!handleRequest.jovo!.$session) {
-      handleRequest.jovo!.$session = { $data: {} };
-    }
-
-    handleRequest.jovo!.$session.$data = { ...handleRequest.jovo!.$user.$session.$data };
 
     // check for duplicated messages and ignore the request if a message with the id was handled already
     const request = handleRequest.jovo.$request as GoogleBusinessRequest;
@@ -164,6 +158,7 @@ export class GoogleBusiness extends Platform<GoogleBusinessRequest, GoogleBusine
       handleRequest.jovo.$session.$data.processedMessages = processedMessages;
       await handleRequest.jovo.$user.saveData();
     }
+    await this.middleware('$session')!.run(handleRequest.jovo);
   }
 
   async tts(handleRequest: HandleRequest) {

--- a/jovo-platforms/jovo-platform-lindenbaum/src/Lindenbaum.ts
+++ b/jovo-platforms/jovo-platform-lindenbaum/src/Lindenbaum.ts
@@ -66,7 +66,6 @@ export class Lindenbaum extends Platform<LindenbaumRequest, LindenbaumResponse> 
     app.middleware('setup')!.use(this.setup.bind(this));
     app.middleware('platform.init')!.use(this.initialize.bind(this));
     app.middleware('platform.nlu')!.use(this.nlu.bind(this));
-    app.middleware('after.user.load')!.use(this.session.bind(this));
     app.middleware('tts')!.use(this.tts.bind(this));
     app.middleware('platform.output')!.use(this.output.bind(this));
     app.middleware('response')!.use(this.response.bind(this));
@@ -115,14 +114,6 @@ export class Lindenbaum extends Platform<LindenbaumRequest, LindenbaumResponse> 
       await this.middleware('$nlu')!.run(handleRequest.jovo);
       await this.middleware('$inputs')!.run(handleRequest.jovo);
     }
-  }
-
-  async session(handleRequest: HandleRequest) {
-    if (!handleRequest.jovo!.$session) {
-      handleRequest.jovo!.$session = { $data: {} };
-    }
-    // @ts-ignore for some reason $session doesn't exist on $user. Works on all the other packages.
-    handleRequest.jovo!.$session.$data = { ...handleRequest.jovo!.$user.$session.$data };
   }
 
   async tts(handleRequest: HandleRequest) {

--- a/jovo-platforms/jovo-platform-twilioautopilot/src/Autopilot.ts
+++ b/jovo-platforms/jovo-platform-twilioautopilot/src/Autopilot.ts
@@ -59,7 +59,6 @@ export class Autopilot extends Platform<AutopilotRequest, AutopilotResponse> {
     app.middleware('platform.init')!.use(this.initialize.bind(this));
     app.middleware('platform.nlu')!.use(this.nlu.bind(this));
     app.middleware('tts')!.use(this.tts.bind(this));
-    app.middleware('before.user.save')!.use(this.saveSessionId.bind(this));
     app.middleware('platform.output')!.use(this.output.bind(this));
     app.middleware('response')!.use(this.response.bind(this));
 
@@ -116,17 +115,6 @@ export class Autopilot extends Platform<AutopilotRequest, AutopilotResponse> {
       return Promise.resolve();
     }
     await this.middleware('$tts')!.run(handleRequest.jovo);
-  }
-
-  async saveSessionId(handleRequest: HandleRequest) {
-    if (handleRequest.jovo?.constructor.name !== 'AutopilotBot') {
-      return Promise.resolve();
-    }
-
-    // is undefined if no active DB
-    if (handleRequest.jovo.$user.$session) {
-      handleRequest.jovo.$user.$session.id = handleRequest.jovo.$request!.getSessionId();
-    }
   }
 
   async output(handleRequest: HandleRequest) {


### PR DESCRIPTION
## Proposed changes
The user-session-id gets only saved when it is defined.
Removed redundant loading of the session data from the user-session-data of `GoogleBusiness`, `Lindenbaum` and `Autopilot`.
The session-data will automatically be loaded by `JovoUser`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed