### PR TITLE
Fix/google sheets after API deprecation

### DIFF
--- a/jovo-integrations/jovo-cms-googlesheets/README.md
+++ b/jovo-integrations/jovo-cms-googlesheets/README.md
@@ -6,8 +6,6 @@ Learn how to use Google Sheets as CMS for your Alexa Skills and Google Actions.
 
 * [Introduction](#introduction)
 * [Configuration](#configuration)
-  * [Public Spreadsheets](#public-spreadsheets)
-  * [Private Spreadsheets](#private-spreadsheets)
 * [Default Sheet Types](#default-sheet-types)
   * [Default](#default)
   * [Responses](#responses)
@@ -69,7 +67,7 @@ module.exports = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
+            credentialsFile: './path/to/credentials.json',
             sheets: [
                 {
                     name: '<sheetName>',
@@ -92,7 +90,7 @@ const config = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
+            credentialsFile: './path/to/credentials.json',
             sheets: [
                 {
                     name: '<sheetName>',
@@ -109,133 +107,9 @@ const config = {
 
 Each sheet can be added as an object that includes both a `name` and a `type`. [Learn more about Sheet Types below](#default-sheet-types).
 
+To make spreadsheets work, you need to create a service account and security credentials. These can be downloaded as a JSON file and then referenced in the `credentialsFile` element (default is `./credentials.json`).
 
-Additional configuration might differ depending if you want to use a publicly accessible or private spreadsheet:
-
-* [Public Spreadsheets](#public-spreadsheets)
-* [Private Spreadsheets](#private-spreadsheets)
-
-### Public Spreadsheets
-
-> [Tutorial: Use Google Sheets as CMS for your Voice App](https://www.jovo.tech/tutorials/google-sheets-cms)
-
-Public spreadsheets allow you to get started quickly whithout having to care about credentials. We recommend setting up a public spreadsheet first and then turning to [private spreadsheets](#private-spreadsheets) later.
-
-For public spreadsheets, you need to add the following to your `config.js` file:
-
-```javascript
-// @language=javascript
-
-// src/config.js
-
-module.exports = {
-    
-    cms: {
-        GoogleSheetsCMS: {
-            spreadsheetId: '<YourSpreadsheetId>',
-            access: 'public',
-            sheets: [
-                {
-                    name: '<sheetName>',
-                    type: '<SheetType>',
-                    position: 1,
-                },
-            ]
-        }
-    },
-
-    // ...
-
-};
-
-// @language=typescript
-
-// src/config.ts
-
-const config = {
-    
-    cms: {
-        GoogleSheetsCMS: {
-            spreadsheetId: '<YourSpreadsheetId>',
-            access: 'public',
-            sheets: [
-                {
-                    name: '<sheetName>',
-                    type: '<SheetType>',
-                    position: 1,
-                },
-            ]
-        }
-    },
-
-    // ...
-
-};
-```
-
-The additional information you need to add for public spreadsheets is the `position` of the sheet. It is the position of the tab the sheet is located in.
-
-
-### Private Spreadsheets
-
-> [Tutorial: Use Private Google Spreadsheets as a CMS](https://www.jovo.tech/tutorials/google-spreadsheet-private-cms)
-
-With private spreadsheets, you can control who has access to your content. This comes with the price of a few more extra steps to set it up.
-
-For private spreadsheets, you need to add the following to your `config.js` file:
-
-```javascript
-// @language=javascript
-
-// src/config.js
-
-module.exports = {
-    
-    cms: {
-        GoogleSheetsCMS: {
-            spreadsheetId: '<YourSpreadsheetId>',
-            access: 'private',
-            credentialsFile: './path/to/credentials.json',
-            sheets: [
-                {
-                    name: 'responses',
-                    type: 'Responses',
-                },
-            ]
-        }
-    },
-
-    // ...
-
-};
-
-// @language=typescript
-
-// src/config.ts
-
-const config = {
-    
-    cms: {
-        GoogleSheetsCMS: {
-            spreadsheetId: '<YourSpreadsheetId>',
-            access: 'private',
-            credentialsFile: './path/to/credentials.json',
-            sheets: [
-                {
-                    name: 'responses',
-                    type: 'Responses',
-                },
-            ]
-        }
-    },
-
-    // ...
-
-};
-```
-
-To make private spreadsheets work, you need to create a service account and security credentials. These can be downloaded as a JSON file and then referenced in the `credentialsFile` element (default is `./credentials.json`).
-
+> [Tutorial: Use Google Spreadsheets as a CMS](https://www.jovo.tech/tutorials/google-spreadsheet-private-cms)
 
 ## Default Sheet Types
 
@@ -514,7 +388,6 @@ module.exports = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
             sheets: [
                 {
                     name: '<sheetName>',
@@ -537,7 +410,6 @@ const config = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
             sheets: [
                 {
                     name: '<sheetName>',
@@ -573,7 +445,6 @@ module.exports = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
             sheets: [
                 {
                     name: '<sheetName>',
@@ -598,7 +469,6 @@ const config = {
     cms: {
         GoogleSheetsCMS: {
             spreadsheetId: '<YourSpreadsheetId>',
-            access: '<public|private>',
             sheets: [
                 {
                     name: '<sheetName>',

--- a/jovo-integrations/jovo-cms-googlesheets/src/DefaultSheet.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/DefaultSheet.ts
@@ -92,28 +92,16 @@ export class DefaultSheet implements Plugin {
     let values: any[] = []; // tslint:disable-line
 
     const access = this.config.access || this.cms.config.access || 'private';
-    if (access === 'private') {
-      Log.verbose('Retrieving private spreadsheet');
-      Log.verbose('Spreadsheet ID: ' + spreadsheetId);
-      Log.verbose('Sheet name: ' + this.config.name);
-      Log.verbose('Sheet range: ' + this.config.range);
+    Log.verbose('Retrieving spreadsheet');
+    Log.verbose('Spreadsheet ID: ' + spreadsheetId);
+    Log.verbose('Sheet name: ' + this.config.name);
+    Log.verbose('Sheet range: ' + this.config.range);
 
-      values = await this.cms.loadPrivateSpreadsheetData(
-        spreadsheetId,
-        this.config.name,
-        this.config.range,
-      ); // tslint:disable-line
-    } else if (access === 'public') {
-      Log.verbose('Retrieving public spreadsheet');
-      Log.verbose('Spreadsheet ID: ' + spreadsheetId);
-      Log.verbose('Sheet position: ' + this.config.position);
-
-      const publicValues = await this.cms.loadPublicSpreadsheetData(
-        spreadsheetId,
-        this.config.position,
-      ); // tslint:disable-line
-      values = this.parsePublicToPrivate(publicValues);
-    }
+    values = await this.cms.loadPrivateSpreadsheetData(
+      spreadsheetId,
+      this.config.name,
+      this.config.range,
+    );
     if (values) {
       this.parse(handleRequest, values);
     }
@@ -136,6 +124,7 @@ export class DefaultSheet implements Plugin {
 
   /**
    * Parses public spreadsheet json to a private spreadsheet format
+   * @deprecated Google API v3 is deprecated
    * @param values
    * @returns {any[]}
    */

--- a/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
@@ -92,6 +92,7 @@ export class GoogleSheetsCMS extends BaseCmsPlugin {
     }
   }
 
+  // @deprecated
   async loadPublicSpreadsheetData(spreadsheetId: string, sheetPosition = 1) {
     const url = `https://spreadsheets.google.com/feeds/list/${spreadsheetId}/${sheetPosition}/public/values?alt=json`;
     Log.verbose('Accessing public spreadsheet: ' + url);

--- a/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/GoogleSheetsCMS.ts
@@ -30,7 +30,7 @@ export interface Config extends ExtensibleConfig {
   credentialsFile?: string;
   spreadsheetId?: string;
   sheets?: GoogleSheetsSheet[];
-  access?: string;
+  access?: string; // @deprecated
   caching?: boolean;
 }
 

--- a/jovo-integrations/jovo-cms-googlesheets/src/ResponsesSheet.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/ResponsesSheet.ts
@@ -149,7 +149,7 @@ export class ResponsesSheet extends DefaultSheet {
               platform,
               resource[platform],
               true,
-              false,
+              true,
             );
           }
         }
@@ -159,7 +159,7 @@ export class ResponsesSheet extends DefaultSheet {
           'translation',
           resource.translation,
           true,
-          false,
+          true,
         );
       });
     }

--- a/jovo-integrations/jovo-cms-googlesheets/src/ResponsesSheet.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/src/ResponsesSheet.ts
@@ -149,7 +149,7 @@ export class ResponsesSheet extends DefaultSheet {
               platform,
               resource[platform],
               true,
-              true,
+              false,
             );
           }
         }
@@ -159,7 +159,7 @@ export class ResponsesSheet extends DefaultSheet {
           'translation',
           resource.translation,
           true,
-          true,
+          false,
         );
       });
     }

--- a/jovo-integrations/jovo-cms-googlesheets/test/DefaultSheet.test.ts
+++ b/jovo-integrations/jovo-cms-googlesheets/test/DefaultSheet.test.ts
@@ -121,22 +121,6 @@ describe('DefaultSheet.parse()', () => {
   });
 });
 
-describe('DefaultSheet.parsePublicToPrivate()', () => {
-  test('should throw Jovo Error with empty feed', () => {
-    const defaultSheet = new DefaultSheet();
-    // tslint:disable-next-line:no-string-literal
-    expect(() => defaultSheet['parsePublicToPrivate']({ feed: {} })).toThrow(
-      'No spreadsheet values found.',
-    );
-  });
-
-  test('with valid values', () => {
-    const defaultSheet = new DefaultSheet();
-    // tslint:disable-next-line:no-string-literal
-    expect(defaultSheet['parsePublicToPrivate'](feed)).toStrictEqual(sheetValues);
-  });
-});
-
 describe('DefaultSheet.retrieve()', () => {
   test('should reject Promise if no parent is set', async () => {
     const defaultSheet = new DefaultSheet();
@@ -163,22 +147,5 @@ describe('DefaultSheet.retrieve()', () => {
     await expect(defaultSheet.retrieve(handleRequest)).rejects.toStrictEqual(
       new JovoError('sheet name has to be set.', ErrorCode.ERR_PLUGIN),
     );
-  });
-
-  test('should set retrieved values with parsePublicToPrivate() from mocked function loadPublicSpreadsheetData()', async () => {
-    const googleSheetsCMS = new GoogleSheetsCMS();
-    googleSheetsCMS.loadPublicSpreadsheetData = (spreadsheetId: string, sheetPosition = 1) =>
-      new Promise((res, rej) => res(feed));
-
-    const defaultSheet = new DefaultSheet({
-      access: 'public',
-      name: 'test',
-      range: 'A:B',
-      spreadsheetId: '123',
-    });
-    defaultSheet.install(googleSheetsCMS);
-
-    await defaultSheet.retrieve(handleRequest);
-    expect(handleRequest.app.$cms.test).toStrictEqual(sheetValues);
   });
 });


### PR DESCRIPTION
Fixes access to public spreadsheets after deprecation of the Google Sheets API v3

https://cloud.google.com/blog/products/g-suite/migrate-your-apps-use-latest-sheets-api#which_version_of_the_api_should_be_used


Jovo apps using `public` spreadsheets have to update the code.


## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed