### PR TITLE
✨ Use postback-payload as input-text for FacebookMessenger

### DIFF
--- a/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
+++ b/platforms/platform-facebookmessenger/src/FacebookMessengerRequest.ts
@@ -48,7 +48,12 @@ export class FacebookMessengerRequest extends JovoRequest {
   }
 
   getInputText(): JovoInput['text'] {
-    return this.messaging?.[0]?.message?.text || this.messaging?.[0]?.postback?.title;
+    const messagingData = this.messaging?.[0];
+    return (
+      messagingData?.message?.text ||
+      messagingData?.postback?.payload ||
+      messagingData?.postback?.title
+    );
   }
 
   getInputAudio(): JovoInput['audio'] {


### PR DESCRIPTION
## Proposed changes
- If there is a postback-payload, it will be used as input-text instead of the postback-title.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed