### PR TITLE
🐛 Fix DynamoDb bug

### DIFF
--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -11,6 +11,7 @@ import {
   DbItem,
   DbPlugin,
   DbPluginConfig,
+  HandleRequest,
   Jovo,
   PersistableSessionData,
   PersistableUserData,
@@ -56,6 +57,13 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
 
   constructor(config: DynamoDbConfig) {
     super(config);
+    this.client = new DynamoDBClient(this.config.libraryConfig?.dynamoDbClient || {});
+  }
+
+  mount(parent: HandleRequest) {
+    super.mount(parent);
+
+    // initialize a new client for the mounted instance with the given request-config
     this.client = new DynamoDBClient(this.config.libraryConfig?.dynamoDbClient || {});
   }
 

--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -60,7 +60,7 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
     this.client = new DynamoDBClient(this.config.libraryConfig?.dynamoDbClient || {});
   }
 
-  mount(parent: HandleRequest) {
+  mount(parent: HandleRequest): Promise<void> | void {
     super.mount(parent);
 
     // initialize a new client for the mounted instance with the given request-config

--- a/integrations/db-dynamodb/src/index.ts
+++ b/integrations/db-dynamodb/src/index.ts
@@ -1,1 +1,13 @@
+import { DynamoDb, DynamoDbConfig } from './DynamoDb';
+
+declare module '@jovotech/framework/dist/types/Extensible' {
+  interface ExtensiblePluginConfig {
+    DynamoDb?: DynamoDbConfig;
+  }
+
+  interface ExtensiblePlugins {
+    DynamoDb?: DynamoDb;
+  }
+}
+
 export { DynamoDb, DynamoDbConfig } from './DynamoDb';


### PR DESCRIPTION
## Proposed changes
Fix a bug that was caused by cloning the `client`-property in `DynamoDb`.
During mounting a new client instance is now instantiated. This has the advantage that his `DynamoDBClient` will use the request-config.

Also added type-hinting for DynamoDb in config and plugins.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed