### PR TITLE
🏷️ ♻️ Refactor `Jovo`-typings

### DIFF
--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -37,11 +37,12 @@ import { JovoHistory, JovoHistoryItem, PersistableHistoryData } from './JovoHist
 import { JovoDevice } from './JovoDevice';
 
 export type JovoConstructor<
-  REQUEST extends JovoRequest = JovoRequest,
-  RESPONSE extends JovoResponse = JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE> = Jovo<REQUEST, RESPONSE>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  PLATFORM extends Platform<REQUEST, RESPONSE, JOVO, any> = Platform<REQUEST, RESPONSE, JOVO, any>,
+  REQUEST extends JovoRequest,
+  RESPONSE extends JovoResponse,
+  JOVO extends Jovo<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>,
+  USER extends JovoUser<JOVO>,
+  DEVICE extends JovoDevice<JOVO>,
+  PLATFORM extends Platform<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>,
 > = new (app: App, handleRequest: HandleRequest, platform: PLATFORM, ...args: unknown[]) => JOVO;
 
 export interface JovoPersistableData {
@@ -79,8 +80,11 @@ export function registerPlatformSpecificJovoReference<
   KEY extends keyof Jovo,
   REQUEST extends JovoRequest,
   RESPONSE extends JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE>,
->(key: KEY, jovoClass: JovoConstructor<REQUEST, RESPONSE, JOVO>): void {
+  JOVO extends Jovo<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>,
+  USER extends JovoUser<JOVO>,
+  DEVICE extends JovoDevice<JOVO>,
+  PLATFORM extends Platform<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>,
+>(key: KEY, jovoClass: JovoConstructor<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>): void {
   Object.defineProperty(Jovo.prototype, key, {
     get(): Jovo[KEY] | undefined {
       return this instanceof jovoClass
@@ -95,6 +99,12 @@ export function registerPlatformSpecificJovoReference<
 export abstract class Jovo<
   REQUEST extends JovoRequest = JovoRequest,
   RESPONSE extends JovoResponse = JovoResponse,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  JOVO extends Jovo<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM> = any,
+  USER extends JovoUser<JOVO> = JovoUser<JOVO>,
+  DEVICE extends JovoDevice<JOVO> = JovoDevice<JOVO>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PLATFORM extends Platform<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM> = any,
 > {
   $asr: AsrData;
   $data: RequestData;
@@ -106,8 +116,8 @@ export abstract class Jovo<
   $route?: JovoRoute;
   $session: JovoSession;
   $type: JovoRequestType;
-  $user: JovoUser<REQUEST, RESPONSE, this>;
-  $device: JovoDevice<REQUEST, RESPONSE, this>;
+  $user: USER;
+  $device: DEVICE;
 
   $history: JovoHistory;
 
@@ -115,7 +125,7 @@ export abstract class Jovo<
     readonly $app: App,
     readonly $handleRequest: HandleRequest,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly $platform: Platform<REQUEST, RESPONSE, any, any>,
+    readonly $platform: PLATFORM,
   ) {
     this.$asr = {};
     this.$data = {};
@@ -127,8 +137,8 @@ export abstract class Jovo<
     this.$nlu = this.$request.getNluData() || {};
     this.$entities = this.$nlu.entities || {};
     this.$history = new JovoHistory();
-    this.$user = this.$platform.createUserInstance(this);
-    this.$device = this.$platform.createDeviceInstance(this);
+    this.$user = this.$platform.createUserInstance(this as unknown as JOVO);
+    this.$device = this.$platform.createDeviceInstance(this as unknown as JOVO);
   }
 
   get $config(): AppConfig {

--- a/framework/src/JovoDevice.ts
+++ b/framework/src/JovoDevice.ts
@@ -1,22 +1,12 @@
-import { JovoRequest } from './JovoRequest';
-import { JovoResponse } from '@jovotech/output';
-
 import { Jovo } from './Jovo';
 
 export type Capability = 'screen' | 'audio' | 'long-form-audio' | string;
 
-export type JovoDeviceConstructor<
-  REQUEST extends JovoRequest,
-  RESPONSE extends JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE>,
-  CAPABILITY extends Capability = Capability
-> = new (jovo: JOVO) => JovoDevice<REQUEST, RESPONSE, JOVO, CAPABILITY>;
+export type JovoDeviceConstructor<JOVO extends Jovo> = new (jovo: JOVO) => JOVO['$device'];
 
 export abstract class JovoDevice<
-  REQUEST extends JovoRequest,
-  RESPONSE extends JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE>,
-  CAPABILITY extends Capability = Capability
+  JOVO extends Jovo = Jovo,
+  CAPABILITY extends Capability = Capability,
 > {
   capabilities: CAPABILITY[] = [];
 
@@ -34,7 +24,7 @@ export abstract class JovoDevice<
     this.capabilities = this.capabilities.concat(capability);
   }
 
-  toJSON(): JovoDevice<REQUEST, RESPONSE, JOVO> {
+  toJSON(): JovoDevice<JOVO> {
     return { ...this, jovo: undefined };
   }
 }

--- a/framework/src/JovoUser.ts
+++ b/framework/src/JovoUser.ts
@@ -1,23 +1,13 @@
-import { JovoResponse } from '@jovotech/output';
 import { UserData } from './interfaces';
 import { Jovo } from './Jovo';
-import { JovoRequest } from './JovoRequest';
 
-export type JovoUserConstructor<
-  REQUEST extends JovoRequest,
-  RESPONSE extends JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE>,
-> = new (jovo: JOVO) => JovoUser<REQUEST, RESPONSE, JOVO>;
+export type JovoUserConstructor<JOVO extends Jovo> = new (jovo: JOVO) => JOVO['$user'];
 
 export interface PersistableUserData {
   data: UserData;
 }
 
-export abstract class JovoUser<
-  REQUEST extends JovoRequest,
-  RESPONSE extends JovoResponse,
-  JOVO extends Jovo<REQUEST, RESPONSE>,
-> {
+export abstract class JovoUser<JOVO extends Jovo = Jovo> {
   createdAt: Date = new Date();
   updatedAt: Date = new Date();
   $data: UserData = {};
@@ -45,7 +35,7 @@ export abstract class JovoUser<
     };
   }
 
-  toJSON(): JovoUser<REQUEST, RESPONSE, JOVO> {
+  toJSON(): JovoUser<JOVO> {
     return { ...this, jovo: undefined };
   }
 }

--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -47,18 +47,20 @@ export const BASE_PLATFORM_MIDDLEWARES: PlatformBaseMiddlewares = [
 ];
 
 export abstract class Platform<
+  REQUEST extends JovoRequest = JovoRequest,
+  RESPONSE extends JovoResponse = JovoResponse,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  REQUEST extends JovoRequest = any,
+  JOVO extends Jovo<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM> = any,
+  USER extends JovoUser<JOVO> = JovoUser<JOVO>,
+  DEVICE extends JovoDevice<JOVO> = JovoDevice<JOVO>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RESPONSE extends JovoResponse = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  JOVO extends Jovo<REQUEST, RESPONSE> = any,
+  PLATFORM extends Platform<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM, CONFIG> = any,
   CONFIG extends ExtensibleConfig = ExtensibleConfig,
 > extends Extensible<CONFIG, PlatformBaseMiddlewares> {
   abstract readonly requestClass: Constructor<REQUEST>;
-  abstract readonly jovoClass: JovoConstructor<REQUEST, RESPONSE, JOVO, this>;
-  abstract readonly userClass: JovoUserConstructor<REQUEST, RESPONSE, JOVO>;
-  abstract readonly deviceClass: JovoDeviceConstructor<REQUEST, RESPONSE, JOVO>;
+  abstract readonly jovoClass: JovoConstructor<REQUEST, RESPONSE, JOVO, USER, DEVICE, PLATFORM>;
+  abstract readonly userClass: JovoUserConstructor<JOVO>;
+  abstract readonly deviceClass: JovoDeviceConstructor<JOVO>;
 
   abstract outputTemplateConverterStrategy: OutputTemplateConverterStrategy<RESPONSE>;
 
@@ -99,11 +101,8 @@ export abstract class Platform<
     propagateMiddleware('interpretation.nlu', '$nlu');
   }
 
-  createJovoInstance<APP extends App>(
-    app: APP,
-    handleRequest: HandleRequest,
-  ): Jovo<REQUEST, RESPONSE> {
-    return new this.jovoClass(app, handleRequest, this);
+  createJovoInstance<APP extends App>(app: APP, handleRequest: HandleRequest): JOVO {
+    return new this.jovoClass(app, handleRequest, this as unknown as PLATFORM);
   }
 
   createRequestInstance(request: REQUEST | AnyObject): REQUEST {
@@ -112,10 +111,10 @@ export abstract class Platform<
     return instance;
   }
 
-  createUserInstance(jovo: JOVO): JovoUser<REQUEST, RESPONSE, JOVO> {
+  createUserInstance(jovo: JOVO): USER {
     return new this.userClass(jovo);
   }
-  createDeviceInstance(jovo: JOVO): JovoDevice<REQUEST, RESPONSE, JOVO> {
+  createDeviceInstance(jovo: JOVO): DEVICE {
     return new this.deviceClass(jovo);
   }
 }

--- a/framework/test/utilities/platform.ts
+++ b/framework/test/utilities/platform.ts
@@ -11,8 +11,8 @@ import {
   MiddlewareCollection,
   Platform,
   JovoDevice,
+  UnknownObject,
 } from '../../src';
-import { UnknownObject } from '../../dist/types';
 
 export class ExamplePlatformRequest extends JovoRequest {
   getEntities(): EntityMap | undefined {
@@ -50,7 +50,14 @@ export class ExamplePlatformRequest extends JovoRequest {
 
 export class ExamplePlatformResponse extends JovoResponse {}
 
-export class ExamplePlatformApp extends Jovo<ExamplePlatformRequest, ExamplePlatformResponse> {}
+export class ExamplePlatformJovo extends Jovo<
+  ExamplePlatformRequest,
+  ExamplePlatformResponse,
+  ExamplePlatformJovo,
+  ExamplePlatformUser,
+  ExamplePlatformDevice,
+  ExamplePlatform
+> {}
 
 export class ExamplePlatformOutputConverterStrategy
   implements OutputTemplateConverterStrategy<ExamplePlatformResponse>
@@ -68,30 +75,29 @@ export class ExamplePlatformOutputConverterStrategy
   }
 }
 
-export class ExamplePlatformUser extends JovoUser<
-  ExamplePlatformRequest,
-  ExamplePlatformResponse,
-  ExamplePlatformApp
-> {
+export class ExamplePlatformUser extends JovoUser<ExamplePlatformJovo> {
   get id(): string {
     return 'ExamplePlatformUser';
   }
 }
 
-export class ExamplePlatformDevice extends JovoDevice<
-  ExamplePlatformRequest,
-  ExamplePlatformResponse,
-  ExamplePlatformApp
-> {
+export class ExamplePlatformDevice extends JovoDevice<ExamplePlatformJovo> {
   protected setCapabilitiesFromRequest(): void {
     //
   }
 }
 
-export class ExamplePlatform extends Platform<ExamplePlatformRequest, ExamplePlatformResponse> {
+export class ExamplePlatform extends Platform<
+  ExamplePlatformRequest,
+  ExamplePlatformResponse,
+  ExamplePlatformJovo,
+  ExamplePlatformUser,
+  ExamplePlatformDevice,
+  ExamplePlatform
+> {
   outputTemplateConverterStrategy = new ExamplePlatformOutputConverterStrategy();
   requestClass = ExamplePlatformRequest;
-  jovoClass = ExamplePlatformApp;
+  jovoClass = ExamplePlatformJovo;
   userClass = ExamplePlatformUser;
   deviceClass = ExamplePlatformDevice;
 

--- a/platforms/platform-alexa/src/Alexa.ts
+++ b/platforms/platform-alexa/src/Alexa.ts
@@ -1,8 +1,18 @@
 import { Jovo } from '@jovotech/framework';
 import { AlexaResponse } from '@jovotech/output-alexa';
+import { AlexaDevice } from './AlexaDevice';
+import { AlexaPlatform } from './AlexaPlatform';
 import { AlexaRequest } from './AlexaRequest';
+import { AlexaUser } from './AlexaUser';
 
-export class Alexa extends Jovo<AlexaRequest, AlexaResponse> {
+export class Alexa extends Jovo<
+  AlexaRequest,
+  AlexaResponse,
+  Alexa,
+  AlexaUser,
+  AlexaDevice,
+  AlexaPlatform
+> {
   getSkillId(): string | undefined {
     return (
       this.$request.session?.application?.applicationId ||

--- a/platforms/platform-alexa/src/AlexaDevice.ts
+++ b/platforms/platform-alexa/src/AlexaDevice.ts
@@ -1,12 +1,9 @@
-import { AlexaResponse } from '@jovotech/output-alexa';
-
-import { AlexaRequest } from './AlexaRequest';
 import { Capability, JovoDevice } from '@jovotech/framework';
 import { Alexa } from './Alexa';
 
 export type AlexaCapability = Capability | 'alexa:apl';
 
-export class AlexaDevice extends JovoDevice<AlexaRequest, AlexaResponse, Alexa, AlexaCapability> {
+export class AlexaDevice extends JovoDevice<Alexa, AlexaCapability> {
   get id(): string | undefined {
     return this.jovo.$request.context?.System.device.deviceId;
   }

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -20,7 +20,15 @@ export interface AlexaConfig extends ExtensibleConfig {
   };
 }
 
-export class AlexaPlatform extends Platform<AlexaRequest, AlexaResponse, Alexa, AlexaConfig> {
+export class AlexaPlatform extends Platform<
+  AlexaRequest,
+  AlexaResponse,
+  Alexa,
+  AlexaUser,
+  AlexaDevice,
+  AlexaPlatform,
+  AlexaConfig
+> {
   outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy =
     new AlexaOutputTemplateConverterStrategy();
   requestClass = AlexaRequest;

--- a/platforms/platform-alexa/src/AlexaUser.ts
+++ b/platforms/platform-alexa/src/AlexaUser.ts
@@ -1,11 +1,10 @@
 import { JovoUser } from '@jovotech/framework';
-import { AlexaResponse } from '@jovotech/output-alexa';
+import { Alexa } from './Alexa';
 
 import { AlexaRequest } from './AlexaRequest';
-import { Alexa } from './Alexa';
 import { ProfileProperty, sendCustomerProfileApiRequest } from './api';
 
-export class AlexaUser extends JovoUser<AlexaRequest, AlexaResponse, Alexa> {
+export class AlexaUser extends JovoUser<Alexa> {
   constructor(jovo: Alexa) {
     super(jovo);
   }

--- a/platforms/platform-core/src/Core.ts
+++ b/platforms/platform-core/src/Core.ts
@@ -1,5 +1,15 @@
 import { Jovo } from '@jovotech/framework';
 import { CorePlatformResponse } from '@jovotech/output-core';
+import { CorePlatform } from './CorePlatform';
+import { CorePlatformDevice } from './CorePlatformDevice';
 import { CorePlatformRequest } from './CorePlatformRequest';
+import { CorePlatformUser } from './CorePlatformUser';
 
-export class Core extends Jovo<CorePlatformRequest, CorePlatformResponse> {}
+export class Core extends Jovo<
+  CorePlatformRequest,
+  CorePlatformResponse,
+  Core,
+  CorePlatformUser,
+  CorePlatformDevice,
+  CorePlatform
+> {}

--- a/platforms/platform-core/src/Core.ts
+++ b/platforms/platform-core/src/Core.ts
@@ -1,15 +1,15 @@
 import { Jovo } from '@jovotech/framework';
-import { CorePlatformResponse } from '@jovotech/output-core';
 import { CorePlatform } from './CorePlatform';
-import { CorePlatformDevice } from './CorePlatformDevice';
-import { CorePlatformRequest } from './CorePlatformRequest';
-import { CorePlatformUser } from './CorePlatformUser';
+import { CoreDevice } from './CoreDevice';
+import { CoreRequest } from './CoreRequest';
+import { CoreUser } from './CoreUser';
+import { CoreResponse } from '.';
 
 export class Core extends Jovo<
-  CorePlatformRequest,
-  CorePlatformResponse,
+  CoreRequest,
+  CoreResponse,
   Core,
-  CorePlatformUser,
-  CorePlatformDevice,
+  CoreUser,
+  CoreDevice,
   CorePlatform
 > {}

--- a/platforms/platform-core/src/CoreDevice.ts
+++ b/platforms/platform-core/src/CoreDevice.ts
@@ -3,7 +3,7 @@ import { Core } from './Core';
 
 export type CorePlatformCapability = Capability;
 
-export class CorePlatformDevice extends JovoDevice<Core, CorePlatformCapability> {
+export class CoreDevice extends JovoDevice<Core, CorePlatformCapability> {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented
   }

--- a/platforms/platform-core/src/CorePlatform.ts
+++ b/platforms/platform-core/src/CorePlatform.ts
@@ -16,6 +16,9 @@ export class CorePlatform extends Platform<
   CorePlatformRequest,
   CorePlatformResponse,
   Core,
+  CorePlatformUser,
+  CorePlatformDevice,
+  CorePlatform,
   CorePlatformConfig
 > {
   // TODO: determine how useful this is and if this is required somewhere

--- a/platforms/platform-core/src/CorePlatform.ts
+++ b/platforms/platform-core/src/CorePlatform.ts
@@ -1,23 +1,21 @@
 import { AnyObject, ExtensibleConfig, Platform } from '@jovotech/framework';
-import {
-  CorePlatformOutputTemplateConverterStrategy,
-  CorePlatformResponse,
-} from '@jovotech/output-core';
+import { CorePlatformOutputTemplateConverterStrategy } from '@jovotech/output-core';
+import { CoreResponse } from '.';
 import { Core } from './Core';
-import { CorePlatformRequest } from './CorePlatformRequest';
-import { CorePlatformUser } from './CorePlatformUser';
-import { CorePlatformDevice } from './CorePlatformDevice';
+import { CoreDevice } from './CoreDevice';
+import { CoreRequest } from './CoreRequest';
+import { CoreUser } from './CoreUser';
 
 export interface CorePlatformConfig extends ExtensibleConfig {
   type: 'jovo-platform-core' | string;
 }
 
 export class CorePlatform extends Platform<
-  CorePlatformRequest,
-  CorePlatformResponse,
+  CoreRequest,
+  CoreResponse,
   Core,
-  CorePlatformUser,
-  CorePlatformDevice,
+  CoreUser,
+  CoreDevice,
   CorePlatform,
   CorePlatformConfig
 > {
@@ -44,10 +42,10 @@ export class CorePlatform extends Platform<
   }
 
   outputTemplateConverterStrategy = new CorePlatformOutputTemplateConverterStrategy();
-  requestClass = CorePlatformRequest;
+  requestClass = CoreRequest;
   jovoClass = Core;
-  userClass = CorePlatformUser;
-  deviceClass = CorePlatformDevice;
+  userClass = CoreUser;
+  deviceClass = CoreDevice;
 
   getDefaultConfig(): CorePlatformConfig {
     return {
@@ -55,11 +53,11 @@ export class CorePlatform extends Platform<
     };
   }
 
-  isRequestRelated(request: AnyObject | CorePlatformRequest): boolean {
+  isRequestRelated(request: AnyObject | CoreRequest): boolean {
     return request.version && request.request?.type && request.type === this.config.type;
   }
 
-  isResponseRelated(response: AnyObject | CorePlatformResponse): boolean {
+  isResponseRelated(response: AnyObject | CoreResponse): boolean {
     return (
       response.version &&
       response.output &&
@@ -70,9 +68,9 @@ export class CorePlatform extends Platform<
   }
 
   finalizeResponse(
-    response: CorePlatformResponse,
+    response: CoreResponse,
     corePlatformApp: Core,
-  ): CorePlatformResponse | Promise<CorePlatformResponse> {
+  ): CoreResponse | Promise<CoreResponse> {
     response.type = this.config.type;
     response.session.data = corePlatformApp.$session;
     return response;

--- a/platforms/platform-core/src/CorePlatformDevice.ts
+++ b/platforms/platform-core/src/CorePlatformDevice.ts
@@ -1,17 +1,9 @@
-import { CorePlatformResponse } from '@jovotech/output-core';
-
 import { Capability, JovoDevice } from '@jovotech/framework';
-import { CorePlatformRequest } from './CorePlatformRequest';
 import { Core } from './Core';
 
 export type CorePlatformCapability = Capability;
 
-export class CorePlatformDevice extends JovoDevice<
-  CorePlatformRequest,
-  CorePlatformResponse,
-  Core,
-  CorePlatformCapability
-> {
+export class CorePlatformDevice extends JovoDevice<Core, CorePlatformCapability> {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented
   }

--- a/platforms/platform-core/src/CorePlatformUser.ts
+++ b/platforms/platform-core/src/CorePlatformUser.ts
@@ -1,13 +1,7 @@
 import { JovoUser } from '@jovotech/framework';
-import { CorePlatformResponse } from '@jovotech/output-core';
 import { Core } from './Core';
-import { CorePlatformRequest } from './CorePlatformRequest';
 
-export class CorePlatformUser extends JovoUser<
-  CorePlatformRequest,
-  CorePlatformResponse,
-  Core
-> {
+export class CorePlatformUser extends JovoUser<Core> {
   constructor(jovo: Core) {
     super(jovo);
   }

--- a/platforms/platform-core/src/CoreRequest.ts
+++ b/platforms/platform-core/src/CoreRequest.ts
@@ -1,7 +1,7 @@
 import { EntityMap, JovoRequest, JovoRequestType, UnknownObject } from '@jovotech/framework';
 import { Context, Request, RequestBodyText } from './interfaces';
 
-export class CorePlatformRequest extends JovoRequest {
+export class CoreRequest extends JovoRequest {
   version?: string;
   type?: 'jovo-platform-core' | string;
   request?: Request;

--- a/platforms/platform-core/src/CoreUser.ts
+++ b/platforms/platform-core/src/CoreUser.ts
@@ -1,7 +1,7 @@
 import { JovoUser } from '@jovotech/framework';
 import { Core } from './Core';
 
-export class CorePlatformUser extends JovoUser<Core> {
+export class CoreUser extends JovoUser<Core> {
   constructor(jovo: Core) {
     super(jovo);
   }

--- a/platforms/platform-core/src/index.ts
+++ b/platforms/platform-core/src/index.ts
@@ -21,7 +21,7 @@ registerPlatformSpecificJovoReference('$core', Core);
 
 export * from './Core';
 export * from './CorePlatform';
-export * from './CorePlatformRequest';
-export * from './CorePlatformUser';
-export type { CorePlatformResponse } from '@jovotech/output-core';
+export * from './CoreRequest';
+export * from './CoreUser';
+export type { CorePlatformResponse as CoreResponse } from '@jovotech/output-core';
 export * from './interfaces';

--- a/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
@@ -14,13 +14,24 @@ import {
   FacebookMessengerResponse,
 } from '@jovotech/output-facebookmessenger';
 import { FACEBOOK_API_BASE_URL, LATEST_FACEBOOK_API_VERSION } from './constants';
+import { FacebookMessengerDevice } from './FacebookMessengerDevice';
+import { FacebookMessengerPlatform } from './FacebookMessengerPlatform';
 import { FacebookMessengerRequest } from './FacebookMessengerRequest';
+import { FacebookMessengerUser } from './FacebookMessengerUser';
 import { SendMessageResult } from './interfaces';
 
-export class FacebookMessenger extends Jovo<FacebookMessengerRequest, FacebookMessengerResponse> {
+export class FacebookMessenger extends Jovo<
+  FacebookMessengerRequest,
+  FacebookMessengerResponse,
+  FacebookMessenger,
+  FacebookMessengerUser,
+  FacebookMessengerDevice,
+  FacebookMessengerPlatform
+> {
   get apiVersion(): string {
     return (
-      this.$handleRequest.config.plugin?.FacebookMessengerPlatform?.version || LATEST_FACEBOOK_API_VERSION
+      this.$handleRequest.config.plugin?.FacebookMessengerPlatform?.version ||
+      LATEST_FACEBOOK_API_VERSION
     );
   }
 

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerDevice.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerDevice.ts
@@ -1,14 +1,9 @@
-import { FacebookMessengerResponse } from '@jovotech/output-facebookmessenger';
-
 import { Capability, JovoDevice } from '@jovotech/framework';
-import { FacebookMessengerRequest } from './FacebookMessengerRequest';
 import { FacebookMessenger } from './FacebookMessenger';
 
 export type FacebookMessengerCapability = Capability;
 
 export class FacebookMessengerDevice extends JovoDevice<
-  FacebookMessengerRequest,
-  FacebookMessengerResponse,
   FacebookMessenger,
   FacebookMessengerCapability
 > {

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
@@ -29,6 +29,9 @@ export class FacebookMessengerPlatform extends Platform<
   FacebookMessengerRequest,
   FacebookMessengerResponse,
   FacebookMessenger,
+  FacebookMessengerUser,
+  FacebookMessengerDevice,
+  FacebookMessengerPlatform,
   FacebookMessengerConfig
 > {
   outputTemplateConverterStrategy = new FacebookMessengerOutputTemplateConverterStrategy();

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerUser.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerUser.ts
@@ -1,13 +1,7 @@
 import { JovoUser } from '@jovotech/framework';
-import { FacebookMessengerResponse } from '@jovotech/output-facebookmessenger';
-import { FacebookMessengerRequest } from './FacebookMessengerRequest';
 import { FacebookMessenger } from './FacebookMessenger';
 
-export class FacebookMessengerUser extends JovoUser<
-  FacebookMessengerRequest,
-  FacebookMessengerResponse,
-  FacebookMessenger
-> {
+export class FacebookMessengerUser extends JovoUser<FacebookMessenger> {
   get id(): string {
     return this.jovo.$request.messaging?.[0]?.sender?.id || 'FacebookMessengerUser';
   }

--- a/platforms/platform-googleassistant/src/GoogleAssistant.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistant.ts
@@ -1,5 +1,15 @@
 import { Jovo } from '@jovotech/framework';
 import { GoogleAssistantResponse } from '@jovotech/output-googleassistant';
+import { GoogleAssistantDevice } from './GoogleAssistantDevice';
+import { GoogleAssistantPlatform } from './GoogleAssistantPlatform';
 import { GoogleAssistantRequest } from './GoogleAssistantRequest';
+import { GoogleAssistantUser } from './GoogleAssistantUser';
 
-export class GoogleAssistant extends Jovo<GoogleAssistantRequest, GoogleAssistantResponse> {}
+export class GoogleAssistant extends Jovo<
+  GoogleAssistantRequest,
+  GoogleAssistantResponse,
+  GoogleAssistant,
+  GoogleAssistantUser,
+  GoogleAssistantDevice,
+  GoogleAssistantPlatform
+> {}

--- a/platforms/platform-googleassistant/src/GoogleAssistantDevice.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantDevice.ts
@@ -1,20 +1,10 @@
-import {
-  GoogleAssistantResponse,
-  Capability as GoogleAssistantNativeCapability,
-} from '@jovotech/output-googleassistant';
-
 import { Capability, JovoDevice } from '@jovotech/framework';
-import { GoogleAssistantRequest } from './GoogleAssistantRequest';
+import { Capability as GoogleAssistantNativeCapability } from '@jovotech/output-googleassistant';
 import { GoogleAssistant } from './GoogleAssistant';
 
 export type GoogleAssistantCapability = Capability;
 
-export class GoogleAssistantDevice extends JovoDevice<
-  GoogleAssistantRequest,
-  GoogleAssistantResponse,
-  GoogleAssistant,
-  GoogleAssistantCapability
-> {
+export class GoogleAssistantDevice extends JovoDevice<GoogleAssistant, GoogleAssistantCapability> {
   setCapabilitiesFromRequest(): void {
     const supportedCapabilites = this.jovo.$request.device?.capabilities;
 

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -22,6 +22,9 @@ export class GoogleAssistantPlatform extends Platform<
   GoogleAssistantRequest,
   GoogleAssistantResponse,
   GoogleAssistant,
+  GoogleAssistantUser,
+  GoogleAssistantDevice,
+  GoogleAssistantPlatform,
   GoogleAssistantConfig
 > {
   outputTemplateConverterStrategy = new GoogleAssistantOutputTemplateConverterStrategy();

--- a/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
@@ -1,13 +1,7 @@
 import { JovoUser } from '@jovotech/framework';
-import { GoogleAssistantResponse } from '@jovotech/output-googleassistant';
 import { GoogleAssistant } from './GoogleAssistant';
-import { GoogleAssistantRequest } from './GoogleAssistantRequest';
 
-export class GoogleAssistantUser extends JovoUser<
-  GoogleAssistantRequest,
-  GoogleAssistantResponse,
-  GoogleAssistant
-> {
+export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
   get id(): string {
     return (
       (this.jovo.$request.user?.params as Record<'userId' | string, string> | undefined)?.userId ||

--- a/platforms/platform-googlebusiness/src/GoogleBusiness.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusiness.ts
@@ -13,10 +13,19 @@ import {
 } from '@jovotech/output-googlebusiness';
 import { JWTInput } from 'google-auth-library';
 import { GOOGLE_BUSINESS_API_BASE_URL, LATEST_GOOGLE_BUSINESS_API_VERSION } from './constants';
+import { GoogleBusinessDevice } from './GoogleBusinessDevice';
 import { GoogleBusinessPlatform } from './GoogleBusinessPlatform';
 import { GoogleBusinessRequest } from './GoogleBusinessRequest';
+import { GoogleBusinessUser } from './GoogleBusinessUser';
 
-export class GoogleBusiness extends Jovo<GoogleBusinessRequest, GoogleBusinessResponse> {
+export class GoogleBusiness extends Jovo<
+  GoogleBusinessRequest,
+  GoogleBusinessResponse,
+  GoogleBusiness,
+  GoogleBusinessUser,
+  GoogleBusinessDevice,
+  GoogleBusinessPlatform
+> {
   get conversationId(): string | undefined {
     return this.$request.conversationId;
   }

--- a/platforms/platform-googlebusiness/src/GoogleBusinessDevice.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessDevice.ts
@@ -1,17 +1,9 @@
-import { GoogleBusinessResponse } from '@jovotech/output-googlebusiness';
-
 import { Capability, JovoDevice } from '@jovotech/framework';
-import { GoogleBusinessRequest } from './GoogleBusinessRequest';
 import { GoogleBusiness } from './GoogleBusiness';
 
 export type GoogleBusinessCapability = Capability;
 
-export class GoogleBusinessDevice extends JovoDevice<
-  GoogleBusinessRequest,
-  GoogleBusinessResponse,
-  GoogleBusiness,
-  GoogleBusinessCapability
-> {
+export class GoogleBusinessDevice extends JovoDevice<GoogleBusiness, GoogleBusinessCapability> {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented
   }

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -28,6 +28,9 @@ export class GoogleBusinessPlatform extends Platform<
   GoogleBusinessRequest,
   GoogleBusinessResponse,
   GoogleBusiness,
+  GoogleBusinessUser,
+  GoogleBusinessDevice,
+  GoogleBusinessPlatform,
   GoogleBusinessConfig
 > {
   outputTemplateConverterStrategy = new GoogleBusinessOutputTemplateConverterStrategy();
@@ -68,6 +71,8 @@ export class GoogleBusinessPlatform extends Platform<
 
   finalizeResponse(
     response: GoogleBusinessResponse[] | GoogleBusinessResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    googleBusiness: GoogleBusiness,
   ):
     | GoogleBusinessResponse[]
     | Promise<GoogleBusinessResponse>

--- a/platforms/platform-googlebusiness/src/GoogleBusinessUser.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessUser.ts
@@ -1,13 +1,7 @@
 import { JovoUser } from '@jovotech/framework';
-import { GoogleBusinessResponse } from '@jovotech/output-googlebusiness';
 import { GoogleBusiness } from './GoogleBusiness';
-import { GoogleBusinessRequest } from './GoogleBusinessRequest';
 
-export class GoogleBusinessUser extends JovoUser<
-  GoogleBusinessRequest,
-  GoogleBusinessResponse,
-  GoogleBusiness
-> {
+export class GoogleBusinessUser extends JovoUser<GoogleBusiness> {
   get id(): string {
     return this.jovo.$request.conversationId || 'GoogleBusinessUser';
   }


### PR DESCRIPTION
## Proposed changes
The correct types are now returned for platform-specific Jovo-instances.

Example:
`this.$alexa.$device` will return an `AlexaDevice`-instance and also have the correct type.
Before, type-hinting assumed a `JovoDevice` was returned.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed