### PR TITLE
:sparkles: Add NextScene output, onScene GoogleAssistantHandle

### DIFF
--- a/output/output-googleassistant/README.md
+++ b/output/output-googleassistant/README.md
@@ -136,7 +136,7 @@ The [generic `quickReplies` element](https://v4.jovo.tech/docs/output-templates#
 ```typescript
 {
   // ...
-  quickReplies: ['Yes', 'No'];
+  quickReplies: ['Yes', 'No'],
 }
 ```
 
@@ -165,7 +165,7 @@ If you define your `quickReplies` using objects instead of strings, the `text` p
       value: 'yes',
     },
     // ...
-  ];
+  ],
 }
 ```
 

--- a/output/output-googleassistant/README.md
+++ b/output/output-googleassistant/README.md
@@ -2,6 +2,7 @@
 title: 'Google Assistant Output'
 excerpt: 'Learn more about Jovo output templates for Google Assistant Output.'
 ---
+
 # Google Assistant Output
 
 Learn more about output templates for [Google Assistant](https://v4.jovo.tech/marketplace/platform-googleassistant).
@@ -33,7 +34,6 @@ You can also add platform-specific output to an output template. [Learn more abo
 }
 ```
 
-
 ## Generic Output Elements
 
 Generic output elements are in the root of the output template and work across platforms. [Learn more in the Jovo output template docs](https://v4.jovo.tech/docs/output-templates).
@@ -43,9 +43,9 @@ Below, you can find a list of generic output elements that work with Google Assi
 - [`message`](#message)
 - [`reprompt`](#reprompt)
 - [`listen`](#listen)
-- [`quickReplies`](#quickreplies-suggestions) (called *suggestions* in Google Assistant)
+- [`quickReplies`](#quickreplies-suggestions) (called _suggestions_ in Google Assistant)
 - [`card`](#card)
-- [`carousel`](#carousel) (called *collection* in Google Assistant)
+- [`carousel`](#carousel) (called _collection_ in Google Assistant)
 
 ### message
 
@@ -114,7 +114,7 @@ Under the hood, Jovo translates the `reprompt` into `NO_INPUT_1`, `NO_INPUT_2`, 
 
 ### listen
 
-The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen)  determines if Google Assistant should keep the microphone open and wait for a user's response.
+The [`listen` element](https://v4.jovo.tech/docs/output-templates#listen) determines if Google Assistant should keep the microphone open and wait for a user's response.
 
 By default (if you don't specify it otherwise in the template), `listen` is set to `true`. If you want to close a session after a response, you need to set it to `false`:
 
@@ -136,7 +136,7 @@ The [generic `quickReplies` element](https://v4.jovo.tech/docs/output-templates#
 ```typescript
 {
   // ...
-  quickReplies: [ 'Yes', 'No' ]
+  quickReplies: ['Yes', 'No'];
 }
 ```
 
@@ -157,19 +157,17 @@ Under the hood, Jovo translates `quickReplies` into the following:
 
 If you define your `quickReplies` using objects instead of strings, the `text` property will be used for the resulting `title`:
 
-
 ```typescript
 {
   quickReplies: [
     {
       text: 'oh yeah', // this is used for 'title'
-      value: 'yes'
+      value: 'yes',
     },
     // ...
-  ]
+  ];
 }
 ```
-
 
 ### card
 
@@ -197,7 +195,7 @@ Under the hood, this gets translated into the following object as part of the re
     "text": "Welcome to this new app built with Jovo.", // Taken from 'content'
     "image": {
       "alt": "Hello world!", // Taken from 'title'
-      "url": "https://...",
+      "url": "https://..."
     }
   }
 }
@@ -205,7 +203,7 @@ Under the hood, this gets translated into the following object as part of the re
 
 ### carousel (Collection)
 
-A [generic `carousel` element](https://v4.jovo.tech/docs/output-templates#carousel) is a horizontally scrollable set of [`card`](#card) items. In Google Assistant, this is called a *collection*. [Learn more in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-selection?hl=en#collection).
+A [generic `carousel` element](https://v4.jovo.tech/docs/output-templates#carousel) is a horizontally scrollable set of [`card`](#card) items. In Google Assistant, this is called a _collection_. [Learn more in the official Google Assistant docs](https://developers.google.com/assistant/conversational/prompts-selection?hl=en#collection).
 
 ```typescript
 {
@@ -246,10 +244,9 @@ A [generic `carousel` element](https://v4.jovo.tech/docs/output-templates#carous
 
 It includes the following properties:
 
-* `selection` (required): This is used to map a selection of an item to both an `intent` and an `entityType`. The type is needed to create a type override ([see official Google documentation](https://developers.google.com/assistant/conversational/webhooks?hl=en&tool=builder#runtime_type_overrides)).
-* `items` (required): An array of elements to be displayed. They also need to include a `selection` property with an `entities` map.
-* `title` (optional): A string that gets displayed at the top.
-
+- `selection` (required): This is used to map a selection of an item to both an `intent` and an `entityType`. The type is needed to create a type override ([see official Google documentation](https://developers.google.com/assistant/conversational/webhooks?hl=en&tool=builder#runtime_type_overrides)).
+- `items` (required): An array of elements to be displayed. They also need to include a `selection` property with an `entities` map.
+- `title` (optional): A string that gets displayed at the top.
 
 ## Google Assistant Output Elements
 
@@ -285,7 +282,11 @@ The [`nativeResponse` property](https://v4.jovo.tech/docs/output-templates#nativ
 }
 ```
 
-For example, you can add `scene` information ([see the official Google docs](https://developers.google.com/assistant/conversational/webhooks?hl=en&tool=builder#response-json_4)) like this:
+You can find examples for the [Google Assistant response format in the official Google documentation](https://developers.google.com/assistant/conversational/webhooks?hl=en&tool=builder#example-response).
+
+### scene
+
+By using [`nativeResponse`](#nativeresponse) you can add information about [Google Assistant scenes](https://v4.jovo.tech/marketplace/platform-googleassistant/scenes) like this:
 
 ```typescript
 {
@@ -297,7 +298,7 @@ For example, you can add `scene` information ([see the official Google docs](htt
           name: 'SceneName',
           slots: {},
           next: {
-            name: 'HiddenScene',
+            name: 'SomeScene',
           }
         }
       }
@@ -306,4 +307,4 @@ For example, you can add `scene` information ([see the official Google docs](htt
 }
 ```
 
-You can find examples for the [Google Assistant response format in the official Google documentation](https://developers.google.com/assistant/conversational/webhooks?hl=en&tool=builder#example-response).
+This way, you can transition to a scene (like `SomeScene` in the example above).

--- a/platforms/platform-googleassistant/docs/scenes.md
+++ b/platforms/platform-googleassistant/docs/scenes.md
@@ -2,19 +2,20 @@
 title: 'Google Assistant Scenes'
 excerpt: 'Learn how to use scenes when building Google Conversational Actions with Jovo.'
 ---
+
 # Google Assistant Scenes
 
 Learn how to use scenes when building Google Conversational Actions with Jovo.
 
 ## Introduction
 
-Scenes are a concept of Google Conversational Actions that are similar to Jovo Components. They are configurable building blocks or flows that are responsible for specific tasks. You can learn more in the [official documentation by Google](https://developers.google.com/assistant/conversational/scenes).
+Scenes are a concept of Google Conversational Actions that are similar to [Jovo Components](https://v4.jovo.tech/docs/components). They are configurable building blocks or flows that are responsible for specific tasks. You can learn more in the [official documentation by Google](https://developers.google.com/assistant/conversational/scenes).
 
-You can configure scenes either in the [Actions Console](https://console.actions.google.com/) or in your Jovo Model. [Learn more about model configuration below](#model-configuration).
+You can configure scenes either in the [Actions Console](https://console.actions.google.com/) or in your [Jovo Model](https://v4.jovo.tech/docs/models). [Learn more about model configuration below](#model-configuration).
 
 Google provides a handful of pre-configured [system scenes](https://developers.google.com/assistant/conversational/scenes#system_scenes) you can use for tasks such as [account linking](https://v4.jovo.tech/marketplace/platform-googleassistant/account-linking). For more specialized tasks, it is possible to define your own [custom scenes](#custom-scenes).
 
-
+In your Jovo app, you can delegate to a scene as well as accept requests from a scene. Learn more in the [communication between Jovo and scenes](#communication-between-jovo-and-scenes) section.
 
 ## Model Configuration
 
@@ -37,7 +38,7 @@ We recommend adding scenes to the [Jovo Model](https://v4.jovo.tech/marketplace/
                         {
                           "speech": "Hello World!"
                         }
-                      ] 
+                      ]
                     },
                     "suggestions": [
                       {
@@ -61,14 +62,13 @@ We recommend adding scenes to the [Jovo Model](https://v4.jovo.tech/marketplace/
 
 The syntax is the same as in your Action's `.yaml` files, but in JSON format.
 
-
 ## Custom Scenes
 
-Custom Scenes have three stages you can configure: 
+Custom Scenes have three stages you can configure:
 
-* [Activation](#activation): A scene must be activated either by a scene transition or intent matching.
-* [Execution](#execution): Once activated, a scene executes it's lifecycle, containing a variation of tasks and conversational flows.
-* [Transition](#transition): When a scene's lifecycle has been completed, it follows it's defined transition, e.g. ending the conversation or transitioning to another scene.
+- [Activation](#activation): A scene must be activated either by a scene transition or intent matching.
+- [Execution](#execution): Once activated, a scene executes it's lifecycle, containing a variation of tasks and conversational flows.
+- [Transition](#transition): When a scene's lifecycle has been completed, it follows it's defined transition, e.g. ending the conversation or transitioning to another scene.
 
 You can also learn more about [custom scenes in the official Google documentation](https://developers.google.com/assistant/conversational/scenes#custom_scenes).
 
@@ -240,5 +240,54 @@ Once your transition criteria have been met, you can define a transition to cont
 		  "transitionToScene": "AnotherCustomScene"
 		},
   ],
+}
+```
+
+## Communication Between Jovo and Scenes
+
+You can transition to a scene from your Jovo handlers by adding a scene property to your [Google Assistant output](https://v4.jovo.tech/marketplace/platform-googleassistant/output).
+
+You can either do this in [`nativeResponse` using `scene.next`](https://v4.jovo.tech/marketplace/platform-googleassistant/output#next-scene) or use the `NextSceneOutput` class:
+
+```typescript
+import { NextSceneOutput } from '@jovotech/platform-googleassistant';
+
+yourHandler() {
+  // ...
+
+  return this.$send(NextSceneOutput, { name: 'SomeScene' })
+}
+```
+
+Under the hood, `NextSceneOutput` looks like this:
+
+```typescript
+{
+  message: this.options.message,
+  platforms: {
+    googleAssistant: {
+      nativeResponse: {
+        scene: {
+          name: this.jovo.$googleAssistant?.$request.scene?.name,
+          slots: this.options.slots || {},
+          next: {
+            name: this.options.name,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+You can also accept requests coming from a scene by using the `onScene` handle:
+
+```typescript
+import { GoogleAssistantHandles } from '@jovotech/platform-googleassistant';
+// ...
+
+@Handle(GoogleAssistantHandles.onScene('CollectionScene'))
+handleCollectionScene() {
+  // ...
 }
 ```

--- a/platforms/platform-googleassistant/src/GoogleAssistantHandles.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantHandles.ts
@@ -4,7 +4,6 @@ import { GoogleAssistantRequest } from './GoogleAssistantRequest';
 export class GoogleAssistantHandles {
   static onScene(sceneName: string): HandleOptions {
     return {
-      global: true,
       types: [InputType.Intent],
       platforms: ['googleAssistant'],
       if: (jovo: Jovo) => (jovo.$request as GoogleAssistantRequest).scene?.name === sceneName,

--- a/platforms/platform-googleassistant/src/GoogleAssistantHandles.ts
+++ b/platforms/platform-googleassistant/src/GoogleAssistantHandles.ts
@@ -1,0 +1,13 @@
+import { HandleOptions, InputType, Jovo } from '@jovotech/framework';
+import { GoogleAssistantRequest } from './GoogleAssistantRequest';
+
+export class GoogleAssistantHandles {
+  static onScene(sceneName: string): HandleOptions {
+    return {
+      global: true,
+      types: [InputType.Intent],
+      platforms: ['googleAssistant'],
+      if: (jovo: Jovo) => (jovo.$request as GoogleAssistantRequest).scene?.name === sceneName,
+    };
+  }
+}

--- a/platforms/platform-googleassistant/src/index.ts
+++ b/platforms/platform-googleassistant/src/index.ts
@@ -43,4 +43,8 @@ export * from './GoogleAssistant';
 export * from './GoogleAssistantPlatform';
 export * from './GoogleAssistantRequest';
 export * from './GoogleAssistantUser';
+export * from './GoogleAssistantHandles';
+
 export * from './interfaces';
+
+export * from './output/NextSceneOutput';

--- a/platforms/platform-googleassistant/src/output/NextSceneOutput.ts
+++ b/platforms/platform-googleassistant/src/output/NextSceneOutput.ts
@@ -1,0 +1,28 @@
+import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
+
+export interface NextSceneOptions extends OutputOptions {
+  name: string;
+  slots?: Record<string, unknown>;
+}
+
+@Output()
+export class NextSceneOutput extends BaseOutput<NextSceneOptions> {
+  build(): OutputTemplate | OutputTemplate[] {
+    return {
+      message: this.options.message,
+      platforms: {
+        googleAssistant: {
+          nativeResponse: {
+            scene: {
+              name: this.jovo.$googleAssistant?.$request.scene?.name,
+              slots: this.options.slots || {},
+              next: {
+                name: this.options.name,
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Proposed changes
Add `NextSceneOutput` and `GoogleAssistantHandles.onScene(name: string)` helper

Usage:
```typescript
export class GlobalComponent extends BaseComponent {
  LAUNCH() {
    return this.$send(NextSceneOutput, { name: 'CollectionScene' });
  }

  @Handle(GoogleAssistantHandles.onScene('CollectionScene'))
  handleCollectionScene() {
    return this.$send({ message: 'hello' });
  }
}
```

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed