### PR TITLE
V3/bugfix/facebook messenger platform

### DIFF
--- a/jovo-platforms/jovo-platform-facebookmessenger/README.md
+++ b/jovo-platforms/jovo-platform-facebookmessenger/README.md
@@ -154,6 +154,58 @@ export = {
 };
 ```
 
+### Automatically set persistent menu
+
+To set the persistent menu payload on startup you have to set the following configuration:
+
+```javascript
+// @language=javascript
+
+// src/config.js
+
+module.exports = {
+	platform: {
+		FacebookMessenger: {
+			persistentMenu: {
+        		updateOnSetup: true,
+        		data: [{
+					locale:"default",
+					composer_input_disabled:false,
+					call_to_actions: [{
+						type:"postback",
+						title:"HelloWorld",
+						payload:"HelloWorldIntent"
+					}]
+				}]
+        	}
+		}
+	}
+};
+
+// @language=typescript
+
+// src/config.ts
+
+export = {
+	platform: {
+		FacebookMessenger: {
+			persistentMenu: {
+				updateOnSetup: true,
+            	data: [{
+					locale:"default",
+					composer_input_disabled:false,
+					call_to_actions: [{
+						type: PersistentMenuItemType.Postback,
+						title:"HelloWorld",
+						payload:"HelloWorldIntent"
+					}]
+				}]
+			}
+		}
+	}
+};
+```
+
 ### Disable synchronous response
 By default, `tell` and `ask` generate a message that will be sent shortly before responding to the initial request.
 As a consequence, this message will **always** be the **last** message sent.

--- a/jovo-platforms/jovo-platform-facebookmessenger/package.json
+++ b/jovo-platforms/jovo-platform-facebookmessenger/package.json
@@ -68,7 +68,8 @@
     }
   },
   "files": [
-    "dist/src/**/*"
+    "dist/src/**/*",
+    "sample-request-json"
   ],
   "gitHead": "85f493970553e479edcee02ad7037f617dd74fcd"
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/sample-request-json/v1/MultipleEventRequest.json
+++ b/jovo-platforms/jovo-platform-facebookmessenger/sample-request-json/v1/MultipleEventRequest.json
@@ -1,0 +1,43 @@
+{
+  "object": "page",
+  "entry": [
+    {
+      "id": "113399660059468",
+      "time": 1458692752478,
+      "messaging": [
+        {
+          "sender": {
+            "id": "2321893584590078"
+          },
+          "recipient": {
+            "id": "113399660059468"
+          },
+          "timestamp": 1628142262677,
+          "postback": {
+            "title": "Get Started",
+            "payload": "INTENT_1"
+          }
+        }
+      ]
+    },
+    {
+      "id": "113399660059468",
+      "time": 1458692752478,
+      "messaging": [
+        {
+          "sender": {
+            "id": "2321893584590078"
+          },
+          "recipient": {
+            "id": "113399660059468"
+          },
+          "timestamp": 1628142262677,
+          "postback": {
+            "title": "Get Started",
+            "payload": "INTENT_2"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/Enums.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/Enums.ts
@@ -34,6 +34,10 @@ export enum WebViewHeightRatio {
   Full = 'FULL',
 }
 
+export enum WebViewShareButton {
+  Hide = 'hide',
+}
+
 export enum MediaType {
   Image = 'image',
   Video = 'video',
@@ -49,4 +53,13 @@ export enum SenderActionType {
   MarkSeen = 'mark_seen',
   TypingOn = 'typing_on',
   TypingOff = 'typing_off',
+}
+
+export enum PersistentMenuItemType {
+  Link = 'web_url',
+  Postback = 'postback',
+}
+
+export enum DisabledSurfaces {
+  CustomerChatPlugin = 'customer_chat_plugin',
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -105,6 +105,7 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
 
     app.middleware('platform.output')!.use(this.output.bind(this));
     app.middleware('response')!.use(this.response.bind(this));
+    app.middleware('after.response')!.use(this.afterResponse.bind(this));
 
     this.use(new FacebookMessengerCore());
 
@@ -288,6 +289,13 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         Log.error(e.response?.data);
       }
     }
+  }
+
+  async afterResponse(handleRequest: HandleRequest) {
+    if (!handleRequest.jovo || handleRequest.jovo.constructor.name !== this.getAppType()) {
+      return Promise.resolve();
+    }
+    await handleRequest.host.setResponse(handleRequest.jovo.$response);
   }
 
   makeTestSuite(): TestSuite<FacebookMessengerRequestBuilder, FacebookMessengerResponseBuilder> {

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -366,11 +366,12 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         request.entry.length > 0;
       if (isMessengerRequest) {
         const promises: Array<Promise<any>> = [];
+        const responseObj: { message: MessengerBotResponse[] } = { message: [] };
         request.entry.forEach((entry: MessengerBotEntry) => {
           const hostCopy: Host = Object.create(host.constructor.prototype);
           // tslint:disable-next-line
           hostCopy.setResponse = async function (obj: any) {
-            return;
+            responseObj.message.push(obj.message);
           };
           for (const key in host) {
             if (host.hasOwnProperty(key)) {
@@ -389,7 +390,7 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         });
 
         await Promise.all(promises);
-        return host.setResponse({});
+        return host.setResponse(responseObj);
       }
       return PROTOTYPE_BACKUP.call(this, host);
     };

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -366,12 +366,12 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         request.entry.length > 0;
       if (isMessengerRequest) {
         const promises: Array<Promise<any>> = [];
-        const responseObj: { message: MessengerBotResponse[] } = { message: [] };
+        const responses: MessengerBotResponse[] = [];
         request.entry.forEach((entry: MessengerBotEntry) => {
           const hostCopy: Host = Object.create(host.constructor.prototype);
           // tslint:disable-next-line
           hostCopy.setResponse = async function (obj: any) {
-            responseObj.message.push(obj.message);
+            responses.push(obj);
           };
           for (const key in host) {
             if (host.hasOwnProperty(key)) {
@@ -390,7 +390,7 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         });
 
         await Promise.all(promises);
-        return host.setResponse(responseObj);
+        return host.setResponse(responses);
       }
       return PROTOTYPE_BACKUP.call(this, host);
     };

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/FacebookMessenger.ts
@@ -369,10 +369,6 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
         const responses: MessengerBotResponse[] = [];
         request.entry.forEach((entry: MessengerBotEntry) => {
           const hostCopy: Host = Object.create(host.constructor.prototype);
-          // tslint:disable-next-line
-          hostCopy.setResponse = async function (obj: any) {
-            responses.push(obj);
-          };
           for (const key in host) {
             if (host.hasOwnProperty(key)) {
               const value = (host as any)[key];
@@ -386,6 +382,10 @@ export class FacebookMessenger extends Platform<MessengerBotRequest, MessengerBo
               }
             }
           }
+          // tslint:disable-next-line
+          hostCopy.setResponse = async function (obj: any) {
+            responses.push(obj);
+          };
           promises.push(PROTOTYPE_BACKUP.call(this, hostCopy));
         });
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
@@ -120,6 +120,12 @@ export class MessengerBot extends Jovo {
     return this;
   }
 
+  private setResponses(message: any): void {
+    const currentResponses = _get(this.$output, 'FacebookMessenger.responses') ?? [];
+    const responses = [...currentResponses, message];
+    _set(this.$output, 'FacebookMessenger.responses', responses);
+  }
+
   showQuickReplies(quickReplies: Array<QuickReply | GenericQuickReply | string>): this {
     return this.setQuickReplies(quickReplies);
   }
@@ -147,6 +153,7 @@ export class MessengerBot extends Jovo {
 
   async showText(options: TextMessageOptions): Promise<AxiosResponse<SendMessageResponse>> {
     const message = new TextMessage({ id: this.$user.getId()! }, { ...options });
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -154,6 +161,7 @@ export class MessengerBot extends Jovo {
     options: AttachmentMessageOptions,
   ): Promise<AxiosResponse<SendMessageResponse>> {
     const message = new AttachmentMessage({ id: this.$user.getId()! }, options);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -165,6 +173,7 @@ export class MessengerBot extends Jovo {
       template_type: TemplateType.Airline,
     };
     const message = new AirlineTemplate({ id: this.$user.getId()! }, payload);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -176,6 +185,7 @@ export class MessengerBot extends Jovo {
       template_type: TemplateType.Button,
     };
     const message = new ButtonTemplate({ id: this.$user.getId()! }, payload);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -187,6 +197,7 @@ export class MessengerBot extends Jovo {
       template_type: TemplateType.Generic,
     };
     const message = new GenericTemplate({ id: this.$user.getId()! }, payload);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -198,6 +209,7 @@ export class MessengerBot extends Jovo {
       template_type: TemplateType.Media,
     };
     const message = new MediaTemplate({ id: this.$user.getId()! }, payload);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 
@@ -209,6 +221,7 @@ export class MessengerBot extends Jovo {
       template_type: TemplateType.Receipt,
     };
     const message = new ReceiptTemplate({ id: this.$user.getId()! }, payload);
+    this.setResponses(message);
     return message.send(this.pageAccessToken, this.version);
   }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
@@ -230,6 +230,41 @@ export class MessengerBot extends Jovo {
     return message.send(this.pageAccessToken, this.version);
   }
 
+  async showTyping(delayInMs: number): Promise<void> {
+    const typingOnRequest = await new SenderAction(
+      { id: this.$user.getId()! },
+      SenderActionType.TypingOn,
+    );
+    const typingOnResponse = typingOnRequest.send(this.pageAccessToken, this.version);
+
+    const typingOffRequest = new SenderAction(
+      { id: this.$user.getId()! },
+      SenderActionType.TypingOff,
+    );
+
+    const typingOffResponse = typingOffRequest.send(this.pageAccessToken, this.version);
+
+    this.setResponses({
+      typingOn: typingOnRequest,
+      typingOff: typingOffRequest,
+      delayInMs: delayInMs,
+    });
+
+    const promises: Array<Promise<SendMessageResponse | unknown>> = [typingOnResponse];
+
+    // Remove delay when this method is being used in testing
+    if (this.$host.headers['jovo-test'] !== 'true') {
+      const delay = new Promise((resolve) => setTimeout(resolve, delayInMs));
+      promises.push(delay);
+    }
+
+    promises.push(typingOffResponse);
+
+    for (let i = 0; i < promises.length; i++) {
+      await promises[i];
+    }
+  }
+
   get version(): string {
     return _get(this.$config, 'plugin.FacebookMessenger.version', DEFAULT_VERSION);
   }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
@@ -116,7 +116,7 @@ export class MessengerBot extends Jovo {
 
   // Output methods
   setText(text: string): this {
-    _set(this.$output.FacebookMessenger, 'Overwrite.Text', text);
+    _set(this.$output, 'FacebookMessenger.Overwrite.Text', text);
     return this;
   }
 
@@ -130,18 +130,18 @@ export class MessengerBot extends Jovo {
         ? new TextQuickReply(quickReply.label || quickReply.value, quickReply.value)
         : quickReply;
     });
-    _set(this.$output.FacebookMessenger, 'Overwrite.QuickReplies', facebookQuickReplies);
+    _set(this.$output, 'FacebookMessenger.Overwrite.QuickReplies', facebookQuickReplies);
     return this;
   }
 
   addQuickReply(quickReply: QuickReply | GenericQuickReply | string): this {
-    const quickReplies = _get(this.$output.FacebookMessenger, 'Overwrite.QuickReplies');
+    const quickReplies = _get(this.$output, 'FacebookMessenger.Overwrite.QuickReplies');
     quickReplies.push(
       typeof quickReply === 'object' && 'value' in quickReply
         ? new TextQuickReply(quickReply.label || quickReply.value, quickReply.value)
         : quickReply,
     );
-    _set(this.$output.FacebookMessenger, 'Overwrite.QuickReplies', quickReplies);
+    _set(this.$output, 'FacebookMessenger.Overwrite.QuickReplies', quickReplies);
     return this;
   }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBotResponse.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBotResponse.ts
@@ -42,7 +42,7 @@ export class MessengerBotResponse implements JovoResponse {
     return this.getSpeechPlain();
   }
 
-  getSpeechPlain(): string | undefined {
+  getSpeechPlain(separator?: string): string | undefined {
     return this.messages
       .map((m) => {
         if (m instanceof TextMessage) {
@@ -51,7 +51,7 @@ export class MessengerBotResponse implements JovoResponse {
         return;
       })
       .filter((m) => !!m)
-      .join(' ');
+      .join(separator || ' ');
   }
 
   hasSessionAttribute(name: string, value?: any): boolean {

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBotResponse.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBotResponse.ts
@@ -75,13 +75,13 @@ export class MessengerBotResponse implements JovoResponse {
 
     if (typeof speechText === 'string') {
       return (
-        SpeechBuilder.removeSSML(speechText) === (this.message?.[0] as TextMessage).message.text
+        SpeechBuilder.removeSSML(speechText) === (this.message?.[0] as TextMessage)?.message?.text
       );
     }
 
     if (Array.isArray(speechText)) {
       return speechText.some((text) => {
-        return SpeechBuilder.removeSSML(text) === (this.message?.[0] as TextMessage).message.text;
+        return SpeechBuilder.removeSSML(text) === (this.message?.[0] as TextMessage)?.message?.text;
       });
     }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/index.ts
@@ -3,7 +3,7 @@ import { Config } from './FacebookMessenger';
 import { ApiVersion, QuickReply } from './Interfaces';
 import { Message } from './responses/Message';
 
-export { FacebookMessenger, Config } from './FacebookMessenger';
+export { FacebookMessenger, Config, PersistentMenuElement } from './FacebookMessenger';
 
 export const BASE_URL = 'https://graph.facebook.com';
 export const DEFAULT_VERSION: ApiVersion = 'v8.0';

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
@@ -49,10 +49,9 @@ export class FacebookMessengerCore implements Plugin {
   }
 
   async type(messengerBot: MessengerBot) {
-    let type: EnumRequestType = EnumRequestType.INTENT;
-
-    const payload = _get(messengerBot, '$request.messaging[0].postback.payload');
-    if (!!payload && !!this.launchPayload && payload === this.launchPayload) {
+    let type =
+      _get(messengerBot, '$request.messaging[0].postback.payload') ?? EnumRequestType.INTENT;
+    if (!!type && !!this.launchPayload && type === this.launchPayload) {
       type = EnumRequestType.LAUNCH;
     }
 

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
@@ -76,6 +76,8 @@ export class FacebookMessengerCore implements Plugin {
 
     const response = messengerBot.$response as MessengerBotResponse;
 
+    response.message = [];
+
     if (Object.keys(output).length === 0) {
       return;
     }
@@ -86,19 +88,28 @@ export class FacebookMessengerCore implements Plugin {
     const tell = _get(output, 'tell');
     if (tell) {
       const text = setText || tell.speech.toString();
-      response.message = new TextMessage(
-        { id: messengerBot.$user.getId()! },
-        { text, quickReplies: overWriteQuickReplies },
+      response.message.push(
+        new TextMessage(
+          { id: messengerBot.$user.getId()! },
+          { text, quickReplies: overWriteQuickReplies },
+        ),
       );
     }
 
     const ask = _get(output, 'ask');
     if (ask) {
       const text = setText || ask.speech.toString();
-      response.message = new TextMessage(
-        { id: messengerBot.$user.getId()! },
-        { text, quickReplies: overWriteQuickReplies },
+      response.message.push(
+        new TextMessage(
+          { id: messengerBot.$user.getId()! },
+          { text, quickReplies: overWriteQuickReplies },
+        ),
       );
+    }
+
+    const responses = _get(output, 'FacebookMessenger.responses');
+    if (responses && responses.length) {
+      response.message = [...response.message, ...responses];
     }
   }
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/modules/FacebookMessengerCore.ts
@@ -75,7 +75,7 @@ export class FacebookMessengerCore implements Plugin {
 
     const response = messengerBot.$response as MessengerBotResponse;
 
-    response.message = [];
+    response.messages = [];
 
     if (Object.keys(output).length === 0) {
       return;
@@ -87,7 +87,7 @@ export class FacebookMessengerCore implements Plugin {
     const tell = _get(output, 'tell');
     if (tell) {
       const text = setText || tell.speech.toString();
-      response.message.push(
+      response.messages.push(
         new TextMessage(
           { id: messengerBot.$user.getId()! },
           { text, quickReplies: overWriteQuickReplies },
@@ -98,7 +98,7 @@ export class FacebookMessengerCore implements Plugin {
     const ask = _get(output, 'ask');
     if (ask) {
       const text = setText || ask.speech.toString();
-      response.message.push(
+      response.messages.push(
         new TextMessage(
           { id: messengerBot.$user.getId()! },
           { text, quickReplies: overWriteQuickReplies },
@@ -108,7 +108,7 @@ export class FacebookMessengerCore implements Plugin {
 
     const responses = _get(output, 'FacebookMessenger.responses');
     if (responses && responses.length) {
-      response.message = [...response.message, ...responses];
+      response.messages = [...response.messages, ...responses];
     }
   }
 }

--- a/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
@@ -1,0 +1,144 @@
+import { MessengerBotRequest, FacebookMessenger, MessengerBot, Message } from '../src';
+import { App, ExpressJS, JovoRequest, EnumRequestType } from 'jovo-framework';
+import { TestSuite, Conversation, HandleRequest } from 'jovo-core';
+
+const multipleEventRequest = require('../sample-request-json/v1/MultipleEventRequest.json');
+
+process.env.NODE_ENV = 'UNIT_TEST';
+let app: App;
+let t: TestSuite;
+
+describe('response', () => {
+  beforeAll(() => {
+    // Let's make Message.send noop as we don't need to make calls to fb
+    Message.prototype.send = jest.fn().mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    app = new App();
+
+    const messenger = new FacebookMessenger({
+      fetchUserProfile: false,
+      shouldOverrideAppHandle: true,
+    });
+
+    app.use(messenger);
+    t = messenger.makeTestSuite();
+  });
+
+  test('single request', async (done) => {
+    app.setHandler({
+      LAUNCH_TEST() {
+        // Single fb api call
+        this.$messengerBot?.tell('hello');
+      },
+    });
+    const req = await t.requestBuilder.launch();
+    app.handle(ExpressJS.dummyRequest(req));
+
+    app.on('response', (handleRequest: HandleRequest) => {
+      const messengerResponse = handleRequest.jovo!.$response;
+      expect(messengerResponse).toMatchObject({
+        message: [
+          {
+            message: { quick_replies: undefined, text: 'hello world' },
+            message_type: 'RESPONSE',
+            recipient: { id: '2321893584590078' },
+          },
+        ],
+      });
+      done();
+    });
+  });
+
+  test('multiple responses', async (done) => {
+    app.setHandler({
+      LAUNCH_TEST() {
+        // Two fb api calls
+        this.$messengerBot?.showText({
+          text: 'hello world 1',
+        });
+        this.$messengerBot?.showText({
+          text: 'hello world 2',
+        });
+      },
+    });
+
+    const request: JovoRequest = await t.requestBuilder.launch();
+    app.handle(ExpressJS.dummyRequest(request));
+
+    app.on('response', (handleRequest: HandleRequest) => {
+      const messengerResponses = handleRequest.jovo!.$response;
+      expect(messengerResponses).toMatchObject({
+        message: [
+          {
+            message: { quick_replies: undefined, text: 'hello world 1' },
+            message_type: 'RESPONSE',
+            recipient: { id: '2321893584590078' },
+          },
+          {
+            message: { quick_replies: undefined, text: 'hello world 2' },
+            message_type: 'RESPONSE',
+            recipient: { id: '2321893584590078' },
+          },
+        ],
+      });
+      done();
+    });
+  });
+
+  test('multiple events', async (done) => {
+    app.setHandler({
+      INTENT_1() {
+        this.$messengerBot?.showText({
+          text: 'hello world 1',
+        });
+      },
+      INTENT_2() {
+        this.$messengerBot?.showText({
+          text: 'hello world 2',
+        });
+      },
+    });
+
+    // Request will call INTENT_1 and INTENT_2 in one call
+    const request: JovoRequest = await t.requestBuilder.launch(multipleEventRequest);
+    app.handle(ExpressJS.dummyRequest(request));
+
+    // This hook should be called twice since there are two events are called
+    app.on('response', (handleRequest: HandleRequest) => {
+      const response = handleRequest.jovo!.$response;
+      const request: any = handleRequest.jovo?.$request;
+
+      const intentName = request.messaging[0].postback.payload;
+
+      if (intentName === 'INTENT_1') {
+        expect(response).toMatchObject({
+          message: [
+            {
+              message: { quick_replies: undefined, text: 'hello world 1' },
+              message_type: 'RESPONSE',
+              recipient: { id: '2321893584590078' },
+            },
+          ],
+        });
+      } else if (intentName === 'INTENT_2') {
+        expect(response).toMatchObject({
+          message: [
+            {
+              message: { quick_replies: undefined, text: 'hello world 2' },
+              message_type: 'RESPONSE',
+              recipient: { id: '2321893584590078' },
+            },
+          ],
+        });
+      }
+
+      done();
+    });
+  });
+});

--- a/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
@@ -107,17 +107,10 @@ describe('response', () => {
 
     // Request will call INTENT_1 and INTENT_2 in one call
     const request: JovoRequest = await t.requestBuilder.launch(multipleEventRequest);
-    app.handle(ExpressJS.dummyRequest(request));
-
-    // This hook should be called twice since there are two events are called
-    app.on('response', (handleRequest: HandleRequest) => {
-      const response = handleRequest.jovo!.$response;
-      const request: any = handleRequest.jovo?.$request;
-
-      const intentName = request.messaging[0].postback.payload;
-
-      if (intentName === 'INTENT_1') {
-        expect(response).toMatchObject({
+    const host = ExpressJS.dummyRequest(request);
+    host.setResponse = async function (response: any) {
+      expect(response).toEqual([
+        {
           messages: [
             {
               message: { quick_replies: undefined, text: 'hello world 1' },
@@ -125,9 +118,8 @@ describe('response', () => {
               recipient: { id: '2321893584590078' },
             },
           ],
-        });
-      } else if (intentName === 'INTENT_2') {
-        expect(response).toMatchObject({
+        },
+        {
           messages: [
             {
               message: { quick_replies: undefined, text: 'hello world 2' },
@@ -135,10 +127,10 @@ describe('response', () => {
               recipient: { id: '2321893584590078' },
             },
           ],
-        });
-      }
-
+        },
+      ]);
       done();
-    });
+    };
+    await app.handle(host);
   });
 });

--- a/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/test/FBMessengerResponse.test.ts
@@ -34,7 +34,7 @@ describe('response', () => {
     app.setHandler({
       LAUNCH_TEST() {
         // Single fb api call
-        this.$messengerBot?.tell('hello');
+        this.$messengerBot?.tell('hello world');
       },
     });
     const req = await t.requestBuilder.launch();
@@ -43,7 +43,7 @@ describe('response', () => {
     app.on('response', (handleRequest: HandleRequest) => {
       const messengerResponse = handleRequest.jovo!.$response;
       expect(messengerResponse).toMatchObject({
-        message: [
+        messages: [
           {
             message: { quick_replies: undefined, text: 'hello world' },
             message_type: 'RESPONSE',
@@ -74,7 +74,7 @@ describe('response', () => {
     app.on('response', (handleRequest: HandleRequest) => {
       const messengerResponses = handleRequest.jovo!.$response;
       expect(messengerResponses).toMatchObject({
-        message: [
+        messages: [
           {
             message: { quick_replies: undefined, text: 'hello world 1' },
             message_type: 'RESPONSE',
@@ -118,7 +118,7 @@ describe('response', () => {
 
       if (intentName === 'INTENT_1') {
         expect(response).toMatchObject({
-          message: [
+          messages: [
             {
               message: { quick_replies: undefined, text: 'hello world 1' },
               message_type: 'RESPONSE',
@@ -128,7 +128,7 @@ describe('response', () => {
         });
       } else if (intentName === 'INTENT_2') {
         expect(response).toMatchObject({
-          message: [
+          messages: [
             {
               message: { quick_replies: undefined, text: 'hello world 2' },
               message_type: 'RESPONSE',


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
This PR addresses some issues I've faced when working on a Jovo v3 app that makes use of the Facebook messenger platform. I thought it would be good to list them here to raise awareness of these issues for when the Facebook messenger platform gets ported to v4. 

### Unpublished `sample-request-json` files
The `sample-request-json` files are not published, this would result in an error when anyone would attempt to write test when using the Facebook messenger platform. Example:

sample.test.ts
```
import { FacebookMessenger } from 'jovo-platform-facebookmessenger';

const facebookMessengerConfig = { ... }

for (const p of [new FacebookMessenger(facebookMessengerConfig) ]) {
    const testSuite = p.makeTestSuite();

    . . . 
   const launchRequest = await testSuite.requestBuilder.launch();
```

Calling `.launch()` would return the following error when you run `npm run test`

```
Cannot find module '../../../sample-request-json/v1/LaunchRequest.json' from 'node_modules/jovo-platform-facebookmessenger/dist/src/core/FacebookMessengerRequestBuilder.js'
```

### Postback buttons would always invoke the ON_TEXT intent
Anytime a user would interact with a postback button, [the user would always be directed to the ON_TEXT intent](https://github.com/brody-ly/jovo-framework/commit/5786e95d05cdb4dc00c1126289c7abec9c1cce05). I believe the correct behaviour should be to route the user to the invocation of the payload string in the postback button. 

Example:
`new PostbackButton("Settings", "SettingsIntent")` should take you the SettingsIntent not ON_TEXT intent

### Facebook messenger platform response
When implementing the Facebook platform, I realised that there was no response returning from the server. This meant that it wasn't possible for me to perform any testing as there was no response returning. 

What I ended up doing was to add in the middleware [`after.response`](https://github.com/brody-ly/jovo-framework/commit/5d5c33a79b2a7bf4bcc1cbad681ec336e05c3648#diff-abf3ecb6ebac910e2e7c6911e6a940b8cd8cadd8cbc7255b39397ef148675bc9R108) to return the response. 

While addressing this issue, I realised that not all helper methods of the Facebook class returned a response. As a fix, I've introduced [a new key in the `$output` object](https://github.com/brody-ly/jovo-framework/commit/10f0855c03fe86ee0dc25c452195a3f5eb2659e0#diff-2d007621a74a9883a19e3143c29799a41ace0f0ac2b49a76d1c92c954bf5ab7aR123-R128) that stores all responses in an invocation. This change introduces a new response for the Facebook messenger platform. An example of this would look something like this,

App.ts
```
app.setHandler({
  LAUNCH() {
    return this.toIntent("GreetingIntent");
  },

  async GreetingIntent() {
    try {
      await this.$messengerBot?.showAttachment({
        type: AttachmentType.Image,
        data:
          "https://via.placeholder.com/200x100",
      });
      await this.$messengerBot?.showButtonTemplate({
        text: `G'day ${this.$messengerBot.$session.$data.userProfile.first_name}, would you like to subscribe?`,
        buttons: [
          new PostbackButton(
            `Yes please!`,
            "SubscribeIntent"
          ),
          new PostbackButton("No thanks", "DenySubscribeIntent"),
          new PostbackButton("Maybe? Not sure", "ConvinceSubscribeIntent"),
        ],
      });
      return;
    } catch (e) {
      console.error(e.response?.data || e.message);
      return;
    }
  }
});
```
The output of a launch request would look like this,

```
{
   "message": [
      {
         "recipient": {
            "id": "xxxxxxxx"
         },
         "options": {
            "type": "image",
            "data": "https://via.placeholder.com/200x100"
         }
      },
      {
         "recipient": {
            "id": "xxxxxxxxx"
         },
         "message": {
            "attachment": {
               "payload": {
                  "text": `G'day Brody, would you like to subscribe?",
                  "buttons": [
                     {
                        "type": "postback",
                        "title": "Yes please! 😄",
                        "payload": "SubscribeIntent"
                     },
                     {
                        "type": "postback",
                        "title": "No thanks",
                        "payload": "DenySubscribeIntent"
                     },
                     {
                        "type": "postback",
                        "title": "Maybe? Not sure",
                        "payload": "ConvinceSubscribeIntent"
                     }
                  ],
                  "template_type": "button"
               },
               "type": "template"
            }
         }
      }
   ]
}
```
Receiving a response like this would make testing possible.

### Facebook messenger typing actions
The current implementation of messenger typing action works as intended, however I found it hard to write tests that would test the delay between typingOn and typingOff action.

Current implementation
App.ts
```
await this.$messengerBot?.showAction(SenderActionType.TypingOn);
await delay(2000);
await this.$messengerBot?.showAction(SenderActionType.TypingOff);
await this.$messengerBot?.showText({
   text: `Hello`,
});
```
With the above implementation, I feel like there is no way to test the delay.

My proposal on a fix would be to do implement something similar to the following,

Called somewhere in App.ts
```
await this.$messengerBot?.showTyping(2000);
```

Which would respond with the following result,

```
{
    messages: [
      {
        typingOn: {
          recipient: {
            id: 'xxxxxxx',
          },
          sender_action: 'typing_on',
        },
        typingOff: {
          recipient: {
            id: 'xxxxxxx',
          },
          sender_action: 'typing_off',
        },
        delayInMs: 2000,
      },
    ],
  };
```
The above response would make it possible to test how long of a pause occurred between typingOn and typingOff. I've implemented a new helper method that does this [here](https://github.com/brody-ly/jovo-framework/commit/b3b0be696aba905d544592a4257dda0adc3d51b3).

I know the Jovo team is busy with the Jovo v4 release, but again, I'd like to reiterate that I thought It would be good to create this PR to raise awareness of the issues I've faced. I would love to get any sort of feedback on the changes in the PR and whether these issues are addressed in Jovo v4. I've held off writing tests until I've received feedback on whether these changes are worth merging or not.  

### Persistent menu
Added a feature that allows the platform to configure [messenger's persistent menu](https://developers.facebook.com/docs/messenger-platform/send-messages/persistent-menu/). 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly ( I will update this based on feedback)
- [ ] I have added tests to cover my changes ( I will update this based on feedback)
- [x] All new and existing tests passed