### PR TITLE
Global Secondary Indexes and provisioned throughput for DynamoDB

### DIFF
--- a/jovo-integrations/jovo-db-dynamodb/README.md
+++ b/jovo-integrations/jovo-db-dynamodb/README.md
@@ -148,7 +148,7 @@ Without GSI, Jovo will create records with two keys in DynamoDB, `userId` and `u
         "userId": "user-id-1",
         "userData": {
             "data": {
-                "subscribed": 1
+                "yourKey": 1
             }
             ...
         }
@@ -157,7 +157,7 @@ Without GSI, Jovo will create records with two keys in DynamoDB, `userId` and `u
         "userId": "user-id-2",
         "userData": {
             "data": {
-                "subscribed": 0
+                "yourKey": 0
             }
             ...
         }
@@ -166,7 +166,7 @@ Without GSI, Jovo will create records with two keys in DynamoDB, `userId` and `u
         "userId": "user-id-3",
         "userData": {
             "data": {
-                "subscribed": 1
+                "yourKey": 1
             }
             ...
         }
@@ -174,9 +174,9 @@ Without GSI, Jovo will create records with two keys in DynamoDB, `userId` and `u
 ]
 ```
 
-If you wanted to do "Give me all users that are subscribed", you can't without GSIs. 
+If you want to query your user data based on other properties, you can't without GSIs. 
 
-When you configure DynamoDB to use GSI, Jovo behind the scenes will project keys you've specified to the root level. This will allow you to perform DynamoDB queries based on keys.
+When you configure DynamoDB to use GSI, Jovo behind the scenes will project keys you've specified to the root level. This will allow you to perform DynamoDB queries based on properties inside user data.
 
 GSIs configuration example:
 
@@ -196,15 +196,16 @@ module.exports = {
                 region:  'yourRegion',
             },
             globalSecondaryIndexes: [{
-                IndexName: "subscribedIndex",
+                IndexName: "yourKeyIndex",
                 KeySchema: [
                     {
-                    AttributeName: "subscribed",
-                    // The type you want to store it as. Can only be "N","S","B" according to DynamoDB docs.
+                    AttributeName: "yourKey",
+                    // The type you want to store it as. 
+                    // LIMITATION: According to DynamoDB docs, HASH and SORT keys can only be "N","S","B".
                     AttributeType: "N", 
                     KeyType: "HASH",
-                    // The path from Jovo's userData you want to query on. In this case we want to perform queries based on the subscribed key.
-                    Path: "data.subscribed",
+                    // The path from Jovo's userData you want to query on. In this case we want to perform queries based on "yourKey".
+                    Path: "data.yourKey",
                     },
                 ],
                 ProvisionedThroughput: {
@@ -234,15 +235,16 @@ const config = {
                 region:  'yourRegion',
             },
             globalSecondaryIndexes: [{
-                IndexName: "subscribedIndex",
+                IndexName: "yourKeyIndex",
                 KeySchema: [
                     {
-                    AttributeName: "subscribed",
-                    // The type you want to store it as. Can only be "N","S","B" according to DynamoDB docs.
+                    AttributeName: "yourKey",
+                    // The type you want to store it as. 
+                    // LIMITATION: According to DynamoDB docs, HASH and SORT keys can only be "N","S","B".
                     AttributeType: "N",
                     KeyType: "HASH",
-                    // The path from Jovo's userData you want to query on. In this case we want to perform queries based on the subscribed key.
-                    Path: "data.subscribed",
+                    // The path from Jovo's userData you want to query on. In this case we want to perform queries based on "yourKey".
+                    Path: "data.yourKey",
                     },
                 ],
                 ProvisionedThroughput: {
@@ -258,7 +260,7 @@ const config = {
 };
 ```
 
-The above configuration will project `userData.data.subscribed` to the root level of the record. Using the example data above, it will transform the data to look something like this:
+The above configuration will project `userData.data.yourKey` to the root level of the record. Using the example data above, it will transform the data to look something like this:
 
 ```javascript
 // example of data saved in DynamoDB
@@ -266,30 +268,30 @@ The above configuration will project `userData.data.subscribed` to the root leve
 "Items": [
     {
         "userId": "user-id-1",
-        "subscribed": 1, // <---- New field added
+        "yourKey": 1, // <---- New field added
         "userData": {
             "data": {
-                "subscribed": 1
+                "yourKey": 1
             }
             ...
         }
     },
     {
         "userId": "user-id-2",
-        "subscribed": 0, // <---- New field added
+        "yourKey": 0, // <---- New field added
         "userData": {
             "data": {
-                "subscribed": 0
+                "yourKey": 0
             }
             ...
         }
     },
     {
         "userId": "user-id-3",
-        "subscribed": 1, // <---- New field added
+        "yourKey": 1, // <---- New field added
         "userData": {
             "data": {
-                "subscribed": 1
+                "yourKey": 1
             }
             ...
         }
@@ -297,7 +299,7 @@ The above configuration will project `userData.data.subscribed` to the root leve
 ]
 ```
 
-You can now peform DynamoDB queries based on the subscribed key.
+You can now peform DynamoDB queries based on 'yourKey'.
 
 ## Provisioned throughput
 

--- a/jovo-integrations/jovo-db-dynamodb/src/DynamoDb.ts
+++ b/jovo-integrations/jovo-db-dynamodb/src/DynamoDb.ts
@@ -280,6 +280,7 @@ export class DynamoDb implements Db {
           AttributeType: 'S',
         },
       ],
+      GlobalSecondaryIndexes: [],
       KeySchema: [
         {
           AttributeName: this.config.primaryKeyColumn!,
@@ -287,7 +288,6 @@ export class DynamoDb implements Db {
         },
       ],
       ProvisionedThroughput: this.config.provisionedThroughput ?? DEFAULT_PROVISIONED_THROUGHPUT,
-      GlobalSecondaryIndexes: [],
       TableName: this.config.tableName!,
     };
 

--- a/jovo-integrations/jovo-db-dynamodb/test/DynamoDb.test.ts
+++ b/jovo-integrations/jovo-db-dynamodb/test/DynamoDb.test.ts
@@ -268,16 +268,16 @@ describe('test database operations', () => {
               {
                 AttributeName: 'testAttrGSI',
                 AttributeType: 'S',
-                Path: 'data.testKey',
                 KeyType: 'S',
+                Path: 'data.testKey',
               },
             ],
             Projection: {
               ProjectionType: 'ALL',
             },
             ProvisionedThroughput: {
-              WriteCapacityUnits: 1,
               ReadCapacityUnits: 2,
+              WriteCapacityUnits: 1,
             },
           },
         ],
@@ -295,12 +295,12 @@ describe('test database operations', () => {
 
       expect(mockPut).toHaveBeenCalledTimes(1);
       expect(mockPut).toHaveBeenCalledWith({
-        TableName: 'test',
         Item: {
           [key]: dummyData,
           [dynamoDb.config.globalSecondaryIndexes![0].KeySchema[0].AttributeName]: 'test-value',
           userId: 'id',
         },
+        TableName: 'test',
       });
     });
   });
@@ -514,7 +514,6 @@ describe('test database operations', () => {
       };
 
       const ddbConfigWithGSI = {
-        tableName: 'TestTable',
         globalSecondaryIndexes: [
           {
             IndexName: 'TestIndex',
@@ -522,19 +521,20 @@ describe('test database operations', () => {
               {
                 AttributeName: 'test',
                 AttributeType: 'S',
-                Path: 'data.testKey',
                 KeyType: 'S',
+                Path: 'data.testKey',
               },
             ],
             Projection: {
               ProjectionType: 'ALL',
             },
             ProvisionedThroughput: {
-              WriteCapacityUnits: 1,
               ReadCapacityUnits: 2,
+              WriteCapacityUnits: 1,
             },
           },
         ],
+        tableName: 'TestTable',
       };
 
       dynamoDb = new DynamoDb(ddbConfigWithGSI);
@@ -576,9 +576,9 @@ describe('test database operations', () => {
       delete gsiRequest[0].KeySchema[0].Path;
 
       expect(mockCreateTable).toHaveBeenCalledWith({
+        AttributeDefinitions: attributeDefinitions,
         ...defaultCreateTableRequests,
         GlobalSecondaryIndexes: gsiRequest,
-        AttributeDefinitions: attributeDefinitions,
       });
     });
   });


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
Hey Jovo team, I have added the ability to configure global secondary indexes and provisioned throughput for DynamoDB. I've run into a use case where a separate application needs to perform queries based on keys within the userData object. 

Any feedback is welcomed.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed