### PR TITLE
🏷️ 🐛 Fix rest-parameters for decorators

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -97,15 +97,16 @@ They include:
 * [`global`](#global-handlers)
 * [`subState`](#substate)
 * [`prioritizedOverUnhandled`](#prioritizedOverUnhandled)
+
 #### Intents
 
-The `intents` property specifies which incoming intents the handler should be able to fulfill. The property can be both a string or an array.
+The `intents` property specifies which incoming intents the handler should be able to fulfill.
 
 For example, this handler responds to only the `ShowMenuIntent`:
 
 ```typescript
 @Handle({
-  intents: 'ShowMenuIntent'
+  intents: ['ShowMenuIntent']
 })
 showMenu() {
   // ...
@@ -127,7 +128,7 @@ Sometimes, a handler should be [`global`](#global-handlers) for only some of the
 
 ```typescript
 @Handle({
-  intents: [ { name: 'ShowMenuIntent', global: true }, 'YesIntent' ]
+  intents: [{ name: 'ShowMenuIntent', global: true }, 'YesIntent']
 })
 showMenu() {
   // ...
@@ -158,11 +159,11 @@ showMenu() {
 
 #### Types
 
-The `types` property specifies which [input types](./input.md) the handler should be able to fulfill. The property can be both a string or an array of strings.
+The `types` property specifies which [input types](./input.md) the handler should be able to fulfill.
 
 ```typescript
 @Handle({
-  types: 'LAUNCH',
+  types: ['LAUNCH'],
 })
 welcomeNewUser() {
   // ...
@@ -176,7 +177,7 @@ import { Types } from '@jovotech/framework';
 
 // ...
 
-@Types('LAUNCH')
+@Types(['LAUNCH'])
 welcomeNewUser() {
   // ...
 }
@@ -250,7 +251,7 @@ Alternatively, you can make an intent an object and add `global` to it:
 
 ```typescript
 @Handle({
-  intents: [ { name: 'ShowMenuIntent', global: true }, 'YesIntent' ]
+  intents: [{ name: 'ShowMenuIntent', global: true }, 'YesIntent']
 })
 showMenu() {
   // ...
@@ -298,7 +299,7 @@ import { SubState, Intents } from '@jovotech/framework';
 // ...
 
 @SubState('YesOrNoState')
-@Intents(['Intents'])
+@Intents(['YesIntent'])
 showMenu() {
   // ...
 }
@@ -343,12 +344,12 @@ Currently, they include:
 * [`if`](#if)
 #### Platforms
 
-You can specify that a handler is only responsible for specific platforms. The `platforms` property can be both a string or an array of strings with the names of each platform in camel case:
+You can specify that a handler is only responsible for specific platforms. The `platforms` property is an array of strings with the names of each platform in camel case:
 
 ```typescript
 @Handle({
   // ...
-  platforms: [ 'alexa', 'googleAssistant' ]
+  platforms: ['alexa', 'googleAssistant']
 })
 yourHandler() {
   // ...
@@ -362,7 +363,7 @@ import { Platforms } from '@jovotech/framework';
 
 // ...
 
-@Platforms('alexa')
+@Platforms(['alexa'])
 yourHandler() {
   // ...
 }
@@ -409,15 +410,15 @@ It's possible that multiple handlers are able to fulfill a request, for example:
 
 ```typescript
 @Handle({
-  intents: [ 'ShowMenuIntent' ]
+  intents: ['ShowMenuIntent']
 })
 showMenu() {
   // ...
 }
 
 @Handle({
-  intents: [ 'ShowMenuIntent' ],
-  platforms: [ 'alexa' ]
+  intents: ['ShowMenuIntent'],
+  platforms: ['alexa']
 })
 showMenuOnAlexa() {
   // ...

--- a/framework/src/decorators/Intents.ts
+++ b/framework/src/decorators/Intents.ts
@@ -1,10 +1,14 @@
 import { Intent } from '../interfaces';
-import { createHandlerOptionDecorator } from '../metadata/HandlerOptionMetadata';
+import {
+  createHandlerOptionDecorator,
+  getValuesOfDecoratorRestParameter,
+} from '../metadata/HandlerOptionMetadata';
 
-export function Intents(...intents: Array<string | Intent>): MethodDecorator;
 export function Intents(intents: Array<string | Intent>): MethodDecorator;
-export function Intents(intents: string | Intent | Array<string | Intent>): MethodDecorator {
+export function Intents(...intents: Array<string | Intent>): MethodDecorator;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function Intents(...intents: any[]): MethodDecorator {
   return createHandlerOptionDecorator({
-    intents: typeof intents === 'string' || !Array.isArray(intents) ? [intents] : intents,
+    intents: getValuesOfDecoratorRestParameter(intents),
   });
 }

--- a/framework/src/decorators/Platforms.ts
+++ b/framework/src/decorators/Platforms.ts
@@ -1,4 +1,4 @@
-import { OmitIndex, OutputTemplatePlatforms } from '../index';
+import { getValuesOfDecoratorRestParameter, OmitIndex, OutputTemplatePlatforms } from '../index';
 import { createHandlerOptionDecorator } from '../metadata/HandlerOptionMetadata';
 
 export type RegisteredPlatformName = Exclude<
@@ -6,12 +6,11 @@ export type RegisteredPlatformName = Exclude<
   number
 >;
 
-export function Platforms(...platforms: Array<RegisteredPlatformName | string>): MethodDecorator;
-export function Platforms(platforms: Array<RegisteredPlatformName | string>): MethodDecorator;
-export function Platforms(
-  platforms: RegisteredPlatformName | string | Array<RegisteredPlatformName | string>,
-): MethodDecorator {
+export function Platforms(platforms: Array<string | RegisteredPlatformName>): MethodDecorator;
+export function Platforms(...platforms: Array<string | RegisteredPlatformName>): MethodDecorator;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function Platforms(...platforms: any[]): MethodDecorator {
   return createHandlerOptionDecorator({
-    platforms: typeof platforms === 'string' ? [platforms] : platforms,
+    platforms: getValuesOfDecoratorRestParameter(platforms),
   });
 }

--- a/framework/src/decorators/Types.ts
+++ b/framework/src/decorators/Types.ts
@@ -1,10 +1,14 @@
 import { InputTypeLike } from '../JovoInput';
-import { createHandlerOptionDecorator } from '../metadata/HandlerOptionMetadata';
+import {
+  createHandlerOptionDecorator,
+  getValuesOfDecoratorRestParameter,
+} from '../metadata/HandlerOptionMetadata';
 
-export function Types(...types: InputTypeLike[]): MethodDecorator;
 export function Types(types: InputTypeLike[]): MethodDecorator;
-export function Types(types: InputTypeLike | InputTypeLike[]): MethodDecorator {
+export function Types(...types: InputTypeLike[]): MethodDecorator;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function Types(...types: any[]): MethodDecorator {
   return createHandlerOptionDecorator({
-    types: typeof types === 'string' ? [types] : types,
+    types: getValuesOfDecoratorRestParameter(types),
   });
 }

--- a/framework/src/metadata/HandlerOptionMetadata.ts
+++ b/framework/src/metadata/HandlerOptionMetadata.ts
@@ -3,6 +3,17 @@ import { HandleOptions } from './HandlerMetadata';
 import { MetadataStorage } from './MetadataStorage';
 import { MethodDecoratorMetadata } from './MethodDecoratorMetadata';
 
+/**
+ * Get values of the rest parameter of a decorator.
+ * Useful for following case:
+ * `@Intent(['foo', 'bar'])` in this case, the actual value in the intents-parameter is `[ ['foo', 'bar'] ]`, therefore we only need to return the inner array.
+ */
+export function getValuesOfDecoratorRestParameter<T>(restParameter: T[] | T[][]): T[] {
+  return restParameter.length && Array.isArray(restParameter[0])
+    ? restParameter[0]
+    : (restParameter as T[]);
+}
+
 export function createHandlerOptionDecorator<
   COMPONENT extends BaseComponent = BaseComponent,
   KEY extends keyof COMPONENT = keyof COMPONENT,


### PR DESCRIPTION
## Proposed changes
The previous implementation caused the transpiled JS to not have a rest-parameter and therefore omit every argument after the first. Now a rest-parameter will always be assumed and the possible types that are passed are limited by overloaded signatures. In case an array is passed, some special treatment was necessary because the actual value will be an array inside the rest-parameter-array.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed