### PR TITLE
👔 Update logic to skip redundant requests for GoogleBusiness

### DIFF
--- a/docs/ridr-lifecycle.md
+++ b/docs/ridr-lifecycle.md
@@ -6,14 +6,6 @@ excerpt: 'Learn more about one of the key concepts of Jovo: The RIDR (Request - 
 
 Learn more about one of the key concepts of Jovo: The RIDR (Request - Interpretation - Dialogue & Logic - Response) Lifecycle.
 
-- [Introduction](#introduction)
-- [Request](#request)
-- [Interpretation](#interpretation)
-- [Dialogue & Logic](#dialogue--logic)
-- [Response](#response)
-- [Middlewares](#middlewares)
-  - [Stopping the Middleware Execution](#stopping-the-middleware-execution)
-
 ## Introduction
 
 ![RIDR Lifecycle: Request - Interpretation - Dialogue & Logic - Response](https://ghost.jovo.tech/content/images/2021/05/ridr-lifecycle-1.png)

--- a/docs/ridr-lifecycle.md
+++ b/docs/ridr-lifecycle.md
@@ -12,6 +12,7 @@ Learn more about one of the key concepts of Jovo: The RIDR (Request - Interpreta
 - [Dialogue & Logic](#dialogue--logic)
 - [Response](#response)
 - [Middlewares](#middlewares)
+  - [Stopping the Middleware Execution](#stopping-the-middleware-execution)
 
 ## Introduction
 
@@ -99,3 +100,17 @@ Middleware | Description
 `response.output` | Turns `$output` into a raw JSN response
 `response.tts` | TTS integrations turn text into speech output
 `response.end` | Leaves the `response` middleware group with propagated `$response` object
+
+
+### Stopping the Middleware Execution
+
+Either a [hook](./hooks.md) or a [plugin](./plugins.md) can use `stopMiddlewareExecution` to remove all middlewares from the middleware collection of `HandleRequest` and its plugins. This way, all following middlewares won't be executed.
+
+Here is an example how this could look like for a plugin method (that was registered with a middleware inside `mount`):
+
+```typescript
+someMethod(jovo: Jovo): void {
+  // ...
+  jovo.$handleRequest.stopMiddlewareExecution();
+}
+```

--- a/framework/src/HandleRequest.ts
+++ b/framework/src/HandleRequest.ts
@@ -40,6 +40,11 @@ export class HandleRequest extends Extensible<AppConfig, AppMiddlewares> {
   }
 
   stopMiddlewareExecution(): void {
-    this.middlewareCollection.remove(...this.middlewareCollection.names);
+    this.middlewareCollection.clear();
+    Object.values(this.plugins).forEach((plugin) => {
+      if (plugin instanceof Extensible) {
+        plugin.middlewareCollection.clear();
+      }
+    });
   }
 }

--- a/framework/src/MiddlewareCollection.ts
+++ b/framework/src/MiddlewareCollection.ts
@@ -71,6 +71,11 @@ export class MiddlewareCollection<MIDDLEWARES extends string[] = string[]> {
     return this;
   }
 
+  clear(): this {
+    this.remove(...this.names);
+    return this;
+  }
+
   async run(name: PossibleMiddlewareNames<MIDDLEWARES>, jovo: Jovo): Promise<void>;
   async run(name: string, jovo: Jovo): Promise<void>;
   async run(names: PossibleMiddlewareNames<MIDDLEWARES>[], jovo: Jovo): Promise<void>;
@@ -84,14 +89,13 @@ export class MiddlewareCollection<MIDDLEWARES extends string[] = string[]> {
   ): Promise<void> {
     const names = typeof nameOrNames === 'string' ? [nameOrNames] : nameOrNames;
     for (const name of names) {
-      const middleware = this.get(name);
-      if (!middleware) continue;
       const beforeName = `before.${name}`;
       if (this.has(beforeName)) {
         await this.run(beforeName, jovo);
       }
 
-      await middleware.run(jovo);
+      const middleware = this.get(name);
+      await middleware?.run(jovo);
 
       const afterName = `after.${name}`;
       if (this.has(afterName)) {

--- a/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessPlatform.ts
@@ -57,7 +57,9 @@ export class GoogleBusinessPlatform extends Platform<
 
   mount(parent: Extensible): Promise<void> | void {
     super.mount(parent);
-    this.middlewareCollection.use('before.request.start', (jovo) => {
+
+    // hook into parent's middleware in order to be able to call this first and skip before other plugins are called.
+    parent.middlewareCollection.use('before.request.start', (jovo) => {
       return this.beforeRequestStart(jovo);
     });
   }


### PR DESCRIPTION
## Proposed changes
Just like before, typing-indicator- and receipt-requests will be ignored, but now no further middlewares will be executed. This way the debugger for example will not log these requests.

Also improved `run` of `MiddlewareCollection` to check if the middleware exists after the `before.`-middleware has been executed. This way, removing middlewares in the `before.`-middleware allows skipping any further middlewares even the same middleware without the prefix.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed