### PR TITLE
:sparkles: Implement passing of OutputTemplate-properties directly to `$send` via the options

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -149,13 +149,43 @@ build() {
 
 ### Output Options
 
-As a convention, an output template should only be responsible for organizing the output, not collecting any data. To achieve this, the handler should first collect all necessary information and the pass it to the output class as `options`:
+As a convention, an output template should only be responsible for organizing the output, not collecting any data. To achieve this, the handler should first collect all necessary information and then pass it to the output class as `options`:
 
 ```typescript
 return this.$send(YourOutput, { /* options */ });
 ```
 
-These options can then be referenced inside the output class using `this.options`.
+There are two types of properties that can be passed:
+* Reserved properties: You can pass elements like `message` to be automatically added to the output template
+* Custom options: Pass any additional data to be used in the output class
+
+
+#### Reserved Properties
+
+Reserved properties are output elements that can be passed as options. They are automatically added to the output object and allow the `$send` method to override default properties in the output template.
+
+For example, a `message` can be passed right from the handler:
+
+```typescript
+return this.$send(YourOutput, { message: 'Hi there!' });
+```
+
+Even if `YourOutput` already includes a `message` property, it will be replaced with `"Hi there!"`.
+
+The following properties are reserved:
+* `message`
+* `reprompt`
+* `listen`
+* `quickReplies`
+* `card`
+* `carousel`
+* `platforms`
+
+All properties except `platforms` replace the current property in the output template. For `platforms`, the content gets merged to allow for more granularity.
+
+#### Custom Options
+
+You can pass any other options that are not [reserved properties](#reserved-properties) and reference them inside the output class using `this.options`.
 
 For example, here we're passing a user's `name`: 
 

--- a/framework/package.json
+++ b/framework/package.json
@@ -23,7 +23,7 @@
   "author": "jovotech",
   "license": "Apache-2.0",
   "dependencies": {
-    "@jovotech/output": "^4.0.0-alpha.9",
+    "@jovotech/output": "^4.0.0-alpha.10",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "i18next": "^20.3.1",

--- a/framework/src/BaseOutput.ts
+++ b/framework/src/BaseOutput.ts
@@ -11,9 +11,7 @@ export type OutputConstructor<
   JOVO extends Jovo<REQUEST, RESPONSE> = Jovo<REQUEST, RESPONSE>,
 > = new (jovo: JOVO, options?: DeepPartial<OUTPUT['options']>, ...args: unknown[]) => OUTPUT;
 
-export interface OutputOptions {
-  [key: string]: unknown;
-}
+export interface OutputOptions extends OutputTemplate {}
 
 export abstract class BaseOutput<OPTIONS extends OutputOptions = OutputOptions> extends JovoProxy {
   readonly options: OPTIONS;

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -228,7 +228,17 @@ export abstract class Jovo<
   ): Promise<void> {
     if (typeof outputConstructorOrTemplate === 'function') {
       const outputInstance = new outputConstructorOrTemplate(this, options);
-      this.$output = await outputInstance.build();
+      const output = await outputInstance.build();
+      OutputTemplate.getKeys().forEach((key) => {
+        if (options?.[key]) {
+          if (Array.isArray(output)) {
+            output[output.length - 1][key] = options[key];
+          } else {
+            output[key] = options[key];
+          }
+        }
+      });
+      this.$output = output;
     } else {
       this.$output = outputConstructorOrTemplate;
     }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -1,6 +1,7 @@
 import { JovoResponse, OutputTemplate } from '@jovotech/output';
 import _cloneDeep from 'lodash.clonedeep';
 import _get from 'lodash.get';
+import _merge from 'lodash.merge';
 import _set from 'lodash.set';
 import { App, AppConfig } from './App';
 import { InternalIntent, RequestType, RequestTypeLike } from './enums';
@@ -232,9 +233,13 @@ export abstract class Jovo<
       OutputTemplate.getKeys().forEach((key) => {
         if (options?.[key]) {
           if (Array.isArray(output)) {
-            output[output.length - 1][key] = options[key];
+            output[output.length - 1][key] =
+              key === 'platforms'
+                ? _merge({}, output[output.length - 1].platforms || {}, options[key])
+                : options[key];
           } else {
-            output[key] = options[key];
+            output[key] =
+              key === 'platforms' ? _merge({}, output[key] || {}, options[key]) : options[key];
           }
         }
       });


### PR DESCRIPTION
## Proposed changes
It is now possible to pass properties of `OutputTemplate` to `$send`, e.g.  `$send(SomeOutput, { message: 'Overwritten message' })` will result in an `OutputTemplate` with `message` set to 'Overwritten message'.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed