### PR TITLE
🐛 Fix logic for setting entities on Alexa user event

### DIFF
--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -84,15 +84,8 @@ export class AlexaPlatform extends Platform<
             jovo.$input.intent = argument.intent;
           }
           if (argument.entities) {
-            const entityMap: EntityMap = argument.entities.reduce(
-              (entityMap: EntityMap, entity: Entity) => {
-                entityMap[entity.name] = entity;
-                return entityMap;
-              },
-              {},
-            );
-            jovo.$input.entities = { ...entityMap };
-            jovo.$entities = entityMap;
+            jovo.$input.entities = { ...argument.entities };
+            jovo.$entities = argument.entities;
           }
         }
       });

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -1,7 +1,5 @@
 import {
   AnyObject,
-  Entity,
-  EntityMap,
   ExtensibleConfig,
   HandleRequest,
   InputType,


### PR DESCRIPTION
## Proposed changes
When changing the structure of the Alexa user event, the logic for setting entities from that data has not been updated.
Now `AlexaPlatform` will use the directly passed entity map instead of trying to build one.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed