### PR TITLE
:bug: google analytics skill events + error tracking fixed

### DIFF
--- a/jovo-integrations/jovo-analytics-googleanalytics/README.md
+++ b/jovo-integrations/jovo-analytics-googleanalytics/README.md
@@ -22,7 +22,7 @@ Learn how to use Google Analytics in your Jovo application.
       - [sendEvent()](#sendevent)
       - [sendTransaction()](#sendtransaction)
       - [sendItem()](#senditem)
-      - [sendUserEvent()](#senduserevent)
+      - [enqueUserEvent()](#enqueuserevent)
       - [setCustomMetric()](#setcustommetric)
       - [setParameter](#setparameter)
       - [setOptimizeExperiment](#setoptimizeexperiment)
@@ -248,7 +248,7 @@ The Google Analytics plugin offers developer methods for sending data (like Even
 * sendEvent(eventParameters)
 * sendTransaction(transactionParams)
 * sendItem(itemParams)
-* sendUserEvent (eventCategory, eventElement)
+* enqueUserEvent (eventCategory, eventElement)
 * sendUserTransaction (transactionId)
 * setCustomMetric (index, value)
 * setCustomDimension (index, value)
@@ -272,8 +272,8 @@ Events are user interactions with data describing such events. Events can be com
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendEvent({
+async LAUNCH() {
+    await this.$googleAnalytics.sendEvent({
         eventCategory: 'ItemPrice',
         eventAction: 'Teddy Bear',
         eventLabel: this.$user.getId(),
@@ -286,8 +286,8 @@ LAUNCH() {
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendEvent({
+async LAUNCH() {
+    await this.$googleAnalytics.sendEvent({
         eventCategory: 'ItemPrice',
         eventAction: 'Teddy Bear',
         eventLabel: this.$user.getId(),
@@ -314,8 +314,8 @@ Furthermore, you can attach your own properties to the object.
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendTransaction({
+async LAUNCH() {
+    await this.$googleAnalytics.sendTransaction({
         transactionId: '1234',
         transactionRevenue: 100,
         transactionShipping: 10,
@@ -329,8 +329,8 @@ LAUNCH() {
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendTransaction({
+async LAUNCH() {
+    await this.$googleAnalytics.sendTransaction({
         transactionId: '1234',
         transactionRevenue: 100,
         transactionShipping: 10,
@@ -359,8 +359,8 @@ Furthermore, you can attach your own properties to the object.
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendItem({
+async LAUNCH() {
+    await this.$googleAnalytics.sendItem({
         transactionId: '1234',
         itemName: 'Premium Subscription',
         itemPrice: 30,
@@ -375,8 +375,8 @@ LAUNCH() {
 
 // app.js
 
-LAUNCH() {
-    this.$googleAnalytics.sendItem({
+async LAUNCH() {
+    await this.$googleAnalytics.sendItem({
         transactionId: '1234',
         itemName: 'Premium Subscription',
         itemPrice: 30,
@@ -388,9 +388,10 @@ LAUNCH() {
 }
 ```
 
-#### sendUserEvent()
+#### enqueUserEvent()
 
-`sendUserEvent()` works almost the same as `sendEvent()` except that the only parameters that you have to provide are `eventCategory` and `eventAction`. The plugin sets the values for `eventLabel` and `documentPath` automatically to your users id and the current session path.
+`enqueUserEvent()` works almost the same as `sendEvent()` except that the only parameters that you have to provide are `eventCategory` and `eventAction`. An additional difference is that the enqueued event is not sent immediately but with the next "send" method call. If send is not called manually all events and pageview are sent together before the response middleware.
+The plugin sets the values for `eventLabel` and `documentPath` automatically to your users id and the current session path.
 
 ```javascript
 // @language=javascript
@@ -398,7 +399,7 @@ LAUNCH() {
 // app.js
 
 LAUNCH() {
-    this.$googleAnalytics.sendUserEvent('ItemPrice', 'Teddy Bear');
+    this.$googleAnalytics.enqueUserEvent('ItemPrice', 'Teddy Bear');
 }
 
 // @language=typescript
@@ -406,7 +407,7 @@ LAUNCH() {
 // app.js
 
 LAUNCH() {
-    this.$googleAnalytics.sendUserEvent('ItemPrice', 'Teddy Bear');
+    this.$googleAnalytics.enqueUserEvent('ItemPrice', 'Teddy Bear');
 }
 ```
 

--- a/jovo-integrations/jovo-analytics-googleanalytics/README.md
+++ b/jovo-integrations/jovo-analytics-googleanalytics/README.md
@@ -22,7 +22,7 @@ Learn how to use Google Analytics in your Jovo application.
       - [sendEvent()](#sendevent)
       - [sendTransaction()](#sendtransaction)
       - [sendItem()](#senditem)
-      - [enqueUserEvent()](#enqueuserevent)
+      - [sendUserEvent()](#senduserevent)
       - [setCustomMetric()](#setcustommetric)
       - [setParameter](#setparameter)
       - [setOptimizeExperiment](#setoptimizeexperiment)
@@ -248,7 +248,7 @@ The Google Analytics plugin offers developer methods for sending data (like Even
 * sendEvent(eventParameters)
 * sendTransaction(transactionParams)
 * sendItem(itemParams)
-* enqueUserEvent (eventCategory, eventElement)
+* sendUserEvent (eventCategory, eventElement)
 * sendUserTransaction (transactionId)
 * setCustomMetric (index, value)
 * setCustomDimension (index, value)
@@ -388,9 +388,9 @@ async LAUNCH() {
 }
 ```
 
-#### enqueUserEvent()
+#### sendUserEvent()
 
-`enqueUserEvent()` works almost the same as `sendEvent()` except that the only parameters that you have to provide are `eventCategory` and `eventAction`. An additional difference is that the enqueued event is not sent immediately but with the next "send" method call. If send is not called manually all events and pageview are sent together before the response middleware.
+`sendUserEvent()` works almost the same as `sendEvent()` except that the only parameters that you have to provide are `eventCategory` and `eventAction`. An additional difference is that the enqueued event is not sent immediately but with the next "send" method call. If send is not called manually all events and pageview are sent together before the response middleware.
 The plugin sets the values for `eventLabel` and `documentPath` automatically to your users id and the current session path.
 
 ```javascript
@@ -399,7 +399,7 @@ The plugin sets the values for `eventLabel` and `documentPath` automatically to 
 // app.js
 
 LAUNCH() {
-    this.$googleAnalytics.enqueUserEvent('ItemPrice', 'Teddy Bear');
+    this.$googleAnalytics.sendUserEvent('ItemPrice', 'Teddy Bear');
 }
 
 // @language=typescript
@@ -407,7 +407,7 @@ LAUNCH() {
 // app.js
 
 LAUNCH() {
-    this.$googleAnalytics.enqueUserEvent('ItemPrice', 'Teddy Bear');
+    this.$googleAnalytics.sendUserEvent('ItemPrice', 'Teddy Bear');
 }
 ```
 

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -175,10 +175,8 @@ export class GoogleAnalytics implements Analytics {
     const sessionTag = this.getSessionTag(jovo);
     jovo.$googleAnalytics.visitor!.set('sessionControl', sessionTag);
 
-
     // Track intent data.
     const pageview = jovo.$googleAnalytics.visitor!.pageview(this.getPageParameters(jovo));
-
 
     if (this.config.enableAutomaticEvents) {
       // Detect and send FlowErrors

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -275,10 +275,19 @@ export class GoogleAnalytics implements Analytics {
 
     // Stop the current tracking session.
     jovo.$googleAnalytics.visitor!.set('sessionControl', 'end');
-    await jovo.$googleAnalytics
-      .visitor!
-      .exception(handleRequest.error!.name)
-      .send();
+
+    return new Promise((resolve, reject) => {
+      jovo.$googleAnalytics.visitor
+        ?.pageview(this.getPageParameters(jovo))
+        .exception(handleRequest.error!.name)
+        .send((error, response: any) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(response);
+          }
+        });
+    });
   }
 
   /**

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -180,8 +180,8 @@ export class GoogleAnalytics implements Analytics {
 
     if (this.config.enableAutomaticEvents) {
       // Detect and send FlowErrors
-      this.enqueUnhandledEvents(jovo);
-      this.enqueIntentInputEvents(jovo);
+      this.enqueueUnhandledEvents(jovo);
+      this.enqueueIntentInputEvents(jovo);
     }
 
     return new Promise((resolve, reject) => {
@@ -294,18 +294,18 @@ export class GoogleAnalytics implements Analytics {
    * Detects and sends flow errors, ranging from nlu errors to bugs in the skill handler.
    * @param {object} jovo: Jovo object
    */
-  protected async enqueUnhandledEvents(jovo: Jovo) {
+  protected async enqueueUnhandledEvents(jovo: Jovo) {
     const intent = jovo.$request!.getIntentName();
     const { path } = jovo.getRoute();
 
     // Check if an error in the nlu model occurred.
     if (intent === 'AMAZON.FallbackIntent' || intent === 'Default Fallback Intent') {
-      return jovo.$googleAnalytics.enqueUserEvent('UnhandledEvents', 'NLU_Unhandled');
+      return jovo.$googleAnalytics.sendUserEvent('UnhandledEvents', 'NLU_Unhandled');
     }
 
     // If the current path is unhandled, an error in the skill handler occurred.
     if (path.endsWith('Unhandled')) {
-      return jovo.$googleAnalytics.enqueUserEvent('UnhandledEvents', 'Skill_Unhandled');
+      return jovo.$googleAnalytics.sendUserEvent('UnhandledEvents', 'Skill_Unhandled');
     }
   }
 
@@ -313,7 +313,7 @@ export class GoogleAnalytics implements Analytics {
    * Extract input from intent + set event on visitor object - send later together with pageview
    * @param jovo Jovo object
    */
-  protected enqueIntentInputEvents(jovo: Jovo) {
+  protected enqueueIntentInputEvents(jovo: Jovo) {
     if (jovo.$inputs) {
       for (const [key, value] of Object.entries(jovo.$inputs)) {
         if (!value.key) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -79,11 +79,11 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     }
   }
 
-  protected async sendUnhandledEvents(jovo: Jovo) {
+  protected async enqueUnhandledEvents(jovo: Jovo) {
     if (jovo.$alexaSkill!.getEndReason() === 'EXCEEDED_MAX_REPROMPTS') {
-      await jovo.$googleAnalytics.sendUserEvent('FlowError', 'Exceeded_Max_Reprompts');
+      await jovo.$googleAnalytics.enqueUserEvent('FlowError', 'Exceeded_Max_Reprompts');
     }
-    return super.sendUnhandledEvents(jovo);
+    return super.enqueUnhandledEvents(jovo);
   }
 
   protected initVisitor(jovo: Jovo) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -80,7 +80,6 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
   }
 
   protected async sendUnhandledEvents(jovo: Jovo) {
-
     if (jovo.$alexaSkill!.getEndReason() === 'EXCEEDED_MAX_REPROMPTS') {
       await jovo.$googleAnalytics.sendUserEvent('FlowError', 'Exceeded_Max_Reprompts');
     }

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -81,9 +81,9 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
 
   protected async enqueUnhandledEvents(jovo: Jovo) {
     if (jovo.$alexaSkill!.getEndReason() === 'EXCEEDED_MAX_REPROMPTS') {
-      await jovo.$googleAnalytics.enqueUserEvent('FlowError', 'Exceeded_Max_Reprompts');
+      await jovo.$googleAnalytics.sendUserEvent('FlowError', 'Exceeded_Max_Reprompts');
     }
-    return super.enqueUnhandledEvents(jovo);
+    return super.enqueueUnhandledEvents(jovo);
   }
 
   protected initVisitor(jovo: Jovo) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -38,7 +38,8 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     if (!eventName) {
       return;
     }
-    await jovo.$googleAnalytics.sendEvent({
+
+    return jovo.$googleAnalytics.sendEvent({
       eventCategory: 'AlexaSkillEvent',
       eventAction: eventName,
       eventLabel: this.getUserId(jovo),
@@ -78,12 +79,12 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     }
   }
 
-  protected sendUnhandledEvents(jovo: Jovo) {
-    super.sendUnhandledEvents(jovo);
+  protected async sendUnhandledEvents(jovo: Jovo) {
 
     if (jovo.$alexaSkill!.getEndReason() === 'EXCEEDED_MAX_REPROMPTS') {
-      jovo.$googleAnalytics.sendUserEvent('FlowError', 'Exceeded_Max_Reprompts');
+      await jovo.$googleAnalytics.sendUserEvent('FlowError', 'Exceeded_Max_Reprompts');
     }
+    return super.sendUnhandledEvents(jovo);
   }
 
   protected initVisitor(jovo: Jovo) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
@@ -160,7 +160,7 @@ export class GoogleAnalyticsInstance {
    * @param {string} eventName maps to category -> eventGroup
    * @param {string} eventElement maps to action -> instance of eventGroup
    */
-  enqueUserEvent(eventCategory: string, eventAction: string) {
+  sendUserEvent(eventCategory: string, eventAction: string) {
     const params: Event = {
       eventCategory,
       eventAction,

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
@@ -120,7 +120,6 @@ export class GoogleAnalyticsInstance {
   }
 
   async sendEvent(params: Event) {
-    console.log(`sending in handleAlexaSkillEvents`);
     return new Promise((resolve, reject) => {
       return this.visitor!.event(params).send((error, response: any) => {
         if (error) {
@@ -130,7 +129,6 @@ export class GoogleAnalyticsInstance {
         }
       });
     });
-    console.log(`finished sending in handleAlexaSkillEvents`);
   }
 
   sendTransaction(params: Transaction) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
@@ -131,7 +131,6 @@ export class GoogleAnalyticsInstance {
       });
     });
     console.log(`finished sending in handleAlexaSkillEvents`);
-
   }
 
   sendTransaction(params: Transaction) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
@@ -120,26 +120,41 @@ export class GoogleAnalyticsInstance {
   }
 
   async sendEvent(params: Event) {
-    await this.visitor!.event(params, (err: any) => {
-      if (err) {
-        throw new JovoError(err.message, ErrorCode.ERR_PLUGIN, 'jovo-analytics-googleanalytics');
-      }
-    }).send();
+    console.log(`sending in handleAlexaSkillEvents`);
+    return new Promise((resolve, reject) => {
+      return this.visitor!.event(params).send((error, response: any) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(response);
+        }
+      });
+    });
+    console.log(`finished sending in handleAlexaSkillEvents`);
+
   }
 
   sendTransaction(params: Transaction) {
-    this.visitor!.transaction(params, (err: any) => {
-      if (err) {
-        throw new JovoError(err.message, ErrorCode.ERR_PLUGIN, 'jovo-analytics-googleanalytics');
-      }
-    }).send();
+    return new Promise((resolve, reject) => {
+      return this.visitor!.transaction(params).send((error, response: any) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(response);
+        }
+      });
+    });
   }
   sendItem(params: TransactionItem) {
-    this.visitor!.transaction(params, (err: any) => {
-      if (err) {
-        throw new JovoError(err.message, ErrorCode.ERR_PLUGIN, 'jovo-analytics-googleanalytics');
-      }
-    }).send();
+    return new Promise((resolve, reject) => {
+      return this.visitor!.transaction(params).send((error, response: any) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(response);
+        }
+      });
+    });
   }
 
   /**
@@ -156,6 +171,6 @@ export class GoogleAnalyticsInstance {
       documentPath: this.jovo.getRoute().path,
     };
 
-    this.jovo.$googleAnalytics.visitor!.event(params);
+    return this.jovo.$googleAnalytics.sendEvent(params);
   }
 }

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsInstance.ts
@@ -162,7 +162,7 @@ export class GoogleAnalyticsInstance {
    * @param {string} eventName maps to category -> eventGroup
    * @param {string} eventElement maps to action -> instance of eventGroup
    */
-  sendUserEvent(eventCategory: string, eventAction: string) {
+  enqueUserEvent(eventCategory: string, eventAction: string) {
     const params: Event = {
       eventCategory,
       eventAction,
@@ -170,6 +170,7 @@ export class GoogleAnalyticsInstance {
       documentPath: this.jovo.getRoute().path,
     };
 
-    return this.jovo.$googleAnalytics.sendEvent(params);
+    this.jovo.$googleAnalytics.visitor?.event(params);
+    return this.jovo.$googleAnalytics.visitor;
   }
 }


### PR DESCRIPTION
## Proposed changes
When sending skill events and errors to google analytics there were situations where the lambda returned before finishing the calls. Result: hard error on next start.
I also changed two method names from "send*" to "enqueue*" because the methods did not send but enqueue.  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed