### PR TITLE
🐛 Fix bug caused by multiple `$send`-calls when using FacebookMessenger or GoogleBusiness

### DIFF
--- a/platforms/platform-facebookmessenger/src/MessengerBot.ts
+++ b/platforms/platform-facebookmessenger/src/MessengerBot.ts
@@ -45,6 +45,7 @@ export class MessengerBot extends Jovo<FacebookMessengerRequest, FacebookMesseng
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
+    // get the length of the current output, if it's an object, assume the length is 1
     const currentOutputLength = Array.isArray(this.$output) ? this.$output.length : 1;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);
@@ -54,6 +55,8 @@ export class MessengerBot extends Jovo<FacebookMessengerRequest, FacebookMesseng
     const outputConverter = new OutputTemplateConverter(
       new FacebookMessengerOutputTemplateConverterStrategy(),
     );
+
+    // get only the newly added output
     const newOutput = Array.isArray(this.$output)
       ? this.$output.slice(currentOutputLength)
       : this.$output;

--- a/platforms/platform-googlebusiness/src/GoogleBusinessBot.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessBot.ts
@@ -42,6 +42,7 @@ export class GoogleBusinessBot extends Jovo<GoogleBusinessRequest, GoogleBusines
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
+    // get the length of the current output, if it's an object, assume the length is 1
     const currentOutputLength = Array.isArray(this.$output) ? this.$output.length : 1;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);
@@ -51,6 +52,8 @@ export class GoogleBusinessBot extends Jovo<GoogleBusinessRequest, GoogleBusines
     const outputConverter = new OutputTemplateConverter(
       new GoogleBusinessOutputTemplateConverterStrategy(),
     );
+
+    // get only the newly added output
     const newOutput = Array.isArray(this.$output)
       ? this.$output.slice(currentOutputLength)
       : this.$output;

--- a/platforms/platform-googlebusiness/src/GoogleBusinessBot.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessBot.ts
@@ -42,18 +42,20 @@ export class GoogleBusinessBot extends Jovo<GoogleBusinessRequest, GoogleBusines
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
+    const currentOutputLength = Array.isArray(this.$output) ? this.$output.length : 1;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);
     } else {
       await super.$send(outputConstructorOrTemplate);
     }
-    if (!this.$output) {
-      return;
-    }
     const outputConverter = new OutputTemplateConverter(
       new GoogleBusinessOutputTemplateConverterStrategy(),
     );
-    let response = await outputConverter.toResponse(this.$output);
+    const newOutput = Array.isArray(this.$output)
+      ? this.$output.slice(currentOutputLength)
+      : this.$output;
+
+    let response = await outputConverter.toResponse(newOutput);
     response = await this.$platform.finalizeResponse(response, this);
 
     const conversationId = this.conversationId;


### PR DESCRIPTION
## Proposed changes
Multiple `$send`-calls caused the output to be sent multiple times.
Only the output that was created by the respective `$send`-call is now sent.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed