### PR TITLE
✨ Add accessToken property to JovoUser

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -58,6 +58,7 @@ const score = this.$user.data.score;
 Additionally to the persisted data, you can also access the following information about the user:
 
 * `this.$user.id`: The user's ID is also the key to their database entry.
+* `this.$user.accessToken`: For platforms that offer account linking, the `accessToken` is a string for signed in users. The value is `undefined` if the user hasn't linked their account, or the platform does not support account linking.
 * `this.$user.createdAt`: When was this user's database entry created?
 * `this.$user.updatedAt`: When was this user's data last updated?
 * `this.$user.isNew`: A `boolean` that is `true` for first-time users.

--- a/framework/src/JovoUser.ts
+++ b/framework/src/JovoUser.ts
@@ -16,6 +16,10 @@ export abstract class JovoUser<JOVO extends Jovo = Jovo> {
 
   abstract id: string;
 
+  get accessToken(): string | undefined {
+    return;
+  }
+
   isNew = true;
 
   getPersistableData(): PersistableUserData {

--- a/platforms/platform-alexa/src/AlexaUser.ts
+++ b/platforms/platform-alexa/src/AlexaUser.ts
@@ -24,6 +24,10 @@ export class AlexaUser extends JovoUser<Alexa> {
     return this.jovo.$request.session?.user?.userId || 'AlexaUser';
   }
 
+  get accessToken(): string | undefined {
+    return this.jovo.$request.session?.user.accessToken;
+  }
+
   async getEmail(): Promise<string | undefined> {
     const request: AlexaRequest = this.jovo.$request;
     const email: string = await sendCustomerProfileApiRequest(

--- a/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
@@ -11,6 +11,11 @@ export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
     );
   }
 
+  get accessToken(): string | undefined {
+    const headers = this.jovo.$server.getRequestHeaders();
+    return headers.authorization as string;
+  }
+
   isAccountLinked(): boolean {
     return this.jovo.$request.user?.accountLinkingStatus === AccountLinkingStatus.Linked;
   }


### PR DESCRIPTION
Adds `accessToken` property to `JovoUser` class + Implementations for `AlexaUser` and `GoogleAssistantUser`

`this.$user.accessToken` can be undefined or of type `string`. 

### Usage

```typescript
LAUNCH() {
    const accessToken = this.$user.accessToken;
    return this.$redirect(LoveHatePizzaComponent);
  }
```

In `v3` the `getAccessToken()` method was part of the abstract `JovoRequest` class. 





## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed