### PR TITLE
♻️💥 `$output` is an array

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,7 +35,7 @@ The code snippet from above consists of the following elements:
 - `<middleware>`: This is the middleware this hook should use, for example `platform.output`. Find all middlewares in the [RIDR docs](./ridr-lifecycle.md#middlewares). You can also add `before` and `after`, e.g. `before.platform.output`. 
 - Callback function with `jovo`: This is where you add the code that should get executed when the middleware triggers the hook.
 
-Here is an example that logs the [`$output` object](./output.md) before it is turned into a native platform response:
+Here is an example that logs the [`$output` array](./output.md) before it is turned into a native platform response:
 
 ```typescript
 // src/app.ts

--- a/docs/jovo-properties.md
+++ b/docs/jovo-properties.md
@@ -47,13 +47,13 @@ this.$input
 
 ### $output
 
-The `$output` property contains structured output that is later turned into a native platform response. It is the result of executing a [handler](./handlers.md) and the third step of the [RIDR lifecycle](./ridr-lifecycle.md).
+The `$output` array contains one or more structured output templates that are later turned into one or more native platform responses. It is the result of executing a [handler](./handlers.md) and the third step of the [RIDR lifecycle](./ridr-lifecycle.md).
 
 ```typescript
 this.$output
 ```
 
-[Learn more about the `$output` property here](./output.md).
+[Learn more about the `$output` array here](./output.md).
 
 
 ### $response

--- a/docs/output.md
+++ b/docs/output.md
@@ -10,7 +10,7 @@ Learn more about how to return output to the user.
 
 A big part of building a Jovo app is returning output to the user. This output could include all sorts of things, speech (for voice interfaces) or text (for visual interfaces) messages being the most prominent.
 
-The goal of a [handler](./handlers.md) is to return a structured [output template](#output-templates), which gets stored inside the Jovo `$output` property. This `$output` then gets translated into a native platform response in the next step of the [RIDR lifecycle](./ridr-lifecycle.md).
+The goal of a [handler](./handlers.md) is to return one or more structured [output templates](#output-templates) that get stored inside the Jovo `$output` array. This `$output` then gets translated into a native platform response in the next step of the [RIDR lifecycle](./ridr-lifecycle.md).
 
 The most popular way to return output is using the `$send` method:
 
@@ -22,6 +22,8 @@ yourHandler() {
   return this.$send(/* output */);
 }
 ```
+
+`$output` is always an array, even if you only send one output template.
 
 Learn more about [ways to return output](#ways-to-return-output), [output templates](#output-templates), and [output classes](#output-classes) below.
 
@@ -47,9 +49,9 @@ yourHandler() {
   
   // ...
 
-  this.$output = {
+  this.$output = [{
     message: 'Hello world',
-  };
+  }];
   return;
 }
 ```
@@ -117,7 +119,7 @@ Learn more about [reserved properties in the output classes documentation](./out
 
 ### Send Multiple Responses
 
-You can also return an array of output objects:
+You can also return an array of output templates:
 
 ```typescript
 [

--- a/docs/ridr-lifecycle.md
+++ b/docs/ridr-lifecycle.md
@@ -62,12 +62,12 @@ Here are some of the things that happen in this step:
 * Services: Utility classes that keep business logic separated dialogue (handlers)
 * [Output](./output.md): The result of a handler is to return an appropriate output
 
-The Dialogue & Logic step usually ends with a populated [Jovo `$output` object](./output.md).
+The Dialogue & Logic step usually ends with a populated [Jovo `$output` array](./output.md).
 
 
 ## Response
 
-In the final Response step, the `$output` object from the previous step is translated into a native platform `$response`.
+In the final Response step, the `$output` array from the previous step is translated into a native platform `$response`.
 
 This response is then returned back to the platform.
 
@@ -87,7 +87,7 @@ Middleware | Description
 `dialogue.start` | Enters the `dialogue` middleware group
 `dialogue.router` | Uses information from the `interpretation` steps to find the right component and handler
 `dialogue.logic` | Executes the component and handler logic
-`dialogue.end` | Leaves the `dialogue` middleware group with propagated `$output` object
+`dialogue.end` | Leaves the `dialogue` middleware group with propagated `$output` array
 `response.start` | Enters the `response` middleware group
 `response.output` | Turns `$output` into a raw JSN response
 `response.tts` | TTS integrations turn text into speech output

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -102,7 +102,7 @@ export abstract class Jovo<
 > {
   $request: REQUEST;
   $input: JovoInput;
-  $output: OutputTemplate | OutputTemplate[];
+  $output: OutputTemplate[];
   $response?: RESPONSE | RESPONSE[];
 
   $data: RequestData;
@@ -264,11 +264,6 @@ export abstract class Jovo<
       newOutput = output;
     } else {
       newOutput = outputConstructorOrTemplate;
-    }
-
-    // make $output an array if it is none
-    if (!Array.isArray(this.$output)) {
-      this.$output = [this.$output];
     }
 
     // push the new OutputTemplate(s) to $output

--- a/framework/src/JovoHistory.ts
+++ b/framework/src/JovoHistory.ts
@@ -10,7 +10,7 @@ export interface JovoHistoryItem extends UnknownObject {
   state?: JovoSession['$state'];
   entities?: EntityMap;
 
-  output?: OutputTemplate | OutputTemplate[];
+  output?: OutputTemplate[];
   response?: JovoResponse | JovoResponse[];
 }
 

--- a/integrations/nlu-snips/src/SnipsNlu.ts
+++ b/integrations/nlu-snips/src/SnipsNlu.ts
@@ -9,7 +9,6 @@ import {
   JovoRequest,
   NluData,
   NluPlugin,
-  OutputTemplate,
 } from '@jovotech/framework';
 import { EntityType, IntentEntityType, JovoModelData } from '@jovotech/model';
 import { join as joinPaths, resolve } from 'path';

--- a/integrations/nlu-snips/src/SnipsNlu.ts
+++ b/integrations/nlu-snips/src/SnipsNlu.ts
@@ -84,10 +84,9 @@ export class SnipsNlu extends NluPlugin<SnipsNluConfig> {
     if (!this.config.dynamicEntities?.enabled) {
       return;
     }
-    const outputs: OutputTemplate[] = Array.isArray(jovo.$output) ? jovo.$output : [jovo.$output];
     const locale: string = this.getLocale(jovo.$request);
 
-    for (const output of outputs) {
+    for (const output of jovo.$output) {
       const listen = output.platforms?.[jovo.$platform.constructor.name]?.listen ?? output.listen;
 
       if (

--- a/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
@@ -56,7 +56,6 @@ export class FacebookMessenger extends Jovo<
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
-    // get the length of the current output, if it's an object, assume the length is 1
     const currentOutputLength = this.$output.length;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);

--- a/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessenger.ts
@@ -57,7 +57,7 @@ export class FacebookMessenger extends Jovo<
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
     // get the length of the current output, if it's an object, assume the length is 1
-    const currentOutputLength = Array.isArray(this.$output) ? this.$output.length : 1;
+    const currentOutputLength = this.$output.length;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);
     } else {
@@ -68,9 +68,7 @@ export class FacebookMessenger extends Jovo<
     );
 
     // get only the newly added output
-    const newOutput = Array.isArray(this.$output)
-      ? this.$output.slice(currentOutputLength)
-      : this.$output;
+    const newOutput = this.$output.slice(currentOutputLength);
 
     let response = await outputConverter.toResponse(newOutput);
     response = await this.$platform.finalizeResponse(response, this);

--- a/platforms/platform-googlebusiness/src/GoogleBusiness.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusiness.ts
@@ -51,7 +51,6 @@ export class GoogleBusiness extends Jovo<
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
-    // get the length of the current output, if it's an object, assume the length is 1
     const currentOutputLength = this.$output.length;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);

--- a/platforms/platform-googlebusiness/src/GoogleBusiness.ts
+++ b/platforms/platform-googlebusiness/src/GoogleBusiness.ts
@@ -52,7 +52,7 @@ export class GoogleBusiness extends Jovo<
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
     // get the length of the current output, if it's an object, assume the length is 1
-    const currentOutputLength = Array.isArray(this.$output) ? this.$output.length : 1;
+    const currentOutputLength = this.$output.length;
     if (typeof outputConstructorOrTemplate === 'function') {
       await super.$send(outputConstructorOrTemplate, options);
     } else {
@@ -63,9 +63,7 @@ export class GoogleBusiness extends Jovo<
     );
 
     // get only the newly added output
-    const newOutput = Array.isArray(this.$output)
-      ? this.$output.slice(currentOutputLength)
-      : this.$output;
+    const newOutput = this.$output.slice(currentOutputLength);
 
     let response = await outputConverter.toResponse(newOutput);
     response = await this.$platform.finalizeResponse(response, this);


### PR DESCRIPTION
## Proposed changes
Previously, `$output` of `Jovo` could either be an array of `OutputTemplate` objects or an `OutputTemplate` object. 
Now it can only be an `OutputTemplate` array. This change makes it easier to manipulate the output without having to check if it's an array or object all the time.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed