### PR TITLE
Alexa Event Tracking on Google Analytics wrong pagename fix

### DIFF
--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -40,7 +40,11 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     if(!eventName) {
       return;
     } 
-    jovo.$googleAnalytics.sendUserEvent('AlexaSkillEvent', eventName);
+    jovo.$googleAnalytics.sendEvent({
+      'eventCategory': 'AlexaSkillEvent',
+      'eventAction': eventName,
+      'eventLabel': this.getUserId(jovo)
+    })
   }
 
   protected setGoogleAnalyticsObject(handleRequest: HandleRequest) {


### PR DESCRIPTION
## Proposed changes
The used method $googleAnalytics.sendUserEvent sets the page parameter to the jovo route. For SkillEvent this is not a valid parameter. Used the event method instead.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed