### PR TITLE
:recycle: Adjust Jovo Debugger plugin

### DIFF
--- a/integrations/plugin-debugger/docs/debugger-config.md
+++ b/integrations/plugin-debugger/docs/debugger-config.md
@@ -20,7 +20,7 @@ const { DebuggerConfig } = require('@jovotech/plugin-debugger');
 
 // ...
 
-const debugger = new DebuggerConfig({
+const debuggerConfig = new DebuggerConfig({
   locales: [ 'en' ],
   buttons: [
 		{
@@ -38,6 +38,8 @@ const debugger = new DebuggerConfig({
     // ...
   ]
 });
+
+module.exports = debuggerConfig;
 ```
 
 It includes the following properties:
@@ -51,7 +53,7 @@ It includes the following properties:
 The `locales` property defines which locales can be selected in the Debugger:
 
 ```js
-const debugger = new DebuggerConfig({
+const debuggerConfig = new DebuggerConfig({
   locales: [ 'en', 'de' ],
   // ...
 });
@@ -66,7 +68,7 @@ The `buttons` array defines which input buttons should be displayed in the Debug
 It's possible to either use `input` or a raw `request`:
 
 ```js
-const debugger = new DebuggerConfig({
+const debuggerConfig = new DebuggerConfig({
   buttons: [
 
     // Button with Input

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -68,6 +68,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
 
   getDefaultConfig(): JovoDebuggerConfig {
     return {
+      skipTests: true,
       nlu: new NlpjsNlu({
         languageMap: getDefaultLanguageMap(),
       }),

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -68,7 +68,6 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
 
   getDefaultConfig(): JovoDebuggerConfig {
     return {
-      skipTests: true,
       nlu: new NlpjsNlu({
         languageMap: getDefaultLanguageMap(),
       }),


### PR DESCRIPTION
## Proposed changes
This PR adjusts some minor details about the Jovo Debugger plugin. Since `debugger` is a reserved keyword, we'll have to use `debuggerConfig` in `jovo.debugger.js` instead. 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed