### PR TITLE
♻️💥 Refactor middleware registering

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,17 +4,7 @@ excerpt: 'Learn how you can build your own plugins to customize and extend the J
 ---
 # Plugins
 
-Learn how you can build your own plugins to customize and extend the Jovo Framework.
-
-- [Introduction](#introduction)
-- [Get Started with Jovo Plugins](#get-started-with-jovo-plugins)
-  - [Basic Plugin Structure](#basic-plugin-structure)
-  - [Plugin Configuration](#plugin-configuration)
-  - [Add a Plugin to the Jovo App](#add-a-plugin-to-the-jovo-app)
-- [Advanced Jovo Plugins](#advanced-jovo-plugins)
-  - [Plugin Lifecycle](#plugin-lifecycle)
-  - [Plugin Mounting](#plugin-mounting)
-  - [Jovo Extensible Structure](#jovo-extensible-structure)
+Learn how you can build your own plugins to customize and extend the Jovo Framework. For lightweight plugins, take a look at [hooks](./hooks.md).
 
 ## Introduction
 

--- a/framework/src/Extensible.ts
+++ b/framework/src/Extensible.ts
@@ -16,16 +16,15 @@ export interface ExtensibleConfig extends PluginConfig {
   plugin?: ExtensiblePluginConfig;
 }
 
-export type ExtensibleInitConfig<CONFIG extends ExtensibleConfig = ExtensibleConfig> = DeepPartial<
-  CONFIG
-> & {
-  plugin?: never;
-  plugins?: Plugin[];
-};
+export type ExtensibleInitConfig<CONFIG extends ExtensibleConfig = ExtensibleConfig> =
+  DeepPartial<CONFIG> & {
+    plugin?: never;
+    plugins?: Plugin[];
+  };
 
 export abstract class Extensible<
   CONFIG extends ExtensibleConfig = ExtensibleConfig,
-  MIDDLEWARES extends string[] = string[]
+  MIDDLEWARES extends string[] = string[],
 > extends Plugin<CONFIG> {
   readonly plugins: ExtensiblePlugins;
   readonly middlewareCollection: MiddlewareCollection<MIDDLEWARES>;

--- a/framework/src/Extensible.ts
+++ b/framework/src/Extensible.ts
@@ -45,9 +45,7 @@ export abstract class Extensible<
     plugins.forEach((plugin) => {
       const name = plugin.constructor.name;
       this.plugins[name] = plugin;
-      if (plugin.install) {
-        plugin.install?.(this);
-      }
+      plugin.install?.(this);
     });
     return this;
   }

--- a/framework/src/Extensible.ts
+++ b/framework/src/Extensible.ts
@@ -38,7 +38,6 @@ export abstract class Extensible<
     }
   }
 
-  // TODO determine whether abstract or a default implementation should exist (that would most likely return an empty MiddlewareCollection)
   abstract initializeMiddlewareCollection(): MiddlewareCollection<MIDDLEWARES>;
 
   use(...plugins: Plugin[]): this {
@@ -53,6 +52,7 @@ export abstract class Extensible<
   }
 
   protected async initializePlugins(): Promise<void> {
+    // for every child-plugin of this extensible
     for (const key in this.plugins) {
       if (this.plugins.hasOwnProperty(key)) {
         const plugin = this.plugins[key];
@@ -65,19 +65,22 @@ export abstract class Extensible<
           ? _merge({}, this.config.plugin?.[key] || {}, plugin.config)
           : _merge({}, plugin.config, this.config.plugin?.[key] || {});
 
+        // overwrite config, this is just used, because the config-property is readonly
         Object.defineProperty(plugin, 'config', {
           enumerable: true,
           value: config,
         });
+        // if this extensible has no plugin-config for nested child-plugins, create it
         if (!this.config.plugin) {
           this.config.plugin = {};
         }
+        // make plugin-config of this extensible aware of the child-plugin's config
+        // this way the config-tree will be build with correct references
         this.config.plugin[key] = config;
 
-        if (plugin.initialize) {
-          await plugin.initialize(this);
-        }
+        await plugin.initialize?.(this);
 
+        // if the plugin extends Extensible and has installed child-plugins, initialize the plugin's child-plugins
         if (plugin instanceof Extensible && Object.keys(plugin.plugins).length) {
           await plugin.initializePlugins();
         }
@@ -86,6 +89,7 @@ export abstract class Extensible<
   }
 
   protected async mountPlugins(): Promise<void> {
+    // for every child-plugin of this extensible
     for (const key in this.plugins) {
       if (this.plugins.hasOwnProperty(key)) {
         const plugin = this.plugins[key];
@@ -93,19 +97,20 @@ export abstract class Extensible<
           continue;
         }
 
+        // get the current plugin's config
         const config = plugin.config;
 
-        Object.defineProperty(plugin, 'config', {
-          enumerable: true,
-          value: config,
-        });
-        await plugin.mount?.(this);
-
+        // if this extensible has no plugin-config for nested child-plugins, create it
         if (!this.config.plugin) {
           this.config.plugin = {};
         }
+        // make plugin-config of this extensible aware of the child-plugin's config
+        // this way the config-tree will be rebuild with correct references
         this.config.plugin[key] = config;
 
+        await plugin.mount?.(this);
+
+        // if the plugin extends Extensible and has installed child-plugins, mount the plugin's child-plugins
         if (plugin instanceof Extensible && (plugin as Extensible).plugins) {
           await plugin.mountPlugins();
         }

--- a/framework/src/Extensible.ts
+++ b/framework/src/Extensible.ts
@@ -16,15 +16,16 @@ export interface ExtensibleConfig extends PluginConfig {
   plugin?: ExtensiblePluginConfig;
 }
 
-export type ExtensibleInitConfig<CONFIG extends ExtensibleConfig = ExtensibleConfig> =
-  DeepPartial<CONFIG> & {
-    plugin?: never;
-    plugins?: Plugin[];
-  };
+export type ExtensibleInitConfig<CONFIG extends ExtensibleConfig = ExtensibleConfig> = DeepPartial<
+  CONFIG
+> & {
+  plugin?: never;
+  plugins?: Plugin[];
+};
 
 export abstract class Extensible<
   CONFIG extends ExtensibleConfig = ExtensibleConfig,
-  MIDDLEWARES extends string[] = string[],
+  MIDDLEWARES extends string[] = string[]
 > extends Plugin<CONFIG> {
   readonly plugins: ExtensiblePlugins;
   readonly middlewareCollection: MiddlewareCollection<MIDDLEWARES>;
@@ -97,16 +98,13 @@ export abstract class Extensible<
           continue;
         }
 
-        // get the current plugin's config
-        const config = plugin.config;
-
         // if this extensible has no plugin-config for nested child-plugins, create it
         if (!this.config.plugin) {
           this.config.plugin = {};
         }
         // make plugin-config of this extensible aware of the child-plugin's config
         // this way the config-tree will be rebuild with correct references
-        this.config.plugin[key] = config;
+        this.config.plugin[key] = plugin.config;
 
         await plugin.mount?.(this);
 

--- a/framework/src/Middleware.ts
+++ b/framework/src/Middleware.ts
@@ -20,7 +20,7 @@ export class Middleware<NAME extends string = string> {
       return;
     }
     for (let i = 0, len = this.fns.length; i < len; i++) {
-      await this.fns[i].call(null, jovo);
+      await this.fns[i](jovo);
     }
   }
 

--- a/framework/src/NluPlugin.ts
+++ b/framework/src/NluPlugin.ts
@@ -27,18 +27,20 @@ export abstract class NluPlugin<
     } as CONFIG;
   }
 
-  install(parent: Extensible): Promise<void> | void {
+  mount(parent: Extensible): Promise<void> | void {
     if (!(parent instanceof Platform)) {
       throw new InvalidParentError(this.constructor.name, 'Platform');
     }
-    parent.middlewareCollection.use('interpretation.nlu', this.nlu);
+    parent.middlewareCollection.use('interpretation.nlu', (jovo) => {
+      return this.nlu(jovo);
+    });
   }
 
   protected isInputTypeSupported(inputType: InputTypeLike): boolean {
     return this.config.input.supportedTypes.includes(inputType);
   }
 
-  protected nlu = async (jovo: Jovo): Promise<void> => {
+  protected async nlu(jovo: Jovo): Promise<void> {
     if (!jovo.$input.text || !this.isInputTypeSupported(jovo.$input.type)) {
       return;
     }
@@ -47,5 +49,5 @@ export abstract class NluPlugin<
       jovo.$input.nlu = nluProcessResult;
       jovo.$entities = nluProcessResult.entities || {};
     }
-  };
+  }
 }

--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -42,6 +42,7 @@ export abstract class Platform<
   abstract isRequestRelated(request: REQUEST | AnyObject): boolean;
 
   abstract isResponseRelated(response: RESPONSE | AnyObject): boolean;
+
   abstract finalizeResponse(
     response: RESPONSE | RESPONSE[],
     jovo: JOVO,
@@ -51,11 +52,10 @@ export abstract class Platform<
     return new MiddlewareCollection<PlatformMiddlewares>(...APP_MIDDLEWARES);
   }
 
-  install(parent: Extensible): void {
-    if (!(parent instanceof App)) {
-      throw new InvalidParentError(this.constructor.name, App);
+  mount(parent: Extensible): void {
+    if (!(parent instanceof HandleRequest)) {
+      throw new InvalidParentError(this.constructor.name, HandleRequest);
     }
-
     // propagate runs of middlewares of parent to middlewares of this
     this.middlewareCollection.names.forEach((middlewareName) => {
       parent.middlewareCollection.use(middlewareName, async (jovo) => {
@@ -80,6 +80,7 @@ export abstract class Platform<
   createUserInstance(jovo: JOVO): USER {
     return new this.userClass(jovo);
   }
+
   createDeviceInstance(jovo: JOVO): DEVICE {
     return new this.deviceClass(jovo);
   }

--- a/framework/src/Plugin.ts
+++ b/framework/src/Plugin.ts
@@ -22,6 +22,7 @@ export abstract class Plugin<CONFIG extends PluginConfig = PluginConfig> {
 
   /**
    * Lifecycle Hook: Called when the plugin is installed via `use`.
+   * This hook should be used for installing additional plugins or modifying the App-object in general.
    * Has to be synchronous.
    * @param parent
    */

--- a/framework/src/Plugin.ts
+++ b/framework/src/Plugin.ts
@@ -36,7 +36,7 @@ export abstract class Plugin<CONFIG extends PluginConfig = PluginConfig> {
 
   /**
    * Lifecycle Hook: Called when a copy of every plugin is created and mounted onto HandleRequest.
-   * This happens on every request.
+   * This happens on every request and should be used for registering middleware-functions.
    * Can be asynchronous.
    * @param parent
    */

--- a/framework/src/plugins/BasicLogging.ts
+++ b/framework/src/plugins/BasicLogging.ts
@@ -8,7 +8,7 @@ import { Plugin, PluginConfig } from '../Plugin';
 
 declare module '../interfaces' {
   interface RequestData {
-    _BASIC_LOGGING_START: number;
+    _BASIC_LOGGING_START?: number;
   }
 }
 
@@ -133,7 +133,9 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
 
   async logResponse(jovo: Jovo): Promise<void> {
     const basicLoggingEnd = new Date().getTime();
-    const duration = basicLoggingEnd - jovo.$data._BASIC_LOGGING_START;
+    const duration = jovo.$data._BASIC_LOGGING_START
+      ? basicLoggingEnd - jovo.$data._BASIC_LOGGING_START
+      : 0;
 
     if (!this.config.response) {
       return;

--- a/framework/src/plugins/BasicLogging.ts
+++ b/framework/src/plugins/BasicLogging.ts
@@ -3,7 +3,7 @@ import colorize from 'json-colorizer';
 import _get from 'lodash.get';
 import _set from 'lodash.set';
 import _unset from 'lodash.unset';
-import { App, Jovo } from '../index';
+import { HandleRequest, Jovo } from '../index';
 import { Plugin, PluginConfig } from '../Plugin';
 
 declare module '../Extensible' {
@@ -70,12 +70,16 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
     };
   }
 
-  install(parent: App): Promise<void> | void {
-    parent.middlewareCollection.use('request.start', this.logRequest);
-    parent.middlewareCollection.use('response.end', this.logResponse);
+  mount(parent: HandleRequest): Promise<void> | void {
+    parent.middlewareCollection.use('request.start', (jovo) => {
+      return this.logRequest(jovo);
+    });
+    parent.middlewareCollection.use('response.end', (jovo: Jovo) => {
+      return this.logResponse(jovo);
+    });
   }
 
-  logRequest = async (jovo: Jovo): Promise<void> => {
+  async logRequest(jovo: Jovo): Promise<void> {
     jovo.$data._BASIC_LOGGING_START = new Date().getTime();
 
     if (!this.config.request) {
@@ -119,8 +123,9 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
     }
 
     /* eslint-enable no-console */
-  };
-  logResponse = async (jovo: Jovo): Promise<void> => {
+  }
+
+  async logResponse(jovo: Jovo): Promise<void> {
     jovo.$data._BASIC_LOGGING_STOP = new Date().getTime();
     const duration = jovo.$data._BASIC_LOGGING_STOP - jovo.$data._BASIC_LOGGING_START;
 
@@ -176,5 +181,5 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
       );
     }
     /* eslint-enable no-console */
-  };
+  }
 }

--- a/framework/src/plugins/BasicLogging.ts
+++ b/framework/src/plugins/BasicLogging.ts
@@ -6,6 +6,12 @@ import _unset from 'lodash.unset';
 import { HandleRequest, Jovo } from '../index';
 import { Plugin, PluginConfig } from '../Plugin';
 
+declare module '../HandleRequest' {
+  interface HandleRequest {
+    basicLoggingStart: number;
+  }
+}
+
 declare module '../Extensible' {
   interface ExtensiblePluginConfig {
     BasicLogging?: BasicLoggingConfig;
@@ -80,7 +86,7 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
   }
 
   async logRequest(jovo: Jovo): Promise<void> {
-    jovo.$data._BASIC_LOGGING_START = new Date().getTime();
+    jovo.$handleRequest.basicLoggingStart = new Date().getTime();
 
     if (!this.config.request) {
       return;
@@ -126,8 +132,8 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
   }
 
   async logResponse(jovo: Jovo): Promise<void> {
-    jovo.$data._BASIC_LOGGING_STOP = new Date().getTime();
-    const duration = jovo.$data._BASIC_LOGGING_STOP - jovo.$data._BASIC_LOGGING_START;
+    const basicLoggingEnd = new Date().getTime();
+    const duration = basicLoggingEnd - jovo.$handleRequest.basicLoggingStart;
 
     if (!this.config.response) {
       return;

--- a/framework/src/plugins/BasicLogging.ts
+++ b/framework/src/plugins/BasicLogging.ts
@@ -6,9 +6,9 @@ import _unset from 'lodash.unset';
 import { HandleRequest, Jovo } from '../index';
 import { Plugin, PluginConfig } from '../Plugin';
 
-declare module '../HandleRequest' {
-  interface HandleRequest {
-    basicLoggingStart: number;
+declare module '../interfaces' {
+  interface RequestData {
+    _BASIC_LOGGING_START: number;
   }
 }
 
@@ -86,7 +86,7 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
   }
 
   async logRequest(jovo: Jovo): Promise<void> {
-    jovo.$handleRequest.basicLoggingStart = new Date().getTime();
+    jovo.$data._BASIC_LOGGING_START = new Date().getTime();
 
     if (!this.config.request) {
       return;
@@ -133,7 +133,7 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
 
   async logResponse(jovo: Jovo): Promise<void> {
     const basicLoggingEnd = new Date().getTime();
-    const duration = basicLoggingEnd - jovo.$handleRequest.basicLoggingStart;
+    const duration = basicLoggingEnd - jovo.$data._BASIC_LOGGING_START;
 
     if (!this.config.response) {
       return;

--- a/framework/src/plugins/DbPlugin.ts
+++ b/framework/src/plugins/DbPlugin.ts
@@ -75,7 +75,7 @@ export abstract class DbPlugin<
     } as unknown as CONFIG;
   }
 
-  mount(parent: HandleRequest) {
+  mount(parent: HandleRequest): void {
     if (!(parent instanceof HandleRequest)) {
       throw new InvalidParentError(this.constructor.name, HandleRequest);
     }

--- a/framework/src/plugins/DbPlugin.ts
+++ b/framework/src/plugins/DbPlugin.ts
@@ -22,9 +22,9 @@ export interface DbItem extends AnyObject {
   updatedAt?: string;
 }
 
-export abstract class DbPlugin<CONFIG extends DbPluginConfig = DbPluginConfig> extends Plugin<
-  CONFIG
-> {
+export abstract class DbPlugin<
+  CONFIG extends DbPluginConfig = DbPluginConfig,
+> extends Plugin<CONFIG> {
   constructor(config?: ExtensibleInitConfig<CONFIG>) {
     super(config);
 
@@ -50,7 +50,7 @@ export abstract class DbPlugin<CONFIG extends DbPluginConfig = DbPluginConfig> e
   }
 
   getDefaultConfig(): CONFIG {
-    return ({
+    return {
       enabled: true,
       storedElements: {
         user: {
@@ -72,7 +72,7 @@ export abstract class DbPlugin<CONFIG extends DbPluginConfig = DbPluginConfig> e
         createdAt: true,
         updatedAt: true,
       },
-    } as unknown) as CONFIG;
+    } as unknown as CONFIG;
   }
 
   mount(parent: HandleRequest) {

--- a/framework/src/plugins/HandlerPlugin.ts
+++ b/framework/src/plugins/HandlerPlugin.ts
@@ -1,4 +1,4 @@
-import { App, PluginConfig, StateStackItem } from '../index';
+import { HandleRequest, PluginConfig, StateStackItem } from '../index';
 import { Jovo } from '../Jovo';
 import { Plugin } from '../Plugin';
 
@@ -19,11 +19,13 @@ export class HandlerPlugin extends Plugin<HandlerPluginConfig> {
     return {};
   }
 
-  install(parent: App): Promise<void> | void {
-    parent.middlewareCollection.use('dialogue.logic', this.handle);
+  mount(parent: HandleRequest): Promise<void> | void {
+    parent.middlewareCollection.use('dialogue.logic', (jovo) => {
+      return this.handle(jovo);
+    });
   }
 
-  private handle = async (jovo: Jovo) => {
+  private async handle(jovo: Jovo): Promise<void> {
     if (!jovo.$route) {
       return;
     }
@@ -54,5 +56,5 @@ export class HandlerPlugin extends Plugin<HandlerPluginConfig> {
       jovo,
       handler: jovo.$route.resolved.handler,
     });
-  };
+  }
 }

--- a/framework/src/plugins/OutputPlugin.ts
+++ b/framework/src/plugins/OutputPlugin.ts
@@ -1,5 +1,5 @@
 import { OutputTemplateConverter } from '@jovotech/output';
-import { App } from '../App';
+import { HandleRequest } from '../HandleRequest';
 import { Jovo } from '../Jovo';
 import { Plugin, PluginConfig } from '../Plugin';
 
@@ -20,14 +20,16 @@ export class OutputPlugin extends Plugin<OutputPluginConfig> {
     return {};
   }
 
-  install(app: App): Promise<void> | void {
-    app.middlewareCollection.get('response.output')?.use(this.handle);
+  mount(parent: HandleRequest): Promise<void> | void {
+    parent.middlewareCollection.use('response.output', (jovo) => {
+      return this.handle(jovo);
+    });
   }
 
-  private handle = async (jovo: Jovo) => {
+  private async handle(jovo: Jovo): Promise<void> {
     const converter = new OutputTemplateConverter(jovo.$platform.outputTemplateConverterStrategy);
     // TODO: catch possible errors
     const response = await converter.toResponse(jovo.$output);
     jovo.$response = await jovo.$platform.finalizeResponse(response, jovo);
-  };
+  }
 }

--- a/framework/src/plugins/RouterPlugin.ts
+++ b/framework/src/plugins/RouterPlugin.ts
@@ -32,14 +32,14 @@ export class RouterPlugin extends Plugin<RouterPluginConfig> {
     return {};
   }
 
+  initialize(parent: App): Promise<void> | void {
+    return this.checkForDuplicateGlobalHandlers(parent);
+  }
+
   mount(parent: HandleRequest): Promise<void> | void {
     parent.middlewareCollection.use('dialogue.router', (jovo) => {
       return this.setRoute(jovo);
     });
-  }
-
-  initialize(parent: App): Promise<void> | void {
-    return this.checkForDuplicateGlobalHandlers(parent);
   }
 
   private async setRoute(jovo: Jovo): Promise<void> {

--- a/framework/src/plugins/RouterPlugin.ts
+++ b/framework/src/plugins/RouterPlugin.ts
@@ -66,9 +66,8 @@ export class RouterPlugin extends Plugin<RouterPluginConfig> {
       const globalHandlerMap: Record<string, HandlerMetadata[]> = {};
 
       app.componentTree.forEach((node) => {
-        const componentHandlerMetadata = MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(
-          node.metadata.target,
-        );
+        const componentHandlerMetadata =
+          MetadataStorage.getInstance().getMergedHandlerMetadataOfComponent(node.metadata.target);
         componentHandlerMetadata.forEach((handlerMetadata) => {
           handlerMetadata.globalIntentNames.forEach((globalIntentName) => {
             const mappedIntentName =

--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -1,14 +1,4 @@
 import {
-  App,
-  DbItem,
-  DbPlugin,
-  DbPluginConfig,
-  Jovo,
-  PersistableSessionData,
-  PersistableUserData,
-  UnknownObject,
-} from '@jovotech/framework';
-import {
   CreateTableCommand,
   DescribeTableCommand,
   DynamoDBClient,
@@ -17,6 +7,15 @@ import {
   PutItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+  DbItem,
+  DbPlugin,
+  DbPluginConfig,
+  Jovo,
+  PersistableSessionData,
+  PersistableUserData,
+  UnknownObject,
+} from '@jovotech/framework';
 
 export interface DynamoDbConfig extends DbPluginConfig {
   table: {
@@ -81,12 +80,7 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
     }
   }
 
-  async install(parent: App): Promise<void> {
-    parent.middlewareCollection.use('request.end', this.loadData);
-    parent.middlewareCollection.use('response.start', this.saveData);
-  }
-
-  createTable = async (): Promise<void> => {
+  async createTable(): Promise<void> {
     const params = {
       AttributeDefinitions: [
         {
@@ -108,9 +102,9 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
     };
 
     await this.client.send(new CreateTableCommand(params));
-  };
+  }
 
-  getDbItem = async (primaryKey: string): Promise<DbItem> => {
+  async getDbItem(primaryKey: string): Promise<DbItem> {
     const params = {
       ConsistentRead: true,
       Key: {
@@ -120,9 +114,9 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
     };
     const data = await this.client.send(new GetItemCommand(params));
     return data.Item as DbItem;
-  };
+  }
 
-  loadData = async (jovo: Jovo): Promise<void> => {
+  async loadData(jovo: Jovo): Promise<void> {
     this.checkRequirements();
     const dbItem = await this.getDbItem(jovo.$user.id);
 
@@ -130,9 +124,9 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
       jovo.$user.isNew = false;
       jovo.setPersistableData(unmarshall(dbItem), this.config.storedElements);
     }
-  };
+  }
 
-  saveData = async (jovo: Jovo): Promise<void> => {
+  async saveData(jovo: Jovo): Promise<void> {
     this.checkRequirements();
 
     const params = {
@@ -153,14 +147,14 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
         Item: marshall(item, { removeUndefinedValues: true }),
       }),
     );
-  };
+  }
 
-  checkRequirements = (): void | Error => {
+  checkRequirements(): void | Error {
     if (!this.config.table.primaryKeyColumn) {
       throw new Error('this.config.table.primaryKeyColumn must not be undefined');
     }
     if (!this.config.table.name) {
       throw new Error('this.config.table.name must not be undefined');
     }
-  };
+  }
 }

--- a/integrations/db-filedb/src/FileDb.ts
+++ b/integrations/db-filedb/src/FileDb.ts
@@ -1,4 +1,4 @@
-import { App, DbItem, DbPlugin, DbPluginConfig, Jovo } from '@jovotech/framework';
+import { DbItem, DbPlugin, DbPluginConfig, Jovo } from '@jovotech/framework';
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
@@ -28,11 +28,6 @@ export class FileDb extends DbPlugin<FileDbConfig> {
     return path.join(process.cwd(), 'dist', this.config.pathToFile);
   }
 
-  async install(parent: App): Promise<void> {
-    parent.middlewareCollection.use('request.end', this.loadData);
-    parent.middlewareCollection.use('response.start', this.saveData);
-  }
-
   async initialize(): Promise<void> {
     const pathToFileDir = path.dirname(this.pathToFile);
 
@@ -48,24 +43,24 @@ export class FileDb extends DbPlugin<FileDbConfig> {
     }
   }
 
-  getDbItem = async (primaryKey: string): Promise<DbItem> => {
+  async getDbItem(primaryKey: string): Promise<DbItem> {
     const fileDataStr = await fs.promises.readFile(this.pathToFile, 'utf8');
     const users = fileDataStr.length > 0 ? JSON.parse(fileDataStr) : [];
 
     return users.find((userItem: DbItem) => {
       return userItem.id === primaryKey;
     });
-  };
+  }
 
-  loadData = async (jovo: Jovo): Promise<void> => {
+  async loadData(jovo: Jovo): Promise<void> {
     const dbItem = await this.getDbItem(jovo.$user.id);
     if (dbItem) {
       jovo.$user.isNew = false;
       jovo.setPersistableData(dbItem, this.config.storedElements);
     }
-  };
+  }
 
-  saveData = async (jovo: Jovo): Promise<void> => {
+  async saveData(jovo: Jovo): Promise<void> {
     const fileDataStr = await fs.promises.readFile(this.pathToFile, 'utf8');
     const users = fileDataStr.length > 0 ? JSON.parse(fileDataStr) : [];
     const id = jovo.$user.id;
@@ -90,5 +85,5 @@ export class FileDb extends DbPlugin<FileDbConfig> {
       }
     }
     return fs.promises.writeFile(this.pathToFile, JSON.stringify(users, null, 2));
-  };
+  }
 }

--- a/integrations/nlu-snips/src/SnipsNlu.ts
+++ b/integrations/nlu-snips/src/SnipsNlu.ts
@@ -42,12 +42,18 @@ export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
   }
 
   async process(jovo: Jovo, text: string): Promise<NluData | undefined> {
+    if (!jovo.$session.id) {
+      throw new JovoError({
+        message: `Can not send request to Snips-NLU. Session-ID is missing.`,
+      });
+    }
+
     const config: AxiosRequestConfig = {
       url: this.config.serverPath,
       params: {
         locale: this.getLocale(jovo.$request).substring(0, 2),
         engine_id: this.config.engineId,
-        session_id: jovo.$session.id!,
+        session_id: jovo.$session.id,
       },
       data: { text },
     };

--- a/integrations/nlu-snips/src/SnipsNlu.ts
+++ b/integrations/nlu-snips/src/SnipsNlu.ts
@@ -17,10 +17,12 @@ import { v4 as uuidV4 } from 'uuid';
 import { SnipsNluConfig, SnipsNluResponse } from './interfaces';
 
 export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
-  install(parent: Extensible): Promise<void> | void {
-    super.install(parent);
+  mount(parent: Extensible): Promise<void> | void {
+    super.mount(parent);
 
-    parent.middlewareCollection.use('response.output', this.trainDynamicEntities.bind(this));
+    parent.middlewareCollection.use('response.output', (jovo) => {
+      return this.trainDynamicEntities(jovo);
+    });
   }
 
   getDefaultConfig(): SnipsNluConfig {
@@ -49,6 +51,7 @@ export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
       },
       data: { text },
     };
+
     const snipsNluResponse: SnipsNluResponse = await this.sendRequestToSnips(config);
     const nluData: NluData = {};
     if (snipsNluResponse.intent.intentName) {

--- a/integrations/nlu-snips/src/SnipsNlu.ts
+++ b/integrations/nlu-snips/src/SnipsNlu.ts
@@ -95,7 +95,7 @@ export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
         !listen.entities ||
         listen.entities.mode === DynamicEntitiesMode.Clear
       ) {
-        return;
+        continue;
       }
 
       for (const [entityKey, entityData] of Object.entries(listen.entities.types || {})) {
@@ -178,7 +178,7 @@ export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
         }
 
         const config: AxiosRequestConfig = {
-          url: '/engine/train/dynamic-entities',
+          url: this.config.dynamicEntities.serverPath,
           params: {
             locale: locale.substring(0, 2),
             entity: entityKey,

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -141,6 +141,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
   }
 
   mount(parent: HandleRequest): Promise<void> | void {
+    this.socket = parent.app.plugins.JovoDebugger?.socket;
     parent.middlewareCollection.use('request.start', (jovo) => {
       return this.onRequest(jovo);
     });

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -126,18 +126,27 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       throw new Error();
     }
 
-    this.socket.on(JovoDebuggerEvent.DebuggingAvailable, this.onDebuggingAvailable);
-    this.socket.on(
-      JovoDebuggerEvent.DebuggerLanguageModelRequest,
-      this.onDebuggerLanguageModelRequest,
-    );
-    this.socket.on(JovoDebuggerEvent.DebuggerRequest, this.onDebuggerRequest.bind(this, app));
-
-    app.middlewareCollection.use('request.start', this.onRequest);
-    app.middlewareCollection.use('response.end', this.onResponse);
+    this.socket.on(JovoDebuggerEvent.DebuggingAvailable, () => {
+      return this.onDebuggingAvailable();
+    });
+    this.socket.on(JovoDebuggerEvent.DebuggerLanguageModelRequest, () => {
+      return this.onDebuggerLanguageModelRequest();
+    });
+    this.socket.on(JovoDebuggerEvent.DebuggerRequest, (request: AnyObject) => {
+      return this.onDebuggerRequest(app, request);
+    });
 
     this.patchHandleRequestToIncludeUniqueId();
     this.patchPlatformsToCreateJovoAsProxy(app.platforms);
+  }
+
+  mount(parent: HandleRequest): Promise<void> | void {
+    parent.middlewareCollection.use('request.start', (jovo) => {
+      return this.onRequest(jovo);
+    });
+    parent.middlewareCollection.use('response.end', (jovo) => {
+      return this.onResponse(jovo);
+    });
   }
 
   // TODO: maybe find a better solution although this might work well because it is independent of the RIDR-pipeline
@@ -231,7 +240,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
     };
   }
 
-  private onDebuggingAvailable = () => {
+  private onDebuggingAvailable(): void {
     if (!this.socket) {
       // TODO: implement error
       throw new Error();
@@ -252,9 +261,9 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       propagateStreamAsLog(process.stderr, this.socket);
       this.hasOverriddenWrite = true;
     }
-  };
+  }
 
-  private onDebuggerLanguageModelRequest = async () => {
+  private async onDebuggerLanguageModelRequest(): Promise<void> {
     if (!this.config.languageModelEnabled) return;
     if (!this.config.languageModelPath || !this.config.debuggerJsonPath) {
       // TODO: determine what to do (warning or error or nothing)
@@ -274,7 +283,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       console.warn('Can not emit language-model: Could not retrieve language-model.');
     }
     // TODO implement sending debuggerConfig if that is required
-  };
+  }
 
   private async getLanguageModel(): Promise<AnyObject> {
     const languageModel: AnyObject = {};
@@ -309,11 +318,11 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
     return languageModel;
   }
 
-  private onDebuggerRequest = async (app: App, request: AnyObject) => {
+  private async onDebuggerRequest(app: App, request: AnyObject): Promise<void> {
     await app.handle(new MockServer(request));
-  };
+  }
 
-  private onRequest = (jovo: Jovo) => {
+  private onRequest(jovo: Jovo) {
     if (!this.socket) {
       // TODO: implement error
       throw new Error();
@@ -323,9 +332,9 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       data: jovo.$request,
     };
     this.socket.emit(JovoDebuggerEvent.AppRequest, payload);
-  };
+  }
 
-  private onResponse = (jovo: Jovo) => {
+  private onResponse(jovo: Jovo) {
     if (!this.socket) {
       // TODO: implement error
       throw new Error();
@@ -335,7 +344,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       data: jovo.$response,
     };
     this.socket.emit(JovoDebuggerEvent.AppResponse, payload);
-  };
+  }
 
   private async connectToWebhook() {
     const webhookId = await this.retrieveLocalWebhookId();

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -21,7 +21,8 @@ export class AlexaPlatform extends Platform<
   AlexaPlatform,
   AlexaConfig
 > {
-  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy = new AlexaOutputTemplateConverterStrategy();
+  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy =
+    new AlexaOutputTemplateConverterStrategy();
   requestClass = AlexaRequest;
   jovoClass = Alexa;
   userClass = AlexaUser;

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -21,8 +21,7 @@ export class AlexaPlatform extends Platform<
   AlexaPlatform,
   AlexaConfig
 > {
-  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy =
-    new AlexaOutputTemplateConverterStrategy();
+  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy = new AlexaOutputTemplateConverterStrategy();
   requestClass = AlexaRequest;
   jovoClass = Alexa;
   userClass = AlexaUser;
@@ -37,7 +36,10 @@ export class AlexaPlatform extends Platform<
   }
 
   mount(parent: HandleRequest): void {
-    parent.middlewareCollection.use('request.start', this.onRequestStart);
+    super.mount(parent);
+    parent.middlewareCollection.use('request.start', (jovo) => {
+      return this.onRequestStart(jovo);
+    });
   }
 
   isRequestRelated(request: AnyObject | AlexaRequest): boolean {
@@ -56,7 +58,7 @@ export class AlexaPlatform extends Platform<
     return response;
   }
 
-  private onRequestStart = (jovo: Jovo) => {
+  private onRequestStart(jovo: Jovo): void {
     if (!(jovo.$platform instanceof AlexaPlatform)) {
       return;
     }
@@ -80,5 +82,5 @@ export class AlexaPlatform extends Platform<
         }
       });
     }
-  };
+  }
 }

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -21,8 +21,7 @@ export class AlexaPlatform extends Platform<
   AlexaPlatform,
   AlexaConfig
 > {
-  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy =
-    new AlexaOutputTemplateConverterStrategy();
+  outputTemplateConverterStrategy: AlexaOutputTemplateConverterStrategy = new AlexaOutputTemplateConverterStrategy();
   requestClass = AlexaRequest;
   jovoClass = Alexa;
   userClass = AlexaUser;
@@ -38,7 +37,7 @@ export class AlexaPlatform extends Platform<
 
   mount(parent: HandleRequest): void {
     super.mount(parent);
-    parent.middlewareCollection.use('request.start', (jovo) => {
+    this.middlewareCollection.use('request.start', (jovo) => {
       return this.onRequestStart(jovo);
     });
   }
@@ -60,9 +59,6 @@ export class AlexaPlatform extends Platform<
   }
 
   private onRequestStart(jovo: Jovo): void {
-    if (!(jovo.$platform instanceof AlexaPlatform)) {
-      return;
-    }
     // Generate generic output to APL if supported and set in config
     this.outputTemplateConverterStrategy.config.genericOutputToApl = !!(
       jovo.$alexa?.$request?.isAplSupported() && this.config.output?.genericOutputToApl

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
@@ -38,7 +38,14 @@ export class FacebookMessengerRequest extends JovoRequest {
 
   getInputType(): InputTypeLike | undefined {
     const postbackPayload = this.messaging?.[0]?.postback?.payload;
-    return postbackPayload === FACEBOOK_LAUNCH_PAYLOAD ? InputType.Launch : InputType.Intent;
+
+    if (postbackPayload === FACEBOOK_LAUNCH_PAYLOAD) {
+      return InputType.Launch;
+    }
+    if (this.nlu?.intentName) {
+      return InputType.Intent;
+    }
+    return InputType.Text;
   }
   getInputText(): JovoInput['text'] {
     return this.messaging?.[0]?.message?.text || this.messaging?.[0]?.postback?.title;

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -39,9 +39,11 @@ export class GoogleAssistantPlatform extends Platform<
     return {};
   }
 
-  install(parent: App): void {
-    super.install(parent);
-    parent.middlewareCollection.use('request.start', this.onRequestStart);
+  mount(parent: App): void {
+    super.mount(parent);
+    parent.middlewareCollection.use('request.start', (jovo) => {
+      return this.onRequestStart(jovo);
+    });
   }
 
   initialize(parent: App): void {
@@ -78,7 +80,7 @@ export class GoogleAssistantPlatform extends Platform<
     return response;
   }
 
-  onRequestStart: MiddlewareFunction = (jovo: Jovo) => {
+  onRequestStart(jovo: Jovo): void {
     const request = jovo.$googleAssistant?.$request;
     // if it is a selection-event
     if (
@@ -91,5 +93,5 @@ export class GoogleAssistantPlatform extends Platform<
     ) {
       jovo.$input.intent = request.session.params._GOOGLE_ASSISTANT_SELECTION_INTENT_;
     }
-  };
+  }
 }

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -34,7 +34,7 @@ export class GoogleAssistantPlatform extends Platform<
 
   mount(parent: App): void {
     super.mount(parent);
-    parent.middlewareCollection.use('request.start', (jovo) => {
+    this.middlewareCollection.use('request.start', (jovo) => {
       return this.onRequestStart(jovo);
     });
   }

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -1,11 +1,4 @@
-import {
-  AnyObject,
-  App,
-  ExtensibleConfig,
-  Jovo,
-  MiddlewareFunction,
-  Platform,
-} from '@jovotech/framework';
+import { AnyObject, App, ExtensibleConfig, Jovo, Platform } from '@jovotech/framework';
 import {
   GoogleAssistantOutputTemplateConverterStrategy,
   GoogleAssistantResponse,

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -55,9 +55,11 @@ export class GoogleBusinessPlatform extends Platform<
     };
   }
 
-  install(parent: Extensible): void {
-    super.install(parent);
-    parent.middlewareCollection.use('before.request.start', this.beforeRequestStart);
+  mount(parent: Extensible): void {
+    super.mount(parent);
+    parent.middlewareCollection.use('before.request.start', (jovo) => {
+      return this.beforeRequestStart(jovo);
+    });
   }
 
   isRequestRelated(request: AnyObject | GoogleBusinessRequest): boolean {
@@ -87,11 +89,11 @@ export class GoogleBusinessPlatform extends Platform<
     return response;
   }
 
-  private beforeRequestStart = (jovo: Jovo) => {
+  private beforeRequestStart(jovo: Jovo): void {
     // if the request is a typing-indicator-request or a receipt-request, just ignore it and send 200 to not get it sent multiple times
     if (jovo.$googleBusiness?.$request?.userStatus || jovo.$googleBusiness?.$request?.receipts) {
       jovo.$response = {} as GoogleBusinessResponse;
       jovo.$handleRequest.stopMiddlewareExecution();
     }
-  };
+  }
 }

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -55,7 +55,7 @@ export class GoogleBusinessPlatform extends Platform<
     };
   }
 
-  mount(parent: Extensible): void {
+  mount(parent: Extensible): Promise<void> | void {
     super.mount(parent);
     parent.middlewareCollection.use('before.request.start', (jovo) => {
       return this.beforeRequestStart(jovo);

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -57,7 +57,7 @@ export class GoogleBusinessPlatform extends Platform<
 
   mount(parent: Extensible): Promise<void> | void {
     super.mount(parent);
-    parent.middlewareCollection.use('before.request.start', (jovo) => {
+    this.middlewareCollection.use('before.request.start', (jovo) => {
       return this.beforeRequestStart(jovo);
     });
   }

--- a/platforms/platform-googlebusiness/src/GoogleBusinessRequest.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessRequest.ts
@@ -61,7 +61,7 @@ export class GoogleBusinessRequest extends JovoRequest {
   }
 
   getInputType(): InputTypeLike | undefined {
-    return InputType.Intent;
+    return InputType.Text;
   }
   getInputText(): JovoInput['text'] {
     return (


### PR DESCRIPTION
## Proposed changes
- Refactor mounting to first register the plugin's config and then mount it
- Refactor middleware registering to only be called from within `mount`
- Arrow functions should not be used for middleware-functions
- Refactor `DbPlugin` to contain abstract methods
- Refactor logic in `BasicLogging` to persist start in `HandleRequest` instead of request-data
- Change input-type that is retrieved from the request for FacebookMessenger and GoogleBusiness

__Breaking Change:__ 💥 Classes that extend `Plugin` and use the parent's `MiddlewareCollection` will have to do that in `mount` and not `install`. Additionally, the function that is passed to the middleware should not be an arrow-function otherwise `this` will not reference the request-copy of the plugin. That means this update will only potentially break custom plugins.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed