### PR TITLE
Fix TLS Errors on Lambda

### DIFF
--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -147,7 +147,7 @@ export class GoogleAnalytics implements Analytics {
    * Auto send intent data after each response. Also setting sessions and flowErrors
    * @param handleRequest
    */
-  track(handleRequest: HandleRequest) {
+  async track(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;
     if (!jovo) {
       throw new JovoError(
@@ -183,11 +183,14 @@ export class GoogleAnalytics implements Analytics {
       this.sendUnhandledEvents(jovo);
       this.sendIntentInputEvents(jovo);
     }
-    jovo.$googleAnalytics.visitor?.send((err: any) => {
-      if (err) {
-        throw new JovoError(err.message, ErrorCode.ERR_PLUGIN, 'jovo-analytics-googleanalytics');
-      }
-    });
+
+
+    return new Promise((resolve, reject) => {
+      jovo.$googleAnalytics.visitor?.send((error, response: any) => {
+        if(error) { reject(error); }
+        else { resolve(response); }
+      })
+    })
   }
 
   protected checkForMissingCustomEntriesInConfig(

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -120,7 +120,7 @@ export class GoogleAnalytics implements Analytics {
 
     app.middleware('before.handler')!.use(GoogleAnalytics.saveStartStateAndLastUsed.bind(this));
     app.middleware('after.platform.init')!.use(this.setGoogleAnalyticsObject.bind(this));
-    app.middleware('after.response')!.use(this.track.bind(this));
+    app.middleware('before.response')!.use(this.track.bind(this));
     app.middleware('fail')!.use(this.sendError.bind(this));
   }
 

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -99,7 +99,7 @@ export class GoogleAnalytics implements Analytics {
   install(app: BaseApp) {
     if (!this.config.trackingId) {
       throw new JovoError(
-        'trackingId has to be set.',
+        `trackingId has to be set for ${this.constructor.name}.`,
         ErrorCode.ERR_PLUGIN,
         'jovo-analytics-googleanalytics',
         '',

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -9,7 +9,7 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     super.install(app);
   }
 
-  track(handleRequest: HandleRequest) {
+  async track(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;
     if (!jovo) {
       throw new JovoError(
@@ -30,7 +30,7 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
       return;
     }
 
-    super.track(handleRequest);
+    await super.track(handleRequest);
   }
 
   protected handleAlexaSkillEvents(jovo: Jovo) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
@@ -61,7 +61,7 @@ export class GoogleAnalyticsGoogleAssistant extends GoogleAnalytics {
     return !requestContainsSubRequest;
   }
 
-  track(handleRequest: HandleRequest) {
+  async track(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;
     if (!jovo) {
       throw new JovoError(
@@ -85,7 +85,7 @@ export class GoogleAnalyticsGoogleAssistant extends GoogleAnalytics {
         return;
       }
     }
-    super.track(handleRequest);
+    await super.track(handleRequest);
   }
 
   initVisitor(jovo: Jovo) {


### PR DESCRIPTION
## Proposed changes
Send data before response + promisify.
Lambda environments skip async sending executions. In the next request the lambda tries to send them again. This can lead to runtime errors or missing data on the dashboard (depending on your lambda settings).

+ improve hint if config is missing 

fixes #837 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed