### PR TITLE
:sparkles: Add enableFullScreen and continueTtsDuringTouch

### DIFF
--- a/jovo-platforms/jovo-platform-googleassistant/src/core/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/src/core/Interfaces.ts
@@ -484,6 +484,8 @@ export interface HtmlResponse {
   updatedState: any; // tslint:disable-line
   suppressMic: boolean;
   url: string;
+  enableFullScreen?: boolean;
+  continueTtsDuringTouch?: boolean;
 }
 
 export interface Item {

--- a/jovo-platforms/jovo-platform-googleassistant/src/modules/InteractiveCanvas.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/src/modules/InteractiveCanvas.ts
@@ -40,6 +40,8 @@ export class InteractiveCanvas implements Plugin {
           url: htmlResponse.url,
           updatedState: htmlResponse.data,
           suppressMic: htmlResponse.suppress,
+          enableFullScreen: htmlResponse.enableFullScreen,
+          continueTtsDuringTouch: htmlResponse.continueTtsDuringTouch,
         },
       });
       _set(googleAction.$originalResponse, 'richResponse.items', richResponseItems);

--- a/jovo-platforms/jovo-platform-googleassistant/src/response/HtmlResponse.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/src/response/HtmlResponse.ts
@@ -1,17 +1,18 @@
-export class HtmlResponse {
+export interface InteractiveCanvasResponse {
   url?: string;
   data?: Record<string, object>;
   suppress?: boolean;
   enableFullScreen?: boolean;
   continueTtsDuringTouch?: boolean;
+}
 
-  constructor(obj: {
-    url?: string;
-    data?: Record<string, object>;
-    suppress?: boolean;
-    enableFullScreen?: boolean;
-    continueTtsDuringTouch?: boolean;
-  }) {
+export class HtmlResponse implements InteractiveCanvasResponse {
+  url?: string;
+  data?: Record<string, object>;
+  suppress?: boolean;
+  enableFullScreen?: boolean;
+  continueTtsDuringTouch?: boolean;
+  constructor(obj: Partial<InteractiveCanvasResponse>) {
     this.url = obj.url;
     this.data = obj.data;
     this.suppress = obj.suppress;

--- a/jovo-platforms/jovo-platform-googleassistant/src/response/HtmlResponse.ts
+++ b/jovo-platforms/jovo-platform-googleassistant/src/response/HtmlResponse.ts
@@ -2,10 +2,20 @@ export class HtmlResponse {
   url?: string;
   data?: Record<string, object>;
   suppress?: boolean;
+  enableFullScreen?: boolean;
+  continueTtsDuringTouch?: boolean;
 
-  constructor(obj: { url?: string; data?: Record<string, object>; suppress?: boolean }) {
+  constructor(obj: {
+    url?: string;
+    data?: Record<string, object>;
+    suppress?: boolean;
+    enableFullScreen?: boolean;
+    continueTtsDuringTouch?: boolean;
+  }) {
     this.url = obj.url;
     this.data = obj.data;
     this.suppress = obj.suppress;
+    this.enableFullScreen = obj.enableFullScreen;
+    this.continueTtsDuringTouch = obj.continueTtsDuringTouch;
   }
 }

--- a/jovo-platforms/jovo-platform-googleassistantconv/src/core/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googleassistantconv/src/core/Interfaces.ts
@@ -916,4 +916,6 @@ export interface HtmlResponse {
   // tslint:disable-next-line:no-any
   data?: Record<string, any>;
   suppressMic?: boolean;
+  enableFullScreen?: boolean;
+  continueTtsDuringTouch?: boolean;
 }


### PR DESCRIPTION
## Proposed changes
Google added `enableFullScreen` and `continueTtsDuringTouch` to the canvas object. This PR updates the existing `HtmlResponse` interfaces

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed