### PR TITLE
🐛 Fix missing check if the reverse-index is small than 0 in `RoutingExecutor`

### DIFF
--- a/framework/src/plugins/RoutingExecutor.ts
+++ b/framework/src/plugins/RoutingExecutor.ts
@@ -51,8 +51,9 @@ export class RoutingExecutor {
   }
 
   setSkipForRouteMatches(intentName: string, rankedRouteMatches: RouteMatch[]): void {
-    const isIntentToSkipUnhandled =
-      this.jovo.$handleRequest.config.routing?.intentsToSkipUnhandled?.includes(intentName);
+    const isIntentToSkipUnhandled = this.jovo.$handleRequest.config.routing?.intentsToSkipUnhandled?.includes(
+      intentName,
+    );
     // if the mapped intent is an intent that is supposed to skip UNHANDLED
     if (isIntentToSkipUnhandled) {
       // set skip: true for all UNHANDLED-matches
@@ -79,6 +80,7 @@ export class RoutingExecutor {
     // if no indexes were found or they're invalid, abort
     if (
       firstRouteMatchIndexWithUnhandled < 0 ||
+      lastReversedRouteMatchIndexWithPrioritizedOverUnhandled < 0 ||
       lastRouteMatchIndexWithPrioritizedOverUnhandled < 0 ||
       lastRouteMatchIndexWithPrioritizedOverUnhandled < firstRouteMatchIndexWithUnhandled
     ) {
@@ -114,8 +116,9 @@ export class RoutingExecutor {
       const handlerMetadataToRouteMatchMapper = this.createHandlerMetadataToRouteMatchMapper(
         node.path,
       );
-      const relatedHandlerMetadata =
-        MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(node.metadata.target);
+      const relatedHandlerMetadata = MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(
+        node.metadata.target,
+      );
       for (const metadata of relatedHandlerMetadata) {
         // if the conditions are no fulfilled, do not add the handler
         if (!(await this.areHandlerConditionsFulfilled(metadata))) {
@@ -154,16 +157,18 @@ export class RoutingExecutor {
     let subState = latestStateStackItem.$subState;
 
     // get the current node
-    let node: ComponentTreeNode | undefined =
-      this.jovo.$handleRequest.componentTree.getNodeAtOrFail(currentComponentPath);
+    let node:
+      | ComponentTreeNode
+      | undefined = this.jovo.$handleRequest.componentTree.getNodeAtOrFail(currentComponentPath);
     // loop all nodes and their parent's as long as root is reached
     while (node) {
       // create a map-callback for the given node's path
       const handlerMetadataToRouteMatchMapper = this.createHandlerMetadataToRouteMatchMapper(
         node.path,
       );
-      const relatedHandlerMetadata =
-        MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(node.metadata.target);
+      const relatedHandlerMetadata = MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(
+        node.metadata.target,
+      );
 
       for (const metadata of relatedHandlerMetadata) {
         // if the conditions are no fulfilled, do not add the handler


### PR DESCRIPTION
## Proposed changes
In #967 a check was forgotten, which checks if the reversed-index is smaller than 0.
This caused the whole routing-matches-list to be skipped. 
By adding the check, this can not occur.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed