### PR TITLE
🐛 Fix invalid path in FileDB

### DIFF
--- a/integrations/db-filedb/src/FileDb.ts
+++ b/integrations/db-filedb/src/FileDb.ts
@@ -40,7 +40,7 @@ export class FileDb extends DbPlugin<FileDbConfig> {
       !!(await fs.promises.stat(pathToFile).catch(() => false));
 
     if (!(await pathExists(pathToFileDir))) {
-      await fs.promises.mkdir(path.dirname(this.config.pathToFile), { recursive: true });
+      await fs.promises.mkdir(pathToFileDir, { recursive: true });
     }
 
     if (!(await pathExists(this.pathToFile))) {


### PR DESCRIPTION
## Proposed changes
Fix invalid path that was used in FileDB to initialize the db-folder

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed