### PR TITLE
🚑️ switched from dot to index notation when filling entity map.

### DIFF
--- a/integrations/nlu-rasa/src/RasaNlu.ts
+++ b/integrations/nlu-rasa/src/RasaNlu.ts
@@ -82,7 +82,7 @@ export class RasaNlu extends NluPlugin<RasaNluConfig> {
     if (rasaEntity.role) {
       entityAlias = rasaEntity.role;
     }
-    entityMap.entityAlias = {
+    entityMap[entityAlias] = {
       id: entityAlias,
       key: entityAlias,
       name: rasaEntity.entity,


### PR DESCRIPTION

## Proposed changes
<!--- Describe your changes in detail -->
Bugfix
Switch from dot to index notation when filling entity map.
The variable entityAlias is not evaluated when using dot notation, which results in always having the key "entityAlias" as the only key in the entity map instead of having the actual entity names as keys

<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed