### PR TITLE
✨ added sessionId to ContextPrevObject

### DIFF
--- a/docs/basic-concepts/data/user.md
+++ b/docs/basic-concepts/data/user.md
@@ -52,6 +52,7 @@ user: {
             request: {
                 intent: true,
                 state: true,
+                sessionId: true,
                 inputs: true,
                 timestamp: true,
             },
@@ -285,6 +286,7 @@ Category | Data | Usage |  | Description
 :--- | :--- | :--- | :--- | :----
 Request | intent | `this.$user.$context.prev[i].request.intent` | `this.$user.getPrevIntent(i)` | String: Intent name
 &nbsp; | state | `this.$user.$context.prev[i].request.state` | `this.$user.getPrevRequestState(i)` | String: State name
+&nbsp; | sessionId | `this.$user.$context.prev[i].request.sessionId` | &nbsp; | String: Session Id
 &nbsp; | timestamp | `this.$user.$context.prev[i].request.timestamp` | `this.$user.getPrevTimestamp(i)` | String: Timestamp of request
 &nbsp; | inputs | `this.$user.$context.prev[i].request.inputs` | `this.$user.getPrevInputs(i)` | Object: Contains all the slots (filled & unfilled). Example: You got a slot called `city`. Access the value with `this.$user.getPrevInputs(i).city.value`.
 Response | speech | `this.$user.$context.prev[i].response.speech` |  `this.$user.getPrevSpeech(i)` | String: Primary speech element
@@ -308,6 +310,7 @@ module.exports = {
                 request: {
                     intent: true,
                     state: true,
+                    sessionId: true,
                     inputs: true,
                     timestamp: true,
                 },

--- a/jovo-framework/src/middleware/user/JovoUser.ts
+++ b/jovo-framework/src/middleware/user/JovoUser.ts
@@ -54,6 +54,7 @@ export interface ContextConfig {
     request?: {
       intent?: boolean;
       state?: boolean;
+      sessionId?: boolean;
       inputs?: boolean;
       timestamp?: boolean;
     };
@@ -74,6 +75,7 @@ export interface ContextPrevObject {
   request?: {
     timestamp?: string;
     state?: string;
+    sessionId?: string;
     intent?: string;
     inputs?: Inputs;
   };
@@ -121,6 +123,7 @@ export class JovoUser implements Plugin {
         request: {
           inputs: true,
           intent: true,
+          sessionId: true,
           state: true,
           timestamp: true,
         },
@@ -669,6 +672,9 @@ export class JovoUser implements Plugin {
     if (this.config.context!.prev!.request!.state) {
       this.updatePrevRequestState(handleRequest, prevObject);
     }
+    if (this.config.context!.prev!.request!.sessionId) {
+      this.updatePrevRequestSessionId(handleRequest, prevObject);
+    }
     if (this.config.context!.prev!.request!.inputs) {
       this.updatePrevInputs(handleRequest, prevObject);
     }
@@ -747,6 +753,14 @@ export class JovoUser implements Plugin {
         SessionConstants.STATE
       ];
     }
+  }
+
+  /**
+   * @param {HandleRequest} handleRequest
+   * @param {ContextPrevObject} prevObject
+   */
+  private updatePrevRequestSessionId(handleRequest: HandleRequest, prevObject: ContextPrevObject) {
+    prevObject.request!.sessionId = handleRequest.jovo!.$request!.getSessionId();
   }
 
   /**

--- a/jovo-framework/test/middleware/user/JovoUser.test.ts
+++ b/jovo-framework/test/middleware/user/JovoUser.test.ts
@@ -567,6 +567,7 @@ describe('test updateContextData', () => {
         request: {
           inputs: false,
           intent: false,
+          sessionId: false,
           state: false,
           timestamp: false,
         },
@@ -756,6 +757,27 @@ describe('test updateContextData', () => {
     jovoUser['updateContextData'](mockHandleRequest); // tslint:disable-line:no-string-literal
 
     expect(mockHandleRequest.jovo!.$user.$context.prev![0].request!.timestamp).toBeUndefined();
+  });
+
+  test('should set request.sessionId', () => {
+    jovoUser.config.context!.prev!.request!.sessionId = true;
+    mockHandleRequest.jovo!.$request!.getSessionId = jest.fn().mockReturnValue('test');
+
+    jovoUser['updateContextData'](mockHandleRequest); // tslint:disable-line:no-string-literal
+
+    expect(mockHandleRequest.jovo!.$user.$context.prev![0].request!.sessionId).toBe('test');
+  });
+
+  test(`shouldn't set request.sessionId`, () => {
+    // enable and mock request.inputs, so the request object is created and saved to the prev array
+    // otherwise we would have an error when trying to access prev[0].request inside expect()
+    jovoUser.config.context!.prev!.request!.inputs = true;
+    mockHandleRequest.jovo!.$inputs = {};
+    jovoUser.config.context!.prev!.request!.sessionId = false;
+
+    jovoUser['updateContextData'](mockHandleRequest); // tslint:disable-line:no-string-literal
+
+    expect(mockHandleRequest.jovo!.$user.$context.prev![0].request!.sessionId).toBeUndefined();
   });
 
   test('should set request.state', () => {


### PR DESCRIPTION
## Proposed changes
This PR adds the sessionId of the request to the ContextPrevObject. A lot of times, the only past interactions of interest are the ones of the same session or a specific session. This adds this session context to the prev array. It also makes it easier to skip for the session irrelevant interactions. One Example would be Alexa Skill Events that happen in the middle of the session and therefore are added to the prev array in middle of all the session requests with no easy way to see, that this interaction was not part of the session. 

I guess this would require an update to the documentation for the user data (https://www.jovo.tech/docs/data/user). I could also add the documentation, if this feature is to be added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed