### PR TITLE
♻️ Make `id` of `JovoUser` optional

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -57,7 +57,7 @@ const score = this.$user.data.score;
 
 Additionally to the persisted data, you can also access the following information about the user:
 
-* `this.$user.id`: The user's ID is also the key to their database entry.
+* `this.$user.id`: The user's ID is also the key to their database entry. This is either a string or `undefined` (if the platform does not support user IDs).
 * `this.$user.accessToken`: For platforms that offer account linking, the `accessToken` is a string for signed in users. The value is `undefined` if the user hasn't linked their account, or the platform does not support account linking.
 * `this.$user.createdAt`: When was this user's database entry created?
 * `this.$user.updatedAt`: When was this user's data last updated?

--- a/framework/src/JovoUser.ts
+++ b/framework/src/JovoUser.ts
@@ -14,7 +14,7 @@ export abstract class JovoUser<JOVO extends Jovo = Jovo> {
 
   constructor(readonly jovo: JOVO) {}
 
-  abstract id: string;
+  abstract get id(): string | undefined;
 
   get accessToken(): string | undefined {
     return;

--- a/framework/src/plugins/DbPlugin.ts
+++ b/framework/src/plugins/DbPlugin.ts
@@ -84,15 +84,21 @@ export abstract class DbPlugin<
     }
 
     parent.middlewareCollection.use('request.end', (jovo) => {
-      return this.loadData(jovo);
+      if (!jovo.$user.id) {
+        return;
+      }
+      return this.loadData(jovo.$user.id, jovo);
     });
     parent.middlewareCollection.use('response.start', (jovo) => {
-      return this.saveData(jovo);
+      if (!jovo.$user.id) {
+        return;
+      }
+      return this.saveData(jovo.$user.id, jovo);
     });
   }
 
-  abstract loadData(jovo: Jovo): Promise<void>;
-  abstract saveData(jovo: Jovo): Promise<void>;
+  abstract loadData(userId: string, jovo: Jovo): Promise<void>;
+  abstract saveData(userId: string, jovo: Jovo): Promise<void>;
 
   async applyPersistableData(jovo: Jovo, item: DbItem): Promise<void> {
     const persistableData = jovo.getPersistableData();

--- a/framework/test/utilities/platform.ts
+++ b/framework/test/utilities/platform.ts
@@ -88,7 +88,7 @@ export class ExamplePlatformOutputConverterStrategy extends OutputTemplateConver
 }
 
 export class ExamplePlatformUser extends JovoUser<ExamplePlatformJovo> {
-  get id(): string {
+  get id(): string | undefined {
     return 'ExamplePlatformUser';
   }
 }

--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -124,28 +124,28 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
     return data.Item as DbItem;
   }
 
-  async loadData(jovo: Jovo): Promise<void> {
+  async loadData(userId: string, jovo: Jovo): Promise<void> {
     this.checkRequirements();
-    const dbItem = await this.getDbItem(jovo.$user.id);
 
+    const dbItem = await this.getDbItem(userId);
     if (dbItem) {
       jovo.$user.isNew = false;
       jovo.setPersistableData(unmarshall(dbItem), this.config.storedElements);
     }
   }
 
-  async saveData(jovo: Jovo): Promise<void> {
+  async saveData(userId: string, jovo: Jovo): Promise<void> {
     this.checkRequirements();
 
     const params = {
       Item: {
-        [this.config.table.primaryKeyColumn!]: jovo.$user.id as string,
+        [this.config.table.primaryKeyColumn!]: userId,
       } as UnknownObject,
       TableName: this.config.table.name!,
     };
 
     const item: DbItem = {
-      [this.config.table.primaryKeyColumn!]: jovo.$user.id,
+      [this.config.table.primaryKeyColumn!]: userId,
     };
     await this.applyPersistableData(jovo, item);
 

--- a/integrations/db-filedb/src/FileDb.ts
+++ b/integrations/db-filedb/src/FileDb.ts
@@ -52,34 +52,33 @@ export class FileDb extends DbPlugin<FileDbConfig> {
     });
   }
 
-  async loadData(jovo: Jovo): Promise<void> {
-    const dbItem = await this.getDbItem(jovo.$user.id);
+  async loadData(userId: string, jovo: Jovo): Promise<void> {
+    const dbItem = await this.getDbItem(userId);
     if (dbItem) {
       jovo.$user.isNew = false;
       jovo.setPersistableData(dbItem, this.config.storedElements);
     }
   }
 
-  async saveData(jovo: Jovo): Promise<void> {
+  async saveData(userId: string, jovo: Jovo): Promise<void> {
     const fileDataStr = await fs.promises.readFile(this.pathToFile, 'utf8');
     const users = fileDataStr.length > 0 ? JSON.parse(fileDataStr) : [];
-    const id = jovo.$user.id;
 
     const dbItem = users.find((userItem: DbItem) => {
-      return userItem.id === id;
+      return userItem.id === userId;
     });
 
     // // create new user
     if (!dbItem) {
       const item: DbItem = {
-        id,
+        id: userId,
       };
       await this.applyPersistableData(jovo, item);
       users.push(item);
     } else {
       // update existing user
       for (let i = 0; i < users.length; i++) {
-        if (users[i].id === id) {
+        if (users[i].id === userId) {
           await this.applyPersistableData(jovo, users[i]);
         }
       }

--- a/platforms/platform-alexa/src/AlexaUser.ts
+++ b/platforms/platform-alexa/src/AlexaUser.ts
@@ -20,8 +20,8 @@ export class AlexaUser extends JovoUser<Alexa> {
     super(jovo);
   }
 
-  get id(): string {
-    return this.jovo.$request.session?.user?.userId || 'AlexaUser';
+  get id(): string | undefined {
+    return this.jovo.$request.session?.user?.userId;
   }
 
   get accessToken(): string | undefined {

--- a/platforms/platform-core/src/CoreUser.ts
+++ b/platforms/platform-core/src/CoreUser.ts
@@ -6,7 +6,7 @@ export class CoreUser extends JovoUser<Core> {
     super(jovo);
   }
 
-  get id(): string {
-    return 'coreplatformuser';
+  get id(): string | undefined {
+    return this.jovo.$request.context?.user?.id;
   }
 }

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerUser.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerUser.ts
@@ -2,7 +2,7 @@ import { JovoUser } from '@jovotech/framework';
 import { FacebookMessenger } from './FacebookMessenger';
 
 export class FacebookMessengerUser extends JovoUser<FacebookMessenger> {
-  get id(): string {
-    return this.jovo.$request.messaging?.[0]?.sender?.id || 'FacebookMessengerUser';
+  get id(): string | undefined {
+    return this.jovo.$request.messaging?.[0]?.sender?.id;
   }
 }

--- a/platforms/platform-googleassistant/README.md
+++ b/platforms/platform-googleassistant/README.md
@@ -76,6 +76,16 @@ There are various Google Assistant specific features added to the user class tha
 this.$googleAssistant.$user
 ```
 
+Google Assistant has the concept of *verified* users. Only if a user is verified (for example logged into their Google account on their mobile phone), data about the user can be stored. Learn more about the [expiration of user storage data in the official Google Assistant docs](https://developers.google.com/assistant/conversational/storage-user#expiration_of_user_storage_data).
+
+You can check is a user is verified like this:
+
+```typescript
+this.$googleAssistant.$user.isVerified()
+```
+
+If a verified user interacts with the Google Action the first time, Jovo generates a user ID and store it into the `user.params._GOOGLE_ASSISTANT_USER_ID_` [user storage](https://developers.google.com/assistant/conversational/storage-user?hl=en) property. This ID will then be used to write and retrieve data using one of the [Jovo database integrations](https://v4.jovo.tech/docs/databases).
+
 Learn more about user specific methods here:
 
 * [Account Linking](https://v4.jovo.tech/marketplace/platform-googleassistant/account-linking)

--- a/platforms/platform-googleassistant/package.json
+++ b/platforms/platform-googleassistant/package.json
@@ -36,6 +36,7 @@
     "lodash.mergewith": "^4.6.2",
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
+    "uuid": "^8.3.2",
     "yaml": "^1.10.2"
   },
   "devDependencies": {

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -84,7 +84,7 @@ export class GoogleAssistantPlatform extends Platform<
   onRequestStart(jovo: Jovo): void {
     const user = jovo.$googleAssistant?.$user;
     // if the user is linked and has no user id, generate one
-    if (user && user.isAccountLinked() && !user.id) {
+    if (user && user.isVerified() && !user.id) {
       user.setId(uuidV4());
     }
 

--- a/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantPlatform.ts
@@ -10,6 +10,7 @@ import { GoogleAssistantDevice } from './GoogleAssistantDevice';
 import { GoogleAssistantRepromptComponent } from './GoogleAssistantRepromptComponent';
 import { GoogleAssistantRequest } from './GoogleAssistantRequest';
 import { GoogleAssistantUser } from './GoogleAssistantUser';
+import { v4 as uuidV4 } from 'uuid';
 
 export interface GoogleAssistantConfig extends ExtensibleConfig {}
 
@@ -67,6 +68,13 @@ export class GoogleAssistantPlatform extends Platform<
         }
       },
     );
+
+    if (googleAssistant.$request.user) {
+      response.user = {
+        ...googleAssistant.$request.user,
+      };
+    }
+
     if (response.scene && googleAssistant.$request.scene?.name) {
       response.scene.name = googleAssistant.$request.scene.name;
     }
@@ -74,6 +82,12 @@ export class GoogleAssistantPlatform extends Platform<
   }
 
   onRequestStart(jovo: Jovo): void {
+    const user = jovo.$googleAssistant?.$user;
+    // if the user is linked and has no user id, generate one
+    if (user && user.isAccountLinked() && !user.id) {
+      user.setId(uuidV4());
+    }
+
     const request = jovo.$googleAssistant?.$request;
     // if it is a selection-event
     if (

--- a/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
@@ -2,14 +2,13 @@ import { axios, JovoError, JovoUser } from '@jovotech/framework';
 import { AccountLinkingStatus, UserVerificationStatus } from '@jovotech/output-googleassistant';
 import { GoogleAssistant } from './GoogleAssistant';
 import { GoogleAccountProfile } from './interfaces';
+import _set from 'lodash.set';
 
 export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
-  get id(): string {
-    return (
-      (this.jovo.$request.user?.params as Record<'userId' | string, string> | undefined)?.userId ||
-      'GoogleAssistantUser'
-    );
+  get id(): string | undefined {
+    return this.jovo.$request.user?.params?._GOOGLE_ASSISTANT_USER_ID_ as string | undefined;
   }
+
 
   get accessToken(): string | undefined {
     const headers = this.jovo.$server.getRequestHeaders();
@@ -22,6 +21,11 @@ export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
 
   isVerified(): boolean {
     return this.jovo.$request.user?.verificationStatus === UserVerificationStatus.Verified;
+  }
+
+  // TODO: determine whether a method or setter is better
+  setId(id: string | undefined) {
+    _set(this.jovo.$request, 'user.params._GOOGLE_ASSISTANT_USER_ID_', id);
   }
 
   async getGoogleProfile(): Promise<GoogleAccountProfile> {

--- a/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantUser.ts
@@ -9,7 +9,6 @@ export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
     return this.jovo.$request.user?.params?._GOOGLE_ASSISTANT_USER_ID_ as string | undefined;
   }
 
-
   get accessToken(): string | undefined {
     const headers = this.jovo.$server.getRequestHeaders();
     return headers.authorization as string;
@@ -24,7 +23,7 @@ export class GoogleAssistantUser extends JovoUser<GoogleAssistant> {
   }
 
   // TODO: determine whether a method or setter is better
-  setId(id: string | undefined) {
+  setId(id: string | undefined): void {
     _set(this.jovo.$request, 'user.params._GOOGLE_ASSISTANT_USER_ID_', id);
   }
 

--- a/platforms/platform-googlebusiness/src/GoogleBusinessUser.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusinessUser.ts
@@ -2,7 +2,7 @@ import { JovoUser } from '@jovotech/framework';
 import { GoogleBusiness } from './GoogleBusiness';
 
 export class GoogleBusinessUser extends JovoUser<GoogleBusiness> {
-  get id(): string {
-    return this.jovo.$request.conversationId || 'GoogleBusinessUser';
+  get id(): string | undefined {
+    return this.jovo.$request.conversationId;
   }
 }


### PR DESCRIPTION
## Proposed changes
- Make `id` of `JovoUser` optional
- Only load and save data if `id` is defined

- Implement logic for Google Assistant to be able to use user data when the user's account is linked:
  - the user-id is then persisted in `user.params._GOOGLE_ASSISTANT_USER_ID_` of the request-object

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed