### PR TITLE
✨ Implement configurable user-session-data-key

### DIFF
--- a/docs/basic-concepts/data/user.md
+++ b/docs/basic-concepts/data/user.md
@@ -501,7 +501,68 @@ If the feature is enabled, the database entry will have the following structure:
     "userData": {
         "session": {
             "lastUpdatedAt": "ISO 8601 string",
-            "data": {
+            "$data": {
+                ...
+            },
+            "id": "session ID"
+        }
+    }
+}
+```
+
+It is also possible to provide `dataKey` which changes the key under which the data gets saved:
+
+> This is helpful, because some database-integrations like MongoDB do not allow special characters like `$` as field names.
+
+```js
+// @language=javascript
+
+// src/config.js
+
+module.exports = {
+    
+    user: {
+        sessionData: {
+            enabled: true,
+            data: true,
+            dataKey: 'customData',
+            id: true
+        },
+    },
+
+    // ...
+
+};
+
+// @language=typescript
+
+// src/config.ts
+
+const config = {
+    
+    user: {
+        sessionData: {
+            enabled: true,
+            data: true,
+            dataKey: 'customData',
+            id: true
+        },
+    },
+
+    // ...
+
+};
+```
+
+This will cause the database-entry to have the following structure:
+
+```js
+{
+    "userId": "...",
+    "userData": {
+        "session": {
+            "lastUpdatedAt": "ISO 8601 string",
+            "customData": {
                 ...
             },
             "id": "session ID"

--- a/jovo-framework/src/middleware/user/JovoUser.ts
+++ b/jovo-framework/src/middleware/user/JovoUser.ts
@@ -42,6 +42,7 @@ export interface MetaDataConfig {
 export interface SessionDataConfig {
   enabled?: boolean;
   data?: boolean;
+  dataKey?: string;
   id?: boolean;
   expireAfterSeconds?: number;
 }
@@ -104,6 +105,7 @@ export interface UserMetaData {
 }
 
 export interface UserSessionData {
+  [key: string]: any;
   $data?: SessionData;
   id?: string;
   lastUpdatedAt?: string;
@@ -350,6 +352,11 @@ export class JovoUser implements Plugin {
         {},
       );
 
+      if(this.config.sessionData.dataKey) {
+        serializedSessionData.$data = serializedSessionData[this.config.sessionData.dataKey];
+        delete serializedSessionData[this.config.sessionData.dataKey];
+      }
+
       const expireAfter = (this.config.sessionData.expireAfterSeconds || 300) * 1000;
 
       let sessionData: UserSessionData = {
@@ -434,9 +441,11 @@ export class JovoUser implements Plugin {
 
     if (this.config.sessionData && this.config.sessionData.enabled) {
       userData.session = {};
+
       if (this.config.sessionData.data) {
         this.updateSessionData(handleRequest);
-        userData.session.$data = handleRequest.jovo.$user.$session.$data;
+        const dataKey = this.config.sessionData.dataKey || '$data';
+        userData.session[dataKey] = handleRequest.jovo.$user.$session.$data;
       }
 
       const sessionId = handleRequest.jovo.$request?.getSessionId();


### PR DESCRIPTION

## Proposed changes
`dataKey` can be passed to the `SessionDataConfig` in order to change the key the data gets persisted for.\
This is helpful for MongoDB, because `$data` is not allowed as a key.

Related issue #833 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed