### PR TITLE
🐛 Fix potential bug for Firestore

### DIFF
--- a/jovo-integrations/jovo-db-firestore/src/Firestore.ts
+++ b/jovo-integrations/jovo-db-firestore/src/Firestore.ts
@@ -160,7 +160,8 @@ export class Firestore implements Db {
     const docRef: firebase.firestore.DocumentReference = this.firestore!.collection(
       this.config.collectionName,
     ).doc(primaryKey);
-    await docRef.set(userData, { merge: true });
+    // remove custom prototypes
+    await docRef.set(JSON.parse(JSON.stringify(userData)), { merge: true });
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
Firestore does not allow saving custom objects that were initialized with `new`. 
Therefore, when saving, instances have to be replaced by objects. This is done by using `JSON.parse` and `JSON.stringify`.

Related issue: #776 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed