### PR TITLE
🏷️  Allow passing strings to `$send` to directly add a message

### DIFF
--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -231,21 +231,23 @@ export abstract class Jovo<
     return this.$app.i18n.t<PATH, LANGUAGE, NAMESPACE>(path, options);
   }
 
+  async $send(message: string): Promise<void>;
   async $send(outputTemplate: OutputTemplate | OutputTemplate[]): Promise<void>;
   async $send<OUTPUT extends BaseOutput>(
     outputConstructor: OutputConstructor<OUTPUT, REQUEST, RESPONSE, this>,
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void>;
   async $send<OUTPUT extends BaseOutput>(
-    outputConstructorOrTemplate:
+    outputConstructorOrTemplateOrMessage:
+      | string
       | OutputConstructor<OUTPUT, REQUEST, RESPONSE, this>
       | OutputTemplate
       | OutputTemplate[],
     options?: DeepPartial<OUTPUT['options']>,
   ): Promise<void> {
     let newOutput: OutputTemplate | OutputTemplate[];
-    if (typeof outputConstructorOrTemplate === 'function') {
-      const outputInstance = new outputConstructorOrTemplate(this, options);
+    if (typeof outputConstructorOrTemplateOrMessage === 'function') {
+      const outputInstance = new outputConstructorOrTemplateOrMessage(this, options);
       const output = await outputInstance.build();
       // overwrite reserved properties of the built object i.e. message
       OutputTemplate.getKeys().forEach((key) => {
@@ -262,8 +264,12 @@ export abstract class Jovo<
         }
       });
       newOutput = output;
+    } else if (typeof outputConstructorOrTemplateOrMessage === 'string') {
+      newOutput = {
+        message: outputConstructorOrTemplateOrMessage,
+      };
     } else {
-      newOutput = outputConstructorOrTemplate;
+      newOutput = outputConstructorOrTemplateOrMessage;
     }
 
     // push the new OutputTemplate(s) to $output


### PR DESCRIPTION
## Proposed changes
A string can now be passed to `$send` of `Jovo` to which translates into `{  message: messageArg }`

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed