### PR TITLE
✨ Use postbackData of suggestions if possible

### DIFF
--- a/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessRequest.ts
+++ b/jovo-platforms/jovo-platform-googlebusiness/src/core/GoogleBusinessRequest.ts
@@ -89,7 +89,7 @@ export class GoogleBusinessRequest implements JovoRequest {
   }
 
   getRawText(): string {
-    return this.message?.text || this.suggestionResponse?.text || '';
+    return this.message?.text || this.suggestionResponse?.postbackData || this.suggestionResponse?.text || '';
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
Changed `getRawText` of `GoogleBusinessRequest` to return the `postbackData` of a `Suggestion` rather than the `text` and only the `text` if there is no `postbackData`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed