### PR TITLE
Improve type for device capabilities

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -27,27 +27,33 @@ You can access a device's capabilities like this:
 ```typescript
 this.$device.capabilities
 
-// Example result: [ 'screen', 'audio' ]
+// Example result: [ 'SCREEN', 'AUDIO' ] or [Capability.Screen, Capability.Audio]
 ```
 
-You can also use the `supports` method to check if the device supports specific capabilities.
+You can also use the `supports` method to check if the device supports specific capabilities. It expects the `Capability` enum or the string value. 
 
 ```typescript
+import { Capability } from '@jovotech/framework';
+
 this.$device.supports(capability: Capability)
 
 // Example for one capability
-if (this.$device.supports('screen')) {}
+if (this.$device.supports(Capability.Screen)) {}
+// or 
+if (this.$device.supports('SCREEN')) {}
 
 // Example for multiple capabilities
-if (this.$device.supports(['screen'] && this.$device.supports('video')) {}
+if (this.$device.supports(Capability.Screen) && this.$device.supports(Capability.Video)) {}
+// or
+if (this.$device.supports('SCREEN') && this.$device.supports('VIDEO')) {}
 ```
 
 The following capabilities are currently available in the generic `$device` class:
 
-* `audio`: It's possible to play audio output via SSML.
-* `long-form-audio`: It's possible to play long-form audio output, e.g. Alexa AudioPlayer or Google Assistant Media Response.
-* `screen`: It's possible to show visual output on a screen.
-* `video`: It's possible to play a video on a screen.
+* `AUDIO` or `Capability.Audio`: It's possible to play audio output via SSML.
+* `LONGFORM_AUDIO` or `Capability.LongformAudio`: It's possible to play long-form audio output, e.g. Alexa AudioPlayer or Google Assistant Media Response.
+* `SCREEN` or `Capability.Screen`: It's possible to show visual output on a screen.
+* `VIDEO` or `Capability.Video`: It's possible to play a video on a screen.
 
 
 
@@ -56,7 +62,11 @@ The following capabilities are currently available in the generic `$device` clas
 Some platforms like Alexa offer specific capabilities like APL. You can access them by prepending the platform name like this:
 
 ```typescript
-this.$device.supports('alexa:apl')
+import { AlexaCapability } from "./AlexaDevice";
+
+this.$device.supports(AlexaCapability.Apl)
+// or
+this.$device.supports('ALEXA:APL')
 ```
 
 If a platform offers specific device features beyond capabilities, you can access its `$device` object as part of the platform object. Here is an example for Amazon Alexa:
@@ -76,17 +86,20 @@ Here is an example for Alexa:
 
 ```typescript
 setCapabilitiesFromRequest(): void {
-  const supportedInterfaces = this.jovo.$request.context?.System?.device?.supportedInterfaces;
+    const supportedInterfaces = this.jovo.$request.context?.System?.device?.supportedInterfaces;
 
-  if (supportedInterfaces?.AudioPlayer) {
-    this.addCapability('audio', 'long-form-audio');
-  }
+    if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.Speech)) {
+        this.addCapability(Capability.Audio);
+    }
 
-  if (supportedInterfaces?.['Alexa.Presentation.APL']) {
-    this.addCapability('screen', 'alexa:apl');
-  }
-
-  // ...
+    if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.LongFormAudio)) {
+        this.addCapability(Capability.LongformAudio);
+    }
+    
+    if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.RichResponse)) {
+        this.addCapability(Capability.Screen);
+    }
+// ...
 }
 ```
 

--- a/docs/device.md
+++ b/docs/device.md
@@ -62,12 +62,22 @@ The following capabilities are currently available in the generic `$device` clas
 Some platforms like Alexa offer specific capabilities like APL. You can access them by prepending the platform name like this:
 
 ```typescript
-import { AlexaCapability } from "./AlexaDevice";
+import { AlexaCapability } from "@jovotech/platform-alexa";
+import { GoogleAssistantCapability } from "@jovotech/platform-googleassistant";
 
 this.$device.supports(AlexaCapability.Apl)
 // or
 this.$device.supports('ALEXA:APL')
+
+this.$device.supports(GoogleAssistantCapability.InteractiveCanvas)
+// or
+this.$device.supports('GOOGLE_ASSISTANT:INTERACTIVE_CANVAS')
+
+
 ```
+
+
+
 
 If a platform offers specific device features beyond capabilities, you can access its `$device` object as part of the platform object. Here is an example for Amazon Alexa:
 

--- a/framework/src/JovoDevice.ts
+++ b/framework/src/JovoDevice.ts
@@ -1,12 +1,19 @@
 import { Jovo } from './Jovo';
 
-export type Capability = 'screen' | 'audio' | 'long-form-audio' | string;
+export enum Capability {
+  Screen = 'SCREEN',
+  Audio = 'AUDIO',
+  LongformAudio = 'LONGFORM_AUDIO',
+  Video = 'VIDEO',
+}
+
+export type CapabilityType = Capability | `${Capability}` | string;
 
 export type JovoDeviceConstructor<JOVO extends Jovo> = new (jovo: JOVO) => JOVO['$device'];
 
 export abstract class JovoDevice<
   JOVO extends Jovo = Jovo,
-  CAPABILITY extends Capability = Capability,
+  CAPABILITY extends CapabilityType = CapabilityType,
 > {
   capabilities: CAPABILITY[] = [];
 

--- a/platforms/platform-alexa/src/AlexaDevice.ts
+++ b/platforms/platform-alexa/src/AlexaDevice.ts
@@ -1,22 +1,27 @@
 import { Capability, JovoDevice } from '@jovotech/framework';
 import { Alexa } from './Alexa';
 
-export type AlexaCapability = Capability | 'alexa:apl';
+export enum AlexaCapability {
+  Apl = 'ALEXA:APL',
+}
 
-export class AlexaDevice extends JovoDevice<Alexa, AlexaCapability> {
+export type AlexaCapabilityType = Capability | AlexaCapability;
+
+export class AlexaDevice extends JovoDevice<Alexa, AlexaCapabilityType> {
   get id(): string | undefined {
     return this.jovo.$request.context?.System.device.deviceId;
   }
 
   setCapabilitiesFromRequest(): void {
     const supportedInterfaces = this.jovo.$request.context?.System?.device?.supportedInterfaces;
+    this.addCapability(Capability.Audio);
 
     if (supportedInterfaces?.AudioPlayer) {
-      this.addCapability('audio', 'long-form-audio');
+      this.addCapability(Capability.LongformAudio);
     }
 
     if (supportedInterfaces?.['Alexa.Presentation.APL']) {
-      this.addCapability('screen', 'Alexa.Apl');
+      this.addCapability(Capability.Screen, AlexaCapability.Apl);
     }
   }
 }

--- a/platforms/platform-core/src/CoreDevice.ts
+++ b/platforms/platform-core/src/CoreDevice.ts
@@ -1,9 +1,9 @@
-import { Capability, JovoDevice } from '@jovotech/framework';
+import { CapabilityType, JovoDevice } from '@jovotech/framework';
 import { Core } from './Core';
 
-export type CorePlatformCapability = Capability;
+export type CorePlatformCapabilityType = CapabilityType;
 
-export class CoreDevice extends JovoDevice<Core, CorePlatformCapability> {
+export class CoreDevice extends JovoDevice<Core, CorePlatformCapabilityType> {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented
   }

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerDevice.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerDevice.ts
@@ -1,11 +1,11 @@
-import { Capability, JovoDevice } from '@jovotech/framework';
+import { CapabilityType, JovoDevice } from '@jovotech/framework';
 import { FacebookMessenger } from './FacebookMessenger';
 
-export type FacebookMessengerCapability = Capability;
+export type FacebookMessengerCapabilityType = CapabilityType;
 
 export class FacebookMessengerDevice extends JovoDevice<
   FacebookMessenger,
-  FacebookMessengerCapability
+  FacebookMessengerCapabilityType
 > {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented

--- a/platforms/platform-googleassistant/src/GoogleAssistantDevice.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantDevice.ts
@@ -2,22 +2,38 @@ import { Capability, JovoDevice } from '@jovotech/framework';
 import { Capability as GoogleAssistantNativeCapability } from '@jovotech/output-googleassistant';
 import { GoogleAssistant } from './GoogleAssistant';
 
-export type GoogleAssistantCapability = Capability;
+export enum GoogleAssistantCapability {
+  InteractiveCanvas = 'GOOGLE_ASSISTANT:INTERACTIVE_CANVAS',
+  WebLink = 'GOOGLE_ASSISTANT:WEB_LINK',
+}
 
-export class GoogleAssistantDevice extends JovoDevice<GoogleAssistant, GoogleAssistantCapability> {
+export type GoogleAssistantCapabilityType = Capability | GoogleAssistantCapability;
+
+export class GoogleAssistantDevice extends JovoDevice<
+  GoogleAssistant,
+  GoogleAssistantCapabilityType
+> {
   setCapabilitiesFromRequest(): void {
     const supportedCapabilites = this.jovo.$request.device?.capabilities;
 
     if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.Speech)) {
-      this.addCapability('audio');
+      this.addCapability(Capability.Audio);
     }
 
     if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.LongFormAudio)) {
-      this.addCapability('long-form-audio');
+      this.addCapability(Capability.LongformAudio);
     }
 
     if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.RichResponse)) {
-      this.addCapability('screen');
+      this.addCapability(Capability.Screen);
+    }
+
+    if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.WebLink)) {
+      this.addCapability(GoogleAssistantCapability.WebLink);
+    }
+
+    if (supportedCapabilites?.includes(GoogleAssistantNativeCapability.InteractiveCanvas)) {
+      this.addCapability(GoogleAssistantCapability.InteractiveCanvas);
     }
   }
 }

--- a/platforms/platform-googlebusiness/src/GoogleBusinessDevice.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessDevice.ts
@@ -1,9 +1,9 @@
-import { Capability, JovoDevice } from '@jovotech/framework';
+import { CapabilityType, JovoDevice } from '@jovotech/framework';
 import { GoogleBusiness } from './GoogleBusiness';
 
-export type GoogleBusinessCapability = Capability;
+export type GoogleBusinessCapabilityType = CapabilityType;
 
-export class GoogleBusinessDevice extends JovoDevice<GoogleBusiness, GoogleBusinessCapability> {
+export class GoogleBusinessDevice extends JovoDevice<GoogleBusiness, GoogleBusinessCapabilityType> {
   setCapabilitiesFromRequest(): void {
     // needs to be implemented
   }


### PR DESCRIPTION
Currently, device capabilities are defined as string types. This PR allows using enums as well. 


```typescript
import { Capability } from '@jovotech/framework';

// Example for one capability
if (this.$device.supports(Capability.Screen)) {}
// or 
if (this.$device.supports('SCREEN')) {}

```
Platform-specific:

```typescript
import { AlexaCapability } from "./AlexaDevice";

this.$device.supports(AlexaCapability.Apl)
// or
this.$device.supports('ALEXA:APL')
```

## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed