### PR TITLE
🐛 Fix bug that caused entities of `NlpjsNlu` to be set to an array instead of an `EntityMap`

### DIFF
--- a/integrations/nlu-nlpjs/README.md
+++ b/integrations/nlu-nlpjs/README.md
@@ -1,0 +1,69 @@
+# NLP.js NLU Integration
+
+Turn raw text into structured meaning with the Jovo Framework integration for the open source natural language understanding service NLP.js.
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Jovo Model](#jovo-model)
+
+## Introduction
+
+[NLP.js](https://github.com/axa-group/nlp.js) is an open source [natural language understanding (NLU)](https://www.jovo.tech/marketplace/tag/nlu) library with features like entity extraction, sentiment analysis, and language detection.
+
+Since it is an open source service, you can host NLP.js on your own servers without any external API calls.
+
+You can use the Jovo NLP.js integration for projects where you receive raw text input that needs to be translated into structured meaning to work with the Jovo intent structure. Patforms like the [Jovo Core Platform](https://www.jovo.tech/marketplace/jovo-platform-core) (e.g. in conjunction with the [Jovo Web Client](https://www.jovo.tech/marketplace/jovo-client-web)), [Facebook Messenger](https://www.jovo.tech/marketplace/jovo-platform-facebookmessenger), and [Google Business Messages](https://www.jovo.tech/marketplace/jovo-platform-googlebusiness) are some examples where this would work.
+
+Smaller NLP.js language models are fast to train and can even be used on serverless infrastructure like [AWS Lambda](https://www.jovo.tech/docs/hosting/aws-lambda) without having to use any additional server infrastructure. We recommend taking a close look at the execution times though, as larger models can take quite some time to build.
+
+
+## Installation
+
+You can install the plugin like this:
+
+```sh
+$ npm install @jovotech/nlu-nlpjs --save
+```
+
+NLU plugins can be added to Jovo platform integrations. Here is an example how it can be added to the Jovo Core Platform in `app.ts`:
+
+```typescript
+import { CorePlatform } from '@jovotech/platform-core';
+import { NlpjsNlu } from '@jovotech/nlu-nlpjs';
+
+// ...
+
+app.configure({
+  plugins: [
+    new CorePlatform().use(new NlpjsNlu({
+      // Configuration
+    }),
+    // ...
+  ],
+});
+```
+
+## Configuration
+
+The following configurations can be added:
+
+```typescript
+new NlpjsNlu({
+  languageMap: { /* ... */ },
+  preTrainedModelFilePath: './model.nlp',
+  useModel: false,
+  modelsPath: './models',
+  setupModelCallback: () => { /* ... */ },
+}),
+```
+
+
+* `languageMap`: TODO
+* `useModel` and `preTrainedModelFilePath`: NLP.js can take a pretrained model if `useModel` is set to `true`. It looks for the model in the `preTrainedModelFilePath`. The default is `./model.nlp`.
+* `setupModelCallback`: TODO
+
+
+
+## Jovo Model
+
+You can use the [Jovo Model](https://www.jovo.tech/marketplace/jovo-model) to turn the language model files in your `models` folder into an NLP.js model. [Learn more about the NLP.js Jovo Model integration here](https://www.jovo.tech/marketplace/jovo-model/nlpjs).

--- a/integrations/nlu-nlpjs/README.md
+++ b/integrations/nlu-nlpjs/README.md
@@ -1,6 +1,7 @@
 # NLP.js NLU Integration
 
 Turn raw text into structured meaning with the Jovo Framework integration for the open source natural language understanding service NLP.js.
+
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Configuration](#configuration)
@@ -15,7 +16,6 @@ Since it is an open source service, you can host NLP.js on your own servers with
 You can use the Jovo NLP.js integration for projects where you receive raw text input that needs to be translated into structured meaning to work with the Jovo intent structure. Patforms like the [Jovo Core Platform](https://www.jovo.tech/marketplace/jovo-platform-core) (e.g. in conjunction with the [Jovo Web Client](https://www.jovo.tech/marketplace/jovo-client-web)), [Facebook Messenger](https://www.jovo.tech/marketplace/jovo-platform-facebookmessenger), and [Google Business Messages](https://www.jovo.tech/marketplace/jovo-platform-googlebusiness) are some examples where this would work.
 
 Smaller NLP.js language models are fast to train and can even be used on serverless infrastructure like [AWS Lambda](https://www.jovo.tech/docs/hosting/aws-lambda) without having to use any additional server infrastructure. We recommend taking a close look at the execution times though, as larger models can take quite some time to build.
-
 
 ## Installation
 
@@ -35,8 +35,8 @@ import { NlpjsNlu } from '@jovotech/nlu-nlpjs';
 
 app.configure({
   plugins: [
-    new CorePlatform().use(new NlpjsNlu({
-      // Configuration
+    new CorePlatform({
+      plugins: [new NlpjsNlu()],
     }),
     // ...
   ],
@@ -53,16 +53,17 @@ new NlpjsNlu({
   preTrainedModelFilePath: './model.nlp',
   useModel: false,
   modelsPath: './models',
-  setupModelCallback: () => { /* ... */ },
+  setupModelCallback: (platform: Platform, nlpjs) => { /* ... */ },
 }),
 ```
 
+- `languageMap`: An object where the key represents a language, and the value is a language-package of NLP.js. By default, it is an empty object.
+- `useModel` and `preTrainedModelFilePath`: NLP.js can take a pretrained model if `useModel` is set to `true`. It looks for the model in the `preTrainedModelFilePath`. The default is `./model.nlp`.
+- `setupModelCallback`: A function that can be passed to set up NLP.js. The first parameter is the current `Platform` and the second parameter is the `Nlp`-instance of NLP.js.
 
-* `languageMap`: TODO
-* `useModel` and `preTrainedModelFilePath`: NLP.js can take a pretrained model if `useModel` is set to `true`. It looks for the model in the `preTrainedModelFilePath`. The default is `./model.nlp`.
-* `setupModelCallback`: TODO
-
-
+Depending on the configuration, NlpjsNlu will try to use the `setupModelCallback` if it exists.
+Otherwise, the integration will check if `useModel` is set to `true`, if that's the case, the model is getting loaded from `preTrainedModelFilePath`.
+If `setupModellCallback` does not exist and `useModel` is falsy, the integration will attempt to build a model based on the local models and train it.
 
 ## Jovo Model
 

--- a/integrations/nlu-nlpjs/src/NlpjsNlu.ts
+++ b/integrations/nlu-nlpjs/src/NlpjsNlu.ts
@@ -1,7 +1,6 @@
 import {
   DeepPartial,
   EntityMap,
-  Extensible,
   HandleRequest,
   Jovo,
   NluData,


### PR DESCRIPTION
## Proposed changes
This fixes a bug that was caused by returning an array of `Entity` instead of an `EntityMap`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed