### PR TITLE
🐛 Fix invalid index when setting `skip` in `RoutingExecutor`

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -47,6 +47,13 @@ export {
   MessageValue,
   PlatformOutputTemplate,
   OutputValidationError,
+  Listen,
+  ListenValue,
+  DynamicEntity,
+  DynamicEntitiesModeLike,
+  DynamicEntities,
+  DynamicEntityValue,
+  DynamicEntitiesMode,
 } from '@jovotech/output';
 
 export * from './App';

--- a/framework/src/plugins/RoutingExecutor.ts
+++ b/framework/src/plugins/RoutingExecutor.ts
@@ -67,11 +67,15 @@ export class RoutingExecutor {
     const firstRouteMatchIndexWithUnhandled = rankedRouteMatches.findIndex(
       (match) => match.type === InternalIntent.Unhandled,
     );
-    // find the last RouteMatch that has prioritizedOverUnhandled
-    const lastRouteMatchIndexWithPrioritizedOverUnhandled = rankedRouteMatches
+    // find index of the last RouteMatch that has prioritizedOverUnhandled in a reversed matches-array
+    const lastReversedRouteMatchIndexWithPrioritizedOverUnhandled = rankedRouteMatches
       .slice()
       .reverse()
       .findIndex((match) => !!match.prioritizedOverUnhandled);
+    // get the actual index in the non-reversed matches-array by subtracting the index from the length and 1 due to arrays starting with 0
+    const lastRouteMatchIndexWithPrioritizedOverUnhandled =
+      rankedRouteMatches.length - lastReversedRouteMatchIndexWithPrioritizedOverUnhandled - 1;
+
     // if no indexes were found or they're invalid, abort
     if (
       firstRouteMatchIndexWithUnhandled < 0 ||


### PR DESCRIPTION
## Proposed changes
- The `lastRouteMatchIndexWithPrioritizedOverUnhandled` was invalid due to being retrieved relative to the reversed array instead of the correctly ordered array

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed