### PR TITLE
Google Analytics: Fix session end for alexa errors + move error metrics to according intent

### DIFF
--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -273,9 +273,6 @@ export class GoogleAnalytics implements Analytics {
       return;
     }
 
-    // Stop the current tracking session.
-    jovo.$googleAnalytics.visitor!.set('sessionControl', 'end');
-
     return new Promise((resolve, reject) => {
       jovo.$googleAnalytics.visitor
         ?.pageview(this.getPageParameters(jovo))

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -133,7 +133,8 @@ export class GoogleAnalytics implements Analytics {
   setEndReason(jovo: Jovo, endReason: validEndReasons): void {
     jovo.$session.$data.endReason = endReason;
     const gaMetricNumber = this.customMetricsIndicesMap.get(endReason);
-    if(jovo.$alexaSkill?.getEndReason() === 'ERROR') { // Error is increased in intent before alexa sends the session ended request
+    if (jovo.$alexaSkill?.getEndReason() === 'ERROR') {
+      // Error is increased in intent before alexa sends the session ended request
       return;
     }
     if (gaMetricNumber) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -272,6 +272,7 @@ export class GoogleAnalytics implements Analytics {
       // don't send anything
       return;
     }
+    this.setEndReason(jovo, 'ERROR');
 
     return new Promise((resolve, reject) => {
       jovo.$googleAnalytics.visitor

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalytics.ts
@@ -133,6 +133,9 @@ export class GoogleAnalytics implements Analytics {
   setEndReason(jovo: Jovo, endReason: validEndReasons): void {
     jovo.$session.$data.endReason = endReason;
     const gaMetricNumber = this.customMetricsIndicesMap.get(endReason);
+    if(jovo.$alexaSkill?.getEndReason() === 'ERROR') { // Error is increased in intent before alexa sends the session ended request
+      return;
+    }
     if (gaMetricNumber) {
       jovo.$googleAnalytics.setCustomMetric(gaMetricNumber, '1');
     } else {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -81,9 +81,10 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
       return;
     }
     const endReason = jovo.$alexaSkill?.getEndReason();
+
     const responseWillEndSessionWithTell =
       _get(jovo.$output, 'Alexa.tell') || _get(jovo.$output, 'tell'); // aus AlexaCore.ts Zeile 95
-    if (this.config.trackEndReasons && endReason) {
+    if (this.config.trackEndReasons && endReason && endReason !== 'ERROR') {
       // set End Reason (eg. ERROR, EXCEEDED_MAX_REPROMPTS, PLAYTIME_LIMIT_REACHED, USER_INITIATED, ...)
       this.setEndReason(jovo, endReason);
     } else if (responseWillEndSessionWithTell) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -30,8 +30,6 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
       return;
     }
 
-
-
     await super.track(handleRequest);
   }
 
@@ -56,7 +54,6 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
     }
     await super.sendError(handleRequest);
   }
-
 
   protected setGoogleAnalyticsObject(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -30,6 +30,8 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
       return;
     }
 
+
+
     await super.track(handleRequest);
   }
 
@@ -45,6 +47,16 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
       eventLabel: this.getUserId(jovo),
     });
   }
+
+  protected async sendError(handleRequest: HandleRequest) {
+    const jovo: Jovo = handleRequest.jovo!;
+    if (jovo?.constructor.name !== 'AlexaSkill') {
+      // don't send anything
+      return;
+    }
+    await super.sendError(handleRequest);
+  }
+
 
   protected setGoogleAnalyticsObject(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsAlexa.ts
@@ -84,7 +84,7 @@ export class GoogleAnalyticsAlexa extends GoogleAnalytics {
 
     const responseWillEndSessionWithTell =
       _get(jovo.$output, 'Alexa.tell') || _get(jovo.$output, 'tell'); // aus AlexaCore.ts Zeile 95
-    if (this.config.trackEndReasons && endReason && endReason !== 'ERROR') {
+    if (this.config.trackEndReasons && endReason) {
       // set End Reason (eg. ERROR, EXCEEDED_MAX_REPROMPTS, PLAYTIME_LIMIT_REACHED, USER_INITIATED, ...)
       this.setEndReason(jovo, endReason);
     } else if (responseWillEndSessionWithTell) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
@@ -103,6 +103,17 @@ export class GoogleAnalyticsGoogleAssistant extends GoogleAnalytics {
     );
   }
 
+  protected async sendError(handleRequest: HandleRequest) {
+    const jovo: Jovo = handleRequest.jovo!;
+    if (jovo?.constructor.name !== 'GoogleAction') {
+      // don't send anything
+      return;
+    }
+    // Stop the current tracking session for google actions because they won't receive session ended requests
+    jovo.$googleAnalytics.visitor!.set('sessionControl', 'end');
+    await super.sendError(handleRequest);
+  }
+
   setGoogleAnalyticsObject(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;
     if (!jovo) {

--- a/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
+++ b/jovo-integrations/jovo-analytics-googleanalytics/src/GoogleAnalyticsGoogleAssistant.ts
@@ -103,16 +103,7 @@ export class GoogleAnalyticsGoogleAssistant extends GoogleAnalytics {
     );
   }
 
-  protected async sendError(handleRequest: HandleRequest) {
-    const jovo: Jovo = handleRequest.jovo!;
-    if (jovo?.constructor.name !== 'GoogleAction') {
-      // don't send anything
-      return;
-    }
-    // Stop the current tracking session for google actions because they won't receive session ended requests
-    jovo.$googleAnalytics.visitor!.set('sessionControl', 'end');
-    await super.sendError(handleRequest);
-  }
+
 
   setGoogleAnalyticsObject(handleRequest: HandleRequest) {
     const jovo: Jovo = handleRequest.jovo!;
@@ -129,5 +120,16 @@ export class GoogleAnalyticsGoogleAssistant extends GoogleAnalytics {
     }
 
     super.setGoogleAnalyticsObject(handleRequest);
+  }
+
+  protected async sendError(handleRequest: HandleRequest) {
+    const jovo: Jovo = handleRequest.jovo!;
+    if (jovo?.constructor.name !== 'GoogleAction') {
+      // don't send anything
+      return;
+    }
+    // Stop the current tracking session for google actions because they won't receive session ended requests
+    jovo.$googleAnalytics.visitor!.set('sessionControl', 'end');
+    await super.sendError(handleRequest);
   }
 }


### PR DESCRIPTION
## Proposed changes
Alexa is sending a session ended request when a backend error occurs. Because we already tracked it there and ended the google analytics session this second request will be seen as an additional session in analytics.
Now the runtime error (first request) will no longer end the session.
Additionally the runtime error (first request) will set the "Error" metric which was done in the session ended request before. This way you can Intents and Errors are linked in the analytics dashboard.  

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed