### PR TITLE
:adhesive_bandage: fix show typing method

### DIFF
--- a/jovo-platforms/jovo-platform-facebookmessenger/README.md
+++ b/jovo-platforms/jovo-platform-facebookmessenger/README.md
@@ -443,6 +443,17 @@ if (this.$messengerBot)
 await this.$messengerBot?.showAction(SenderActionType.TypingOn);
 ```
 
+There is also a helper method that sends the TypingOn and TypingOff action with a delay.
+
+```javascript
+// @language=javascript
+if (this.$messengerBot)
+	await this.$messengerBot.showTyping(5000); // Show typing bubble for 5 seconds.
+
+// @language=typescript
+await this.$messengerBot?.showTyping(SenderActionType.TypingOn); // Show typing bubble for 5 seconds.
+```
+
 Read more [here](https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions).
 
 ### Sending Templates

--- a/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
+++ b/jovo-platforms/jovo-platform-facebookmessenger/src/core/MessengerBot.ts
@@ -231,18 +231,14 @@ export class MessengerBot extends Jovo {
   }
 
   async showTyping(delayInMs: number): Promise<void> {
-    const typingOnRequest = await new SenderAction(
+    const typingOnRequest = new SenderAction(
       { id: this.$user.getId()! },
       SenderActionType.TypingOn,
     );
-    const typingOnResponse = typingOnRequest.send(this.pageAccessToken, this.version);
-
     const typingOffRequest = new SenderAction(
       { id: this.$user.getId()! },
       SenderActionType.TypingOff,
     );
-
-    const typingOffResponse = typingOffRequest.send(this.pageAccessToken, this.version);
 
     this.setResponses({
       typingOn: typingOnRequest,
@@ -250,19 +246,13 @@ export class MessengerBot extends Jovo {
       delayInMs: delayInMs,
     });
 
-    const promises: Array<Promise<SendMessageResponse | unknown>> = [typingOnResponse];
-
+    await typingOnRequest.send(this.pageAccessToken, this.version);
     // Remove delay when this method is being used in testing
     if (this.$host.headers['jovo-test'] !== 'true') {
-      const delay = new Promise((resolve) => setTimeout(resolve, delayInMs));
-      promises.push(delay);
+      await new Promise((resolve) => setTimeout(resolve, delayInMs));
     }
-
-    promises.push(typingOffResponse);
-
-    for (let i = 0; i < promises.length; i++) {
-      await promises[i];
-    }
+    await typingOffRequest.send(this.pageAccessToken, this.version);
+    return;
   }
 
   get version(): string {


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Hey Jovo team,

I introduced `this.$messengerBot.showTyping(delayInMs)` in my previous PR #983 . In that PR I made some mistakes to this method:

- Firing off sender actions before intended

Apologies for this.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed