### PR TITLE
♻️💥 Refactor `$entities` 

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -49,13 +49,15 @@ Each entity is an object that contains the following information:
 ```typescript
 {
   value: 'entityValue',
+  resolved: 'mappedEntityValue',
   id: 'entityValueId',
-  key: 'mappedEntityValue',
+  native: { /* ... */ }
 }
 ```
-* `value`: The value retrieved from the user input.
-* `key`: If the entity value was a synonym, the "main" value of the language model will be provided here.
-* `id`: Some platforms and NLUs provide the possibility to add IDs to their entity values. If there is no ID available, the `id` will be the same as the `value`.
+* `value`: The (raw) value retrieved from the user input.
+* `resolved`: If the entity value was a synonym, the "main" value of the language model will be provided here. If there is no resolved value, this will default to `value`.
+* `id`: Some platforms and NLUs provide the possibility to add IDs to their entity values. If there is no ID available, the `id` will be the same as `resolved`.
+* `native`: For platforms that support additional entity features, the raw entity data of the API response will be stored here.
 
 
 ## Dynamic Entities

--- a/framework/src/interfaces.ts
+++ b/framework/src/interfaces.ts
@@ -14,13 +14,15 @@ export interface UserData extends Data {}
 
 export interface Entity extends UnknownObject {
   id?: string;
-  key?: string;
+  resolved?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  native?: any;
 }
 
-export interface EntityMap {
-  [key: string]: Entity | undefined;
+export interface EntityMap<ENTITY_TYPE extends Entity = Entity> {
+  [key: string]: ENTITY_TYPE | undefined;
 }
 
 export interface AsrData extends UnknownObject {

--- a/platforms/platform-alexa/README.md
+++ b/platforms/platform-alexa/README.md
@@ -116,3 +116,19 @@ If the `getEmail` call returns an error with the code `NO_USER_PERMISSION`, an `
 There are various Alexa specific elements that can be added to the [output](https://v4.jovo.tech/docs/output).
 
 [Learn more in the Jovo Output documentation for Alexa](https://v4.jovo.tech/marketplace/platform-alexa/output).
+
+
+### Entities (Slots)
+
+Alexa *slots* are called *entities* in Jovo. You can learn more in the [Jovo Model](https://v4.jovo.tech/docs/models) and the [`$entities` documentation](https://v4.jovo.tech/docs/entities).
+
+You can access the Alexa-specific `$entities` property like this, which allows you to get typed access to the `native` API result for each slot:
+
+```typescript
+this.$alexa.$entities
+
+// Example: Get native API result object for slot "name"
+this.$alexa.$entities.name.native
+```
+
+Learn more about the structure of the API result in the [official Alexa documentation on entity resolution](https://developer.amazon.com/en-US/docs/alexa/custom-skills/entity-resolution.html).

--- a/platforms/platform-alexa/src/Alexa.ts
+++ b/platforms/platform-alexa/src/Alexa.ts
@@ -1,9 +1,10 @@
-import { Jovo } from '@jovotech/framework';
+import { EntityMap, Jovo } from '@jovotech/framework';
 import { AlexaResponse } from '@jovotech/output-alexa';
 import { AlexaDevice } from './AlexaDevice';
 import { AlexaPlatform } from './AlexaPlatform';
 import { AlexaRequest } from './AlexaRequest';
 import { AlexaUser } from './AlexaUser';
+import { AlexaEntity } from './interfaces';
 
 export class Alexa extends Jovo<
   AlexaRequest,
@@ -13,6 +14,8 @@ export class Alexa extends Jovo<
   AlexaDevice,
   AlexaPlatform
 > {
+  $entities!: EntityMap<AlexaEntity>;
+
   getSkillId(): string | undefined {
     return (
       this.$request.session?.application?.applicationId ||

--- a/platforms/platform-alexa/src/AlexaRequest.ts
+++ b/platforms/platform-alexa/src/AlexaRequest.ts
@@ -11,7 +11,7 @@ import {
 import { ResolutionPerAuthorityStatusCode } from '@jovotech/output-alexa';
 import { AlexaCapability, AlexaCapabilityType } from './AlexaDevice';
 import { DYNAMIC_ENTITY_MATCHES_PREFIX, STATIC_ENTITY_MATCHES_PREFIX } from './constants';
-import { AuthorityResolution, Context, Request, Session } from './interfaces';
+import { AlexaEntity, AuthorityResolution, Context, Request, Session } from './interfaces';
 
 export const ALEXA_REQUEST_TYPE_TO_INPUT_TYPE_MAP: Record<string, InputTypeLike> = {
   'LaunchRequest': InputType.Launch,
@@ -34,22 +34,23 @@ export class AlexaRequest extends JovoRequest {
     return this.request?.intent?.name;
   }
 
-  getEntities(): EntityMap | undefined {
+  getEntities(): EntityMap<AlexaEntity> | undefined {
     const slots = this.request?.intent?.slots;
     if (!slots) return;
-    return Object.keys(slots).reduce((entityMap: EntityMap, slotKey: string) => {
-      const entity: Entity = {
-        alexaSkill: slots[slotKey],
+    return Object.keys(slots).reduce((entityMap: EntityMap<AlexaEntity>, slotKey: string) => {
+      const entity: AlexaEntity = {
+        native: slots[slotKey],
       };
       if (slots[slotKey].value) {
         entity.value = slots[slotKey].value;
-        entity.key = slots[slotKey].value;
+        entity.resolved = slots[slotKey].value;
       }
 
       const modifyEntityByAuthorityResolutions = (authorityResolutions: AuthorityResolution[]) => {
         authorityResolutions.forEach((authorityResolution) => {
-          entity.key = authorityResolution.values[0].value.name;
-          entity.id = authorityResolution.values[0].value.id;
+          const { name, id } = authorityResolution.values[0].value;
+          entity.resolved = name;
+          entity.id = id || name;
         });
       };
 

--- a/platforms/platform-alexa/src/AlexaRequest.ts
+++ b/platforms/platform-alexa/src/AlexaRequest.ts
@@ -1,6 +1,5 @@
 import {
   Capability,
-  Entity,
   EntityMap,
   InputType,
   InputTypeLike,

--- a/platforms/platform-alexa/src/interfaces.ts
+++ b/platforms/platform-alexa/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { JovoSession } from '@jovotech/framework';
+import { Entity, JovoSession } from '@jovotech/framework';
 
 export interface Session {
   new: boolean;
@@ -181,13 +181,17 @@ export interface AuthorityResolutionValueItem {
 
 export interface AuthorityResolutionValue {
   name: string;
-  id: string;
+  id?: string;
 }
 
 export interface Intent {
   name: string;
   confirmationStatus?: ConfirmationStatus;
   slots?: { [key: string]: Slot };
+}
+
+export interface AlexaEntity extends Entity {
+  native: Slot;
 }
 
 export interface Request {
@@ -231,13 +235,3 @@ export interface Request {
   eventPublishingTime?: string; // AlexaSkillEvent.*
   dialogState?: string;
 }
-
-// export interface AlexaInput extends Input {
-//   alexaSkill: {
-//     name?: string;
-//     value?: string;
-//     confirmationStatus?: string;
-//     source?: string;
-//     resolutions?: Resolutions;
-//   };
-// }

--- a/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
@@ -18,32 +18,23 @@ export class FacebookMessengerRequest extends JovoRequest {
    * @link https://developers.facebook.com/docs/messenger-platform/reference/webhook-events#entry
    */
   messaging?: [MessagingData];
-  nlu?: {
-    intentName: string;
-  };
-  inputs?: EntityMap;
-  locale?: string;
 
   getLocale(): string | undefined {
-    return this.locale;
+    return;
   }
 
   getIntent(): JovoInput['intent'] {
-    return this.nlu?.intentName;
+    return;
   }
 
   getEntities(): EntityMap | undefined {
-    return this.inputs;
+    return;
   }
 
   getInputType(): InputTypeLike | undefined {
     const postbackPayload = this.messaging?.[0]?.postback?.payload;
-
     if (postbackPayload === FACEBOOK_LAUNCH_PAYLOAD) {
       return InputType.Launch;
-    }
-    if (this.nlu?.intentName) {
-      return InputType.Intent;
     }
     return InputType.Text;
   }

--- a/platforms/platform-googleassistant/src/GoogleAssistant.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistant.ts
@@ -1,6 +1,7 @@
 import {
   App,
   DbPluginStoredElementsConfig,
+  EntityMap,
   HandleRequest,
   Jovo,
   JovoPersistableData,
@@ -10,6 +11,7 @@ import { GoogleAssistantDevice } from './GoogleAssistantDevice';
 import { GoogleAssistantPlatform } from './GoogleAssistantPlatform';
 import { GoogleAssistantRequest } from './GoogleAssistantRequest';
 import { GoogleAssistantUser } from './GoogleAssistantUser';
+import { GoogleAssistantEntity } from './interfaces';
 
 export class GoogleAssistant extends Jovo<
   GoogleAssistantRequest,
@@ -19,6 +21,8 @@ export class GoogleAssistant extends Jovo<
   GoogleAssistantDevice,
   GoogleAssistantPlatform
 > {
+  $entities!: EntityMap<GoogleAssistantEntity>;
+
   constructor($app: App, $handleRequest: HandleRequest, $platform: GoogleAssistantPlatform) {
     super($app, $handleRequest, $platform);
     if (this.$request.session?.params?._GOOGLE_ASSISTANT_REPROMPTS_) {

--- a/platforms/platform-googleassistant/src/GoogleAssistantRequest.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantRequest.ts
@@ -11,7 +11,7 @@ import type { Device, Home, Scene, Session, User } from '@jovotech/output-google
 import { Capability as NativeCapability } from '@jovotech/output-googleassistant';
 import { GoogleAssistantSystemInputType, GoogleAssistantSystemIntent } from './enums';
 import { GoogleAssistantCapability, GoogleAssistantCapabilityType } from './GoogleAssistantDevice';
-import { Context, Handler, Intent } from './interfaces';
+import { Context, GoogleAssistantEntity, Handler, Intent } from './interfaces';
 
 export class GoogleAssistantRequest extends JovoRequest {
   handler?: Handler;
@@ -31,15 +31,15 @@ export class GoogleAssistantRequest extends JovoRequest {
     return this.intent?.name;
   }
 
-  getEntities(): EntityMap | undefined {
-    const entities: EntityMap = {};
-
+  getEntities(): EntityMap<GoogleAssistantEntity> | undefined {
+    const entities: EntityMap<GoogleAssistantEntity> = {};
     for (const param in this.intent?.params) {
       if (this.intent?.params.hasOwnProperty(param)) {
         entities[param] = {
-          id: this.intent?.params[param].resolved as string,
-          value: this.intent?.params[param].original,
-          key: this.intent?.params[param].resolved as string,
+          native: this.intent.params[param],
+          id: this.intent.params[param].resolved as string,
+          value: this.intent.params[param].original,
+          resolved: this.intent.params[param].resolved as string,
         };
       }
     }

--- a/platforms/platform-googleassistant/src/interfaces.ts
+++ b/platforms/platform-googleassistant/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { AnyObject } from '@jovotech/framework';
+import { AnyObject, Entity } from '@jovotech/framework';
 
 export interface Handler {
   name?: string;
@@ -41,4 +41,8 @@ export interface GoogleAccountProfile {
   picture: string;
   given_name: string;
   family_name: string;
+}
+
+export interface GoogleAssistantEntity extends Entity {
+  native: IntentParameterValue;
 }


### PR DESCRIPTION
## Proposed changes
- Refactor properties of `Entity`:
  - `key` was renamed to `resolved`
  - `id` is now the same value as `resolved` if nothing more fitting exists
  - added `native` property for setting data that caused this entity to be set
  
- `$entities` is now typed for platforms that have a custom `Entity` like Alexa for example:
```
this.$alexa?.$entities?.foo // is of type AlexaEntity | undefined
```

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed