### PR TITLE
feat: add Google Optimize support

### DIFF
--- a/jovo-integrations/jovo-analytics-googleanalytics/README.md
+++ b/jovo-integrations/jovo-analytics-googleanalytics/README.md
@@ -17,12 +17,15 @@ Learn how to use Google Analytics in your Jovo application.
       - [Custom Dimensions](#custom-dimensions)
       - [Custom Metrics](#custom-metrics)
     - [Custom Reports](#custom-reports)
+    - [Optimize Experiments](#optimize-experiments)
     - [Developer Methods](#developer-methods)
       - [sendEvent()](#sendevent)
       - [sendTransaction()](#sendtransaction)
       - [sendItem()](#senditem)
       - [sendUserEvent()](#senduserevent)
       - [setCustomMetric()](#setcustommetric)
+      - [setParameter()](#setparameter)
+      - [setOptimizeExperiment()](#setoptimizeexperiment)
       - [Setup endReason metrics in the gooogle analytics console](#setup-endreason-metrics-in-the-gooogle-analytics-console)
 
 ## About Google Analytics
@@ -223,9 +226,14 @@ Keep in mind, that both custom dimensions and custom metrics are managed on inde
 
 You can enable tracking custom metrics for endReasons by setting trackEndReasons to true. More info upon the setup process is described [here](#setup-endreason-metrics-in-the-gooogle-analytics-console).
 
+
 ### Custom Reports
 
 Not every dimension/metric has a report out of the box. For example, [Exceptions]() need a custom report, before being displayed in Google Analytics. The same goes for custom dimensions/metrics. To create a custom report, go to "Customization" > "Custom Reports". There, you can add a new custom reports with your own attributes, such as the title, the dimensions/metrics you want to track and the report type.
+
+### Optimize Experiments
+
+You can setup A/B testing using Google Optimize and Google Analytics. A detailed guide on creating a server-side experiment can be found [here](https://developers.google.com/optimize/devguides/experiments). 
 
 ### Developer Methods
 
@@ -238,6 +246,8 @@ The Google Analytics plugin offers developer methods for sending data (like Even
 * sendUserTransaction (transactionId)
 * setCustomMetric (index, value)
 * setCustomDimension (index, value)
+* setParameter (parameter, value)
+* setOptimizeExperiment (experimentId, variation)
 
 All these methods are available on the Jovo object in your code and accessible by calling `this.$googleAnalytics.sendEvent(eventParameters)` in your code's handler, for example.
 
@@ -414,6 +424,54 @@ LAUNCH() {
 LAUNCH() {
     this.$googleAnalytics.setCustomMetric(1, 100);
 }
+``` 
+
+
+#### setParameter
+
+If you want to set a specific parameter in the page view events, like overriding your user's geographical location, you can set it with the `setParameter` method. You can find details on all available parameters [here](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters)
+
+```javascript
+// @language=javascript
+
+// app.js
+
+app.hook("before.response", (error, host, jovo) => {
+  jovo.$googleAnalytics.setParameter("geoid", "1017527");
+});
+
+// @language=typescript
+
+// app.js
+
+app.hook("before.response", (error: Error, host: Host, jovo: Jovo) => {
+  jovo.$googleAnalytics.setParameter("geoid", "1017527");
+});
+``` 
+
+
+#### setOptimizeExperiment
+
+`setOptimizeExperiment()` allows you to run A/B testing using Google Optimize. First setup a server-side experiment in Optimize, randomly assign your users to a group, then use `setOptimizeExperiment()` to provide the data. More details on setting up your experiment can be found [here](https://developers.google.com/optimize/devguides/experiments)
+
+```javascript
+// @language=javascript
+
+// app.js
+
+app.hook("before.response", (error, host, jovo) => {
+  const variationId = jovo.$user.$data.variationId;
+  jovo.$googleAnalytics.setOptimizeExperiment("16iQisXuS1qwXDixwB-EWgQ", variationId);
+});
+
+// @language=typescript
+
+// app.js
+
+app.hook("before.response", (error: Error, host: Host, jovo: Jovo) => {
+  const variationId = jovo.$user.$data.variationId;
+  jovo.$googleAnalytics.setOptimizeExperiment("16iQisXuS1qwXDixwB-EWgQ", variationId);
+});
 ``` 
 
 #### Setup endReason metrics in the gooogle analytics console

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -387,7 +387,7 @@ export class GoogleAnalytics implements Analytics {
       },
       /**
        * Set a custom Google Analytics parameter
-       * 
+       *
        * @ref https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
        */
       setParameter(parameter: string, value: string | number): void {
@@ -395,12 +395,12 @@ export class GoogleAnalytics implements Analytics {
       },
       /**
        * Set Google Optimize experiment parameters
-       * 
+       *
        * @ref https://developers.google.com/optimize/devguides/experiments
        */
       setOptimizeExperiment(experimentId: string, variation: string | number): void {
         this.$parameters[`exp`] = `${experimentId}.${variation}`;
-      }
+      },
     };
   }
 }

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -385,19 +385,9 @@ export class GoogleAnalytics implements Analytics {
       setCustomDimension(index: number, value: string | number): void {
         this.$data[`cd${index}`] = value;
       },
-      /**
-       * Set a custom Google Analytics parameter
-       *
-       * @ref https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
-       */
       setParameter(parameter: string, value: string | number): void {
         this.$parameters[parameter] = value;
       },
-      /**
-       * Set Google Optimize experiment parameters
-       *
-       * @ref https://developers.google.com/optimize/devguides/experiments
-       */
       setOptimizeExperiment(experimentId: string, variation: string | number): void {
         this.$parameters[`exp`] = `${experimentId}.${variation}`;
       },

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -249,7 +249,10 @@ export class GoogleAnalytics implements Analytics {
   getPageParameters(jovo: Jovo) {
     const intentType = jovo.$type.type ?? 'fallBackType';
     const intentName = jovo.$request?.getIntentName();
+    const customParameters = jovo.$googleAnalytics.$parameters;
+
     return {
+      ...customParameters,
       documentPath: this.getPageName(jovo),
       documentHostName: jovo.$data.startState ? jovo.$data.startState : '/',
       documentTitle: intentName || intentType,
@@ -339,6 +342,7 @@ export class GoogleAnalytics implements Analytics {
     // Initialise googleAnalytics object.
     jovo.$googleAnalytics = {
       $data: {},
+      $parameters: {},
       sendEvent: (params: Event) => {
         this.visitor!.event(params, (err: any) => {
           if (err) {
@@ -381,6 +385,22 @@ export class GoogleAnalytics implements Analytics {
       setCustomDimension(index: number, value: string | number): void {
         this.$data[`cd${index}`] = value;
       },
+      /**
+       * Set a custom Google Analytics parameter
+       * 
+       * @ref https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+       */
+      setParameter(parameter: string, value: string | number): void {
+        this.$parameters[parameter] = value;
+      },
+      /**
+       * Set Google Optimize experiment parameters
+       * 
+       * @ref https://developers.google.com/optimize/devguides/experiments
+       */
+      setOptimizeExperiment(experimentId: string, variation: string | number): void {
+        this.$parameters[`exp`] = `${experimentId}.${variation}`;
+      }
     };
   }
 }

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/index.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/index.ts
@@ -18,12 +18,25 @@ declare module 'jovo-core/dist/src/core/Jovo' {
   interface Jovo {
     $googleAnalytics: {
       $data: { [key: string]: string | number };
+      $parameters: { [key: string]: string | number };
       sendEvent: (params: Event) => void;
       sendTransaction: (params: Transaction) => void;
       sendItem: (params: TransactionItem) => void;
       sendUserEvent: Function;
       setCustomMetric: (index: number, value: string | number) => void;
       setCustomDimension: (index: number, value: string | number) => void;
+      /**
+       * Set a custom Google Analytics parameter
+       *
+       * @ref https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+       */
+      setParameter: (parameter: string, value: string | number) => void;
+      /**
+       * Set Google Optimize experiment parameters
+       *
+       * @ref https://developers.google.com/optimize/devguides/experiments
+       */
+      setOptimizeExperiment: (experimentId: string, variation: string | number) => void;
     };
 
     getRoute(): { intent: string; path: string; type: string };


### PR DESCRIPTION
## Proposed changes
Allows developers to provide specific Google Analytics parameters, and easily provide details for Google Optimize experiments. This is accomplished by adding the `$parameters` object to google analytics which is used when constructing the pageview parameters.


## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed