### PR TITLE
🐛 Fix invalid reference of `$platform` in `Jovo`

### DIFF
--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -70,7 +70,7 @@ export abstract class Platform<
   }
 
   createJovoInstance<APP extends App>(app: APP, handleRequest: HandleRequest): JOVO {
-    return new this.jovoClass(app, handleRequest, this as unknown as PLATFORM);
+    return new this.jovoClass(app, handleRequest, handleRequest.platform as unknown as PLATFORM);
   }
 
   createRequestInstance(request: REQUEST | AnyObject): REQUEST {


### PR DESCRIPTION
## Proposed changes
`$platform` in `Jovo` was a reference to the platform instance that was passed in `use` or `plugins`.
Now, it will reference the mounted platform instead.

Using `this` in middleware-functions of platforms is no longer causing issues.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed