### PR TITLE
🐛 Fix a bug when delegating from a global component with a non-empty state

### DIFF
--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -331,14 +331,16 @@ export abstract class Jovo<
       this.$handleRequest.activeComponentNode?.path,
     );
 
-    // make sure the state-stack exists and is not empty, even if it is a global component
-    // in order to do that we need to add the path of the currently active component
-    if (!this.$session.state?.length) {
-      this.$session.state = [
-        {
-          component: (this.$handleRequest.activeComponentNode?.path || []).join('.'),
-        },
-      ];
+    // if the component that is currently being executed is global
+    if (this.$handleRequest.activeComponentNode?.metadata?.isGlobal) {
+      // make sure there is a stack
+      if (!this.$session.state) {
+        this.$session.state = [];
+      }
+      // add the current component
+      this.$session.state.push({
+        component: this.$handleRequest.activeComponentNode.path.join('.'),
+      });
     }
 
     // serialize all values in 'resolve'
@@ -366,6 +368,9 @@ export abstract class Jovo<
       });
     }
     // push the delegating component to the state-stack
+    if (!this.$session.state) {
+      this.$session.state = [];
+    }
     this.$session.state.push({
       resolve: serializableResolve,
       config: serializableConfig,


### PR DESCRIPTION
## Proposed changes
- Improved delegation to take into account when the currently delegating component is a global component.
  - Global components usually do not get added to the state stack, but in order to delegate, a state is needed, therefore the global component is added to the stack when delegating but also immediately removed when resolving.

Closes #1049 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed