### PR TITLE
🐛 Add missing statement to set input-type to INTENT when `NluPlugin` retrieved a result

### DIFF
--- a/framework/src/NluPlugin.ts
+++ b/framework/src/NluPlugin.ts
@@ -44,6 +44,7 @@ export abstract class NluPlugin<
     }
     const nluProcessResult = await this.process(jovo, jovo.$input.text);
     if (nluProcessResult) {
+      jovo.$input.type = InputType.Intent;
       jovo.$input.nlu = nluProcessResult;
       jovo.$entities = nluProcessResult.entities || {};
     }


### PR DESCRIPTION
## Proposed changes
Added missing statement that would cause the input-type to not get updated when `NluPlugin` successfully processed text.
Now, `$input.type` will be set to `INTENT` when the nlu-process was successful.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed