### PR TITLE
✨♻️ Implement expiration of persisted session data as well as minor improvements to database plugins 

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -4,6 +4,7 @@ Jovo offers a variety of integrations that allow you to store elements like user
 
 - [Integrations](#integrations)
 - [Configuration](#configuration)
+  - [storedElements](#storedelements)
 
 ## Integrations
 
@@ -47,6 +48,8 @@ It includes:
 * A user `id` to identify the current user. This is either taken from the platform (e.g. an Alexa Skill user ID) or created internally by Jovo.
 * A `user` object that stores [user data](./data.md#user-data).
 * Timestamps `createdAt` and `updatedAt` that help debug users in large datasets.
+
+### storedElements
 
 There are also additional elements that can be stored in the database. These can be configured with `storedElements`, which makes it possible to granularly define which types of data should be stored in the database.
 

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -69,8 +69,52 @@ new FileDb({
 ```
 
 * `user`: Persist user data across sessions using `this.$user.data`. Enabled by default.
-* `session`: Persist session data across interactions using `this.$session.data`. This is necessary for some platforms (like Facebook Messenger) that don't allow for session storage.
+* [`session`](#session): Persist session data across interactions using `this.$session.data`. This is necessary for some platforms (like Facebook Messenger) that don't allow for session storage.
 * `history`: Persist an interaction history and define which elements (e.g. `nlu` or `output`) data you want to store from previous requests and responses.
 * `createdAt` and `updatedAt`: These timestamps are enabled by default.
 
 [Learn more about the different data types here](./data.md).
+
+
+#### session
+
+Platforms like [Facebook Messenger](https://v4.jovo.tech/marketplace/platform-facebookmessenger) or [Google Business Messages](https://v4.jovo.tech/marketplace/platform-googlebusiness) don't support session storage. This is why all [session data](./data.md#session-data) needs to be persisted in a database.
+
+```typescript
+new FileDb({
+  // ...
+  storedElements: {
+    // ...
+    session: true,
+  }
+}),
+```
+
+For platforms that do not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified with the `expiresAfterSeconds` option:
+
+```typescript
+new FileDb({
+  // ...
+  storedElements: {
+    // ...
+    session: {
+      expiresAfterSeconds: 900,
+    }
+  }
+}),
+```
+
+If the option is added, the `session` field is automatically enabled. However, you can also add `enabled` if you like:
+
+```typescript
+new FileDb({
+  // ...
+  storedElements: {
+    // ...
+    session: {
+      enabled: true,
+      expiresAfterSeconds: 900,
+    }
+  }
+}),
+```

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -440,14 +440,14 @@ export abstract class Jovo<
   setPersistableData(data: JovoPersistableData, config?: DbPluginStoredElementsConfig): void {
     const isStoredElementEnabled = (key: 'user' | 'session' | 'history') => {
       const value = config?.[key];
-      return !!(typeof value === 'object' ? value.enabled : value);
+      return typeof value === 'object' ? value.enabled !== false : !!value;
     };
 
     if (isStoredElementEnabled('user')) {
       this.$user.setPersistableData(data.user);
     }
     if (isStoredElementEnabled('session')) {
-      this.$session.setPersistableData(data.session);
+      this.$session.setPersistableData(data.session, config?.session);
     }
     if (isStoredElementEnabled('history')) {
       this.$history.setPersistableData(data.history);

--- a/framework/src/JovoSession.ts
+++ b/framework/src/JovoSession.ts
@@ -74,7 +74,7 @@ export class JovoSession {
     if (isExpired) {
       return this;
     }
-    // the loaded session can not be null because it was loaded from the database and is not expired
+    // the loaded session can not be new because it was loaded from the database and is not expired
     this.isNew = false;
 
     this.id = data?.id || this.id;

--- a/framework/src/JovoUser.ts
+++ b/framework/src/JovoUser.ts
@@ -29,12 +29,6 @@ export abstract class JovoUser<JOVO extends Jovo = Jovo> {
     return this;
   }
 
-  getDefaultPersistableData(): PersistableUserData {
-    return {
-      data: {},
-    };
-  }
-
   toJSON(): JovoUser<JOVO> {
     return { ...this, jovo: undefined };
   }

--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -6,6 +6,7 @@ import {
   APP_MIDDLEWARES,
   AppMiddlewares,
   Constructor,
+  DbPlugin,
   HandleRequest,
   InvalidParentError,
   Jovo,
@@ -83,5 +84,25 @@ export abstract class Platform<
 
   createDeviceInstance(jovo: JOVO): DEVICE {
     return new this.deviceClass(jovo);
+  }
+
+  protected enableDatabaseSessionStorage(jovo: Jovo): void {
+    const dbPlugins = Object.values(jovo.$handleRequest.plugins).filter(
+      (plugin) => plugin instanceof DbPlugin,
+    ) as DbPlugin[];
+
+    if (!dbPlugins.length) {
+      // eslint-disable-next-line no-console
+      console.warn('No database plugin is installed. Session storage can not be enabled.');
+    }
+
+    dbPlugins.forEach((dbPlugin) => {
+      if (!dbPlugin.config.storedElements) {
+        dbPlugin.config.storedElements = dbPlugin.getDefaultConfig().storedElements || {};
+      }
+      // eslint-disable-next-line no-console
+      console.warn(`Session storage was enabled for database plugin ${dbPlugin.constructor.name}`);
+      dbPlugin.config.storedElements.session = true;
+    });
   }
 }

--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -12,6 +12,7 @@ import {
   Jovo,
   JovoConstructor,
   JovoUser,
+  StoredElementSession,
 } from '.';
 import { Extensible, ExtensibleConfig } from './Extensible';
 import { JovoDevice, JovoDeviceConstructor } from './JovoDevice';
@@ -86,7 +87,10 @@ export abstract class Platform<
     return new this.deviceClass(jovo);
   }
 
-  protected enableDatabaseSessionStorage(jovo: Jovo): void {
+  protected enableDatabaseSessionStorage(
+    jovo: Jovo,
+    sessionConfig?: StoredElementSession & { enabled?: never },
+  ): void {
     const dbPlugins = Object.values(jovo.$handleRequest.plugins).filter(
       (plugin) => plugin instanceof DbPlugin,
     ) as DbPlugin[];
@@ -102,7 +106,12 @@ export abstract class Platform<
       }
       // eslint-disable-next-line no-console
       console.warn(`Session storage was enabled for database plugin ${dbPlugin.constructor.name}`);
-      dbPlugin.config.storedElements.session = true;
+
+      if (sessionConfig) {
+        dbPlugin.config.storedElements.session = { ...sessionConfig, enabled: true };
+      } else {
+        dbPlugin.config.storedElements.session = true;
+      }
     });
   }
 }

--- a/framework/src/interfaces.ts
+++ b/framework/src/interfaces.ts
@@ -48,7 +48,11 @@ export interface StoredElement extends UnknownObject {
   enabled?: boolean;
 }
 
-export interface StoredElementHistory extends StoredElement, UnknownObject {
+export interface StoredElementSession extends StoredElement {
+  expiresAfterSeconds?: number;
+}
+
+export interface StoredElementHistory extends StoredElement {
   size?: number;
   asr?: StoredElement | boolean;
   state?: StoredElement | boolean;
@@ -64,7 +68,7 @@ export interface DbPluginConfig extends PluginConfig {
 
 export interface DbPluginStoredElementsConfig extends UnknownObject {
   user?: StoredElement | boolean;
-  session?: StoredElement | boolean;
+  session?: StoredElementSession | boolean;
   history?: StoredElementHistory | boolean;
   createdAt?: StoredElement | boolean;
   updateAt?: StoredElement | boolean;

--- a/framework/src/plugins/DbPlugin.ts
+++ b/framework/src/plugins/DbPlugin.ts
@@ -12,6 +12,8 @@ import { PersistableSessionData } from '../JovoSession';
 import { PersistableUserData } from '../JovoUser';
 import { Plugin, PluginConfig } from '../Plugin';
 
+export const DEFAULT_SESSION_EXPIRES_AFTER_SECONDS = 900;
+
 export interface DbItem extends AnyObject {
   id?: string;
 
@@ -58,6 +60,7 @@ export abstract class DbPlugin<
         },
         session: {
           enabled: false,
+          expiresAfterSeconds: DEFAULT_SESSION_EXPIRES_AFTER_SECONDS,
         },
         history: {
           size: 3,
@@ -72,7 +75,7 @@ export abstract class DbPlugin<
         createdAt: true,
         updatedAt: true,
       },
-    } as unknown as CONFIG;
+    } as DbPluginConfig as CONFIG;
   }
 
   mount(parent: HandleRequest): void {

--- a/framework/src/plugins/DbPlugin.ts
+++ b/framework/src/plugins/DbPlugin.ts
@@ -80,7 +80,8 @@ export abstract class DbPlugin<
     for (const prop in persistableData) {
       if (
         persistableData.hasOwnProperty(prop) &&
-        (this.config.storedElements![prop] as StoredElement).enabled
+        (this.config.storedElements?.[prop] === true ||
+          (this.config.storedElements?.[prop] as StoredElement).enabled)
       ) {
         if (prop === 'history') {
           // different saving behavior for history elements

--- a/platforms/platform-facebookmessenger/README.md
+++ b/platforms/platform-facebookmessenger/README.md
@@ -1,3 +1,8 @@
+---
+title: 'Facebook Messenger Platform Integration'
+excerpt: 'The Facebook Messenger platform integration allows you to build custom Messenger Bots using Jovo.'
+---
+
 # Facebook Messenger Platform Integration
 
 The Facebook Messenger [platform integration](https://v4.jovo.tech/docs/platforms) allows you to build custom Messenger bots using Jovo.
@@ -88,13 +93,13 @@ new FacebookMessengerPlatform({
 
 ## Platform-Specific Features
 
-You can access the Google Assistant specific object like this:
+You can access the Facebook Messenger specific object like this:
 
 ```typescript
 this.$facebookMessenger
 ```
 
-You can also use this object to see if the request is coming from Google Assistant (or a different platform):
+You can also use this object to see if the request is coming from Facebook Messenger (or a different platform):
 
 ```typescript
 if(this.$facebookMessenger) {

--- a/platforms/platform-facebookmessenger/README.md
+++ b/platforms/platform-facebookmessenger/README.md
@@ -1,0 +1,138 @@
+# Facebook Messenger Platform Integration
+
+The Facebook Messenger [platform integration](https://v4.jovo.tech/docs/platforms) allows you to build custom Messenger bots using Jovo.
+
+
+## Getting Started
+
+You can install the plugin like this:
+
+```sh
+$ npm install @jovotech/platform-facebookmessenger
+```
+
+Add it as plugin to your [app configuration](https://v4.jovo.tech/docs/app-config), e.g. `app.ts`:
+
+```typescript
+import { App } from '@jovotech/framework';
+import { FacebookMessengerPlatform } from '@jovotech/platform-facebookmessenger';
+// ...
+
+const app = new App({
+  plugins: [
+    new FacebookMessengerPlatform(),
+    // ...
+  ],
+});
+```
+
+## Configuration
+
+You can configure the Facebook Messenger platform in the [app configuration](https://v4.jovo.tech/docs/app-config), for example `app.ts`:
+
+```typescript
+import { FacebookMessengerPlatform } from '@jovotech/platform-facebookmessenger';
+
+// ...
+
+const app = new App({
+  plugins: [
+    // For example NLU integration
+  ],
+  sessionExpiresAfterSeconds: 900
+});
+```
+
+Options include:
+
+- `plugins`: Add an [NLU integration](#nlu-integration) here.
+- `sessionExpiresAfterSeconds`: Defines when a request should be treated as a new session. Take a look at [session data](#session-data) for more information.
+
+
+### NLU Integration
+
+Facebook Messenger requests mostly consist of raw text that need to be turned into structured data using an [natural language understanding (NLU) integration](https://v4.jovo.tech/docs/nlu).
+
+Here is an example how you can add an NLU integration (in this case [NLP.js](https://v4.jovo.tech/marketplace/nlu-nlpjs)) to the [app configuration](https://v4.jovo.tech/docs/app-config) in `app.ts`:
+
+```typescript
+import { FacebookMessengerPlatform } from '@jovotech/platform-facebookmessenger';
+import { NlpjsNlu } from '@jovotech/nlu-nlpjs';
+
+// ...
+
+const app = new App({
+  plugins: [
+    new FacebookMessengerPlatform({
+      plugins: [new NlpjsNlu()],
+    }),
+    // ...
+  ],
+});
+```
+
+### Session Data
+
+Facebook Messenger does not offer session storage, which is needed for features like [session data](https://v4.jovo.tech/docs/data#session-data), [component data](https://v4.jovo.tech/docs/data#component-data), and the [`$state` stack](https://v4.jovo.tech/docs/state-stack).
+
+To make Facebook Messenger bots work with these features, Jovo automatically enables the storage of session data to the active [database integration](https://v4.jovo.tech/docs/databases). Under the hood, it adds `session` to the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements).
+
+Since Facebook does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified with the `sessionExpiresAfterSeconds` option:
+
+```typescript
+new FacebookMessengerPlatform({
+  sessionExpiresAfterSeconds: 900,
+});
+```
+
+
+## Platform-Specific Features
+
+You can access the Google Assistant specific object like this:
+
+```typescript
+this.$facebookMessenger
+```
+
+You can also use this object to see if the request is coming from Google Assistant (or a different platform):
+
+```typescript
+if(this.$facebookMessenger) {
+  // ...
+}
+```
+
+
+### Output
+
+There are various Facebook Messenger specific elements that can be added to the [output](https://v4.jovo.tech/docs/output).
+
+For output that is only used for Facebook Messenger, you can add the following to the output object:
+
+```typescript
+{
+  // ...
+  platforms: {
+    facebookMessenger: {
+      // ...
+    }
+  }
+}
+```
+
+You can add response objects that should show up exactly like this in the Facebook Messenger response object using the `nativeResponse` object:
+
+```typescript
+{
+  // ...
+  platforms: {
+    facebookMessenger: {
+      nativeResponse: {
+        // ...
+      }
+      // ...
+    }
+  }
+}
+```
+

--- a/platforms/platform-facebookmessenger/README.md
+++ b/platforms/platform-facebookmessenger/README.md
@@ -42,16 +42,19 @@ import { FacebookMessengerPlatform } from '@jovotech/platform-facebookmessenger'
 
 const app = new App({
   plugins: [
-    // For example NLU integration
+    new FacebookMessengerPlatform({
+      plugins: [ /* ... */ ],
+      session: { /* ... */ },
+    }),
+    // ...
   ],
-  sessionExpiresAfterSeconds: 900
 });
 ```
 
 Options include:
 
-- `plugins`: Add an [NLU integration](#nlu-integration) here.
-- `sessionExpiresAfterSeconds`: Defines when a request should be treated as a new session. Take a look at [session data](#session-data) for more information.
+- `plugins`: For example, you need to ddd an [NLU integration](#nlu-integration) here.
+- `session`: Session specific config. Take a look at [session data](#session-data) for more information.
 
 
 ### NLU Integration
@@ -82,11 +85,13 @@ Facebook Messenger does not offer session storage, which is needed for features 
 
 To make Facebook Messenger bots work with these features, Jovo automatically enables the storage of session data to the active [database integration](https://v4.jovo.tech/docs/databases). Under the hood, it adds `session` to the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements).
 
-Since Facebook does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified with the `sessionExpiresAfterSeconds` option:
+Since Facebook does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified either in the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements) (works across platforms) or in the Facebook Messenger config:
 
 ```typescript
 new FacebookMessengerPlatform({
-  sessionExpiresAfterSeconds: 900,
+  session: {
+    expiresAfterSeconds: 900,
+  },
 });
 ```
 

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
@@ -24,6 +24,8 @@ export interface FacebookMessengerConfig extends ExtensibleConfig {
   version: typeof LATEST_FACEBOOK_API_VERSION | string;
   verifyToken: string;
   pageAccessToken: string;
+
+  sessionExpiresAfterSeconds?: number;
 }
 
 export class FacebookMessengerPlatform extends Platform<
@@ -52,7 +54,12 @@ export class FacebookMessengerPlatform extends Platform<
     super.mount(parent);
 
     this.middlewareCollection.use('request.start', (jovo) => {
-      return this.enableDatabaseSessionStorage(jovo);
+      return this.enableDatabaseSessionStorage(
+        jovo,
+        this.config.sessionExpiresAfterSeconds
+          ? { expiresAfterSeconds: this.config.sessionExpiresAfterSeconds }
+          : undefined,
+      );
     });
   }
 

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
@@ -51,7 +51,7 @@ export class FacebookMessengerPlatform extends Platform<
     this.augmentAppHandle();
   }
 
-  mount(parent: HandleRequest) {
+  mount(parent: HandleRequest): Promise<void> | void {
     super.mount(parent);
 
     this.middlewareCollection.use('request.start', (jovo) => {

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
@@ -3,6 +3,7 @@ import {
   App,
   Extensible,
   ExtensibleConfig,
+  HandleRequest,
   JovoError,
   Platform,
   Server,
@@ -13,11 +14,11 @@ import {
 } from '@jovotech/output-facebookmessenger';
 import _cloneDeep from 'lodash.clonedeep';
 import { DEFAULT_FACEBOOK_VERIFY_TOKEN, LATEST_FACEBOOK_API_VERSION } from './constants';
+import { FacebookMessenger } from './FacebookMessenger';
+import { FacebookMessengerDevice } from './FacebookMessengerDevice';
 import { FacebookMessengerRequest } from './FacebookMessengerRequest';
 import { FacebookMessengerUser } from './FacebookMessengerUser';
 import { MessengerBotEntry } from './interfaces';
-import { FacebookMessenger } from './FacebookMessenger';
-import { FacebookMessengerDevice } from './FacebookMessengerDevice';
 
 export interface FacebookMessengerConfig extends ExtensibleConfig {
   version: typeof LATEST_FACEBOOK_API_VERSION | string;
@@ -45,6 +46,14 @@ export class FacebookMessengerPlatform extends Platform<
       await super.initialize(parent);
     }
     this.augmentAppHandle();
+  }
+
+  mount(parent: HandleRequest) {
+    super.mount(parent);
+
+    this.middlewareCollection.use('request.start', (jovo) => {
+      return this.enableDatabaseSessionStorage(jovo);
+    });
   }
 
   getDefaultConfig(): FacebookMessengerConfig {

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerPlatform.ts
@@ -7,6 +7,7 @@ import {
   JovoError,
   Platform,
   Server,
+  StoredElementSession,
 } from '@jovotech/framework';
 import {
   FacebookMessengerOutputTemplateConverterStrategy,
@@ -25,7 +26,7 @@ export interface FacebookMessengerConfig extends ExtensibleConfig {
   verifyToken: string;
   pageAccessToken: string;
 
-  sessionExpiresAfterSeconds?: number;
+  session?: StoredElementSession & { enabled?: never };
 }
 
 export class FacebookMessengerPlatform extends Platform<
@@ -54,12 +55,7 @@ export class FacebookMessengerPlatform extends Platform<
     super.mount(parent);
 
     this.middlewareCollection.use('request.start', (jovo) => {
-      return this.enableDatabaseSessionStorage(
-        jovo,
-        this.config.sessionExpiresAfterSeconds
-          ? { expiresAfterSeconds: this.config.sessionExpiresAfterSeconds }
-          : undefined,
-      );
+      return this.enableDatabaseSessionStorage(jovo, this.config.session);
     });
   }
 

--- a/platforms/platform-googlebusiness/README.md
+++ b/platforms/platform-googlebusiness/README.md
@@ -42,16 +42,19 @@ import { GoogleBusinessPlatform } from '@jovotech/platform-googlebusiness';
 
 const app = new App({
   plugins: [
-    // For example NLU integration
+    new GoogleBusinessPlatform({
+      plugins: [ /* ... */ ],
+      session: { /* ... */ },
+    }),
+    // ...
   ],
-  sessionExpiresAfterSeconds: 900
 });
 ```
 
 Options include:
 
-- `plugins`: Add an [NLU integration](#nlu-integration) here.
-- `sessionExpiresAfterSeconds`: Defines when a request should be treated as a new session. Take a look at [session data](#session-data) for more information.
+- `plugins`: For example, you need to ddd an [NLU integration](#nlu-integration) here.
+- `session`: Session specific config. Take a look at [session data](#session-data) for more information.
 
 
 ### NLU Integration
@@ -82,11 +85,14 @@ Google Business does not offer session storage, which is needed for features lik
 
 To make Google Business bots work with these features, Jovo automatically enables the storage of session data to the active [database integration](https://v4.jovo.tech/docs/databases). Under the hood, it adds `session` to the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements).
 
-Since Google Business does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified with the `sessionExpiresAfterSeconds` option:
+Since Google Business does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified either in the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements) (works across platforms) or in the Google Business config:
 
 ```typescript
 new GoogleBusinessPlatform({
-  sessionExpiresAfterSeconds: 900,
+  // ...
+  session: {
+    expiresAfterSeconds: 900,
+  },
 });
 ```
 

--- a/platforms/platform-googlebusiness/README.md
+++ b/platforms/platform-googlebusiness/README.md
@@ -1,0 +1,138 @@
+# Google Business Messages Platform Integration
+
+The Google Business Messages [platform integration](https://v4.jovo.tech/docs/platforms) allows you to build custom Google Business bots using Jovo.
+
+
+## Getting Started
+
+You can install the plugin like this:
+
+```sh
+$ npm install @jovotech/platform-googlebusiness
+```
+
+Add it as plugin to your [app configuration](https://v4.jovo.tech/docs/app-config), e.g. `app.ts`:
+
+```typescript
+import { App } from '@jovotech/framework';
+import { GoogleBusinessPlatform } from '@jovotech/platform-googlebusiness';
+// ...
+
+const app = new App({
+  plugins: [
+    new GoogleBusinessPlatform(),
+    // ...
+  ],
+});
+```
+
+## Configuration
+
+You can configure the Google Business platform in the [app configuration](https://v4.jovo.tech/docs/app-config), for example `app.ts`:
+
+```typescript
+import { GoogleBusinessPlatform } from '@jovotech/platform-googlebusiness';
+
+// ...
+
+const app = new App({
+  plugins: [
+    // For example NLU integration
+  ],
+  sessionExpiresAfterSeconds: 900
+});
+```
+
+Options include:
+
+- `plugins`: Add an [NLU integration](#nlu-integration) here.
+- `sessionExpiresAfterSeconds`: Defines when a request should be treated as a new session. Take a look at [session data](#session-data) for more information.
+
+
+### NLU Integration
+
+Google Business requests mostly consist of raw text that need to be turned into structured data using an [natural language understanding (NLU) integration](https://v4.jovo.tech/docs/nlu).
+
+Here is an example how you can add an NLU integration (in this case [NLP.js](https://v4.jovo.tech/marketplace/nlu-nlpjs)) to the [app configuration](https://v4.jovo.tech/docs/app-config) in `app.ts`:
+
+```typescript
+import { GoogleBusinessPlatform } from '@jovotech/platform-googlebusiness';
+import { NlpjsNlu } from '@jovotech/nlu-nlpjs';
+
+// ...
+
+const app = new App({
+  plugins: [
+    new GoogleBusinessPlatform({
+      plugins: [new NlpjsNlu()],
+    }),
+    // ...
+  ],
+});
+```
+
+### Session Data
+
+Google Business does not offer session storage, which is needed for features like [session data](https://v4.jovo.tech/docs/data#session-data), [component data](https://v4.jovo.tech/docs/data#component-data), and the [`$state` stack](https://v4.jovo.tech/docs/state-stack).
+
+To make Google Business bots work with these features, Jovo automatically enables the storage of session data to the active [database integration](https://v4.jovo.tech/docs/databases). Under the hood, it adds `session` to the [`storedElements` config](https://v4.jovo.tech/docs/databases#storedelements).
+
+Since Google Business does not have the concept of sessions, we need to define after which time a request should be seen as the start of the new session. The default is *15 minutes* and can be modified with the `sessionExpiresAfterSeconds` option:
+
+```typescript
+new GoogleBusinessPlatform({
+  sessionExpiresAfterSeconds: 900,
+});
+```
+
+
+## Platform-Specific Features
+
+You can access the Google Business specific object like this:
+
+```typescript
+this.$googleBusiness
+```
+
+You can also use this object to see if the request is coming from Google Business (or a different platform):
+
+```typescript
+if(this.$googleBusiness) {
+  // ...
+}
+```
+
+
+### Output
+
+There are various Google Business specific elements that can be added to the [output](https://v4.jovo.tech/docs/output).
+
+For output that is only used for Google Business, you can add the following to the output object:
+
+```typescript
+{
+  // ...
+  platforms: {
+    googleBusiness: {
+      // ...
+    }
+  }
+}
+```
+
+You can add response objects that should show up exactly like this in the Google Business response object using the `nativeResponse` object:
+
+```typescript
+{
+  // ...
+  platforms: {
+    googleBusiness: {
+      nativeResponse: {
+        // ...
+      }
+      // ...
+    }
+  }
+}
+```
+

--- a/platforms/platform-googlebusiness/README.md
+++ b/platforms/platform-googlebusiness/README.md
@@ -1,3 +1,8 @@
+---
+title: 'Google Business Messages Platform Integration'
+excerpt: 'The Google Business Messages platform integration allows you to build custom Google Business Bots using Jovo.'
+---
+
 # Google Business Messages Platform Integration
 
 The Google Business Messages [platform integration](https://v4.jovo.tech/docs/platforms) allows you to build custom Google Business bots using Jovo.

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -60,6 +60,9 @@ export class GoogleBusinessPlatform extends Platform<
     this.middlewareCollection.use('before.request.start', (jovo) => {
       return this.beforeRequestStart(jovo);
     });
+    this.middlewareCollection.use('request.start', (jovo) => {
+      return this.enableDatabaseSessionStorage(jovo);
+    });
   }
 
   isRequestRelated(request: AnyObject | GoogleBusinessRequest): boolean {

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -19,6 +19,8 @@ import { GoogleBusinessDevice } from './GoogleBusinessDevice';
 
 export interface GoogleBusinessConfig extends ExtensibleConfig {
   serviceAccount: JWTInput;
+
+  sessionExpiresAfterSeconds?: number;
 }
 export type GoogleBusinessInitConfig = ExtensibleInitConfig<GoogleBusinessConfig> &
   Pick<GoogleBusinessConfig, 'serviceAccount'>;
@@ -61,7 +63,12 @@ export class GoogleBusinessPlatform extends Platform<
       return this.beforeRequestStart(jovo);
     });
     this.middlewareCollection.use('request.start', (jovo) => {
-      return this.enableDatabaseSessionStorage(jovo);
+      return this.enableDatabaseSessionStorage(
+        jovo,
+        this.config.sessionExpiresAfterSeconds
+          ? { expiresAfterSeconds: this.config.sessionExpiresAfterSeconds }
+          : undefined,
+      );
     });
   }
 

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -5,6 +5,7 @@ import {
   ExtensibleInitConfig,
   Jovo,
   Platform,
+  StoredElementSession,
 } from '@jovotech/framework';
 import {
   GoogleBusinessOutputTemplateConverterStrategy,
@@ -20,7 +21,7 @@ import { GoogleBusinessDevice } from './GoogleBusinessDevice';
 export interface GoogleBusinessConfig extends ExtensibleConfig {
   serviceAccount: JWTInput;
 
-  sessionExpiresAfterSeconds?: number;
+  session?: StoredElementSession & { enabled?: never };
 }
 export type GoogleBusinessInitConfig = ExtensibleInitConfig<GoogleBusinessConfig> &
   Pick<GoogleBusinessConfig, 'serviceAccount'>;
@@ -63,12 +64,7 @@ export class GoogleBusinessPlatform extends Platform<
       return this.beforeRequestStart(jovo);
     });
     this.middlewareCollection.use('request.start', (jovo) => {
-      return this.enableDatabaseSessionStorage(
-        jovo,
-        this.config.sessionExpiresAfterSeconds
-          ? { expiresAfterSeconds: this.config.sessionExpiresAfterSeconds }
-          : undefined,
-      );
+      return this.enableDatabaseSessionStorage(jovo, this.config.session);
     });
   }
 


### PR DESCRIPTION
## Proposed changes
- The session data that is saved in the database now expires after a configurable amount of time. The default amount is 15 minutes.
- Platforms that do not have their own session data will by default enable the session data in the database in order to be able to use states and other session-related features. 

_Some of these changes are based on changes of #1015, therefore this should only be merged after #1015 was merged._

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed