### PR TITLE
🐛 Fix bug caused by passing a string `createdAt`-date

### DIFF
--- a/framework/src/JovoSession.ts
+++ b/framework/src/JovoSession.ts
@@ -36,7 +36,11 @@ export class JovoSession {
     this.$state = data?.$state;
     this.isNew = data?.isNew ?? true;
     this.updatedAt = new Date();
-    this.createdAt = this.isNew ? new Date() : data?.createdAt || new Date();
+    this.createdAt = this.isNew
+      ? new Date()
+      : data?.createdAt
+      ? new Date(data.createdAt)
+      : new Date();
   }
 
   getPersistableData(): PersistableSessionData {


### PR DESCRIPTION
## Proposed changes
`JovoSession` did directly take the passed `createdAt` from `data`. Now, a new Date object will be created based on the passed `data.createdAt`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed