### PR TITLE
🐛🏷️ Fix typing bug that caused $t method to not work as intended

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -35,7 +35,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "ts-mixer": "^6.0.0",
-    "ts-toolbelt": "^9.6.0",
+    "ts-toolbelt": "9.5.13",
     "type-fest": "^2.5.1",
     "uuid": "^8.3.2"
   },

--- a/framework/src/I18Next.ts
+++ b/framework/src/I18Next.ts
@@ -51,15 +51,6 @@ export type I18NextValueAt<
   >,
 > = RESULT extends undefined ? string : RESULT;
 
-export type I18NextTFunctionReturnType<
-  FORCED_RESULT extends any,
-  PATH extends string,
-  LANGUAGE extends I18NextResourcesLanguageKeys | string,
-  NAMESPACE extends I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE> | string,
-  VALUE = I18NextValueAt<PATH, LANGUAGE, NAMESPACE>,
-  // if the forced result is not never, return the forced result, otherwise return the value
-> = A.Equals<FORCED_RESULT, never> extends 0 ? FORCED_RESULT : VALUE;
-
 // Custom init-options for i18next in case some custom properties are used in the future.
 export interface I18NextOptions extends InitOptions {}
 export type I18NextTFunctionResult = TFunctionResult;

--- a/framework/src/I18Next.ts
+++ b/framework/src/I18Next.ts
@@ -104,20 +104,20 @@ export class I18Next {
   }
 
   t<
-    FORCED_RESULT = never,
-    PATH extends string = string,
+    PATH extends string,
     LANGUAGE extends I18NextResourcesLanguageKeys | string = I18NextResourcesLanguageKeys,
     NAMESPACE extends
       | I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>
       | string = I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>,
-    RETURN_TYPE = I18NextTFunctionReturnType<FORCED_RESULT, PATH, LANGUAGE, NAMESPACE>,
   >(
     path:
       | I18NextAutoPath<PATH, LANGUAGE, NAMESPACE>
       | PATH
       | Array<I18NextAutoPath<PATH, LANGUAGE, NAMESPACE> | PATH>,
     options?: I18NextTOptions<LANGUAGE, NAMESPACE>,
-  ): RETURN_TYPE {
-    return this.i18n.t(path, options) as unknown as RETURN_TYPE;
+  ): I18NextValueAt<PATH, LANGUAGE, NAMESPACE>;
+  t<FORCED_RESULT>(path: string | string[], options?: I18NextTFunctionOptions): FORCED_RESULT;
+  t(path: string | string[], options?: I18NextTFunctionOptions): I18NextTFunctionResult {
+    return this.i18n.t(path, options);
   }
 }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -15,8 +15,10 @@ import {
   I18NextAutoPath,
   I18NextResourcesLanguageKeys,
   I18NextResourcesNamespaceKeysOfLanguage,
-  I18NextTFunctionReturnType,
+  I18NextTFunctionOptions,
+  I18NextTFunctionResult,
   I18NextTOptions,
+  I18NextValueAt,
   JovoInput,
   MetadataStorage,
   OutputConstructor,
@@ -206,21 +208,21 @@ export abstract class Jovo<
   }
 
   $t<
-    FORCED_RESULT = never,
-    PATH extends string = string,
+    PATH extends string,
     LANGUAGE extends I18NextResourcesLanguageKeys | string = I18NextResourcesLanguageKeys,
     NAMESPACE extends
       | I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>
       | string = I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>,
-    RETURN_TYPE = I18NextTFunctionReturnType<FORCED_RESULT, PATH, LANGUAGE, NAMESPACE>,
   >(
     path:
       | I18NextAutoPath<PATH, LANGUAGE, NAMESPACE>
       | PATH
       | Array<I18NextAutoPath<PATH, LANGUAGE, NAMESPACE> | PATH>,
     options?: I18NextTOptions<LANGUAGE, NAMESPACE>,
-  ): RETURN_TYPE {
-    return this.$app.i18n.t<FORCED_RESULT, PATH, LANGUAGE, NAMESPACE, RETURN_TYPE>(path, options);
+  ): I18NextValueAt<PATH, LANGUAGE, NAMESPACE>;
+  $t<FORCED_RESULT>(path: string | string[], options?: I18NextTFunctionOptions): FORCED_RESULT;
+  $t(path: string | string[], options?: I18NextTFunctionOptions): I18NextTFunctionResult {
+    return this.$app.i18n.t(path, options);
   }
 
   async $send(outputTemplateOrMessage: OutputTemplate | OutputTemplate[] | string): Promise<void>;

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -15,9 +15,7 @@ import {
   I18NextAutoPath,
   I18NextResourcesLanguageKeys,
   I18NextResourcesNamespaceKeysOfLanguage,
-  I18NextResult,
-  I18NextTFunctionOptions,
-  I18NextTFunctionResult,
+  I18NextTFunctionReturnType,
   I18NextTOptions,
   JovoInput,
   MetadataStorage,
@@ -26,7 +24,6 @@ import {
   PersistableUserData,
   Server,
   StateStackItem,
-  StringLiteral,
 } from './index';
 
 import { EntityMap, RequestData } from './interfaces';
@@ -208,27 +205,22 @@ export abstract class Jovo<
     };
   }
 
-  // The first signature only allows string literals
   $t<
-    PATH extends string,
+    FORCED_RESULT = never,
+    PATH extends string = string,
     LANGUAGE extends I18NextResourcesLanguageKeys | string = I18NextResourcesLanguageKeys,
     NAMESPACE extends
       | I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>
       | string = I18NextResourcesNamespaceKeysOfLanguage<LANGUAGE>,
-    LITERAL_PATH extends string = StringLiteral<PATH>,
+    RETURN_TYPE = I18NextTFunctionReturnType<FORCED_RESULT, PATH, LANGUAGE, NAMESPACE>,
   >(
     path:
-      | I18NextAutoPath<LITERAL_PATH, LANGUAGE, NAMESPACE>
-      | LITERAL_PATH
-      | Array<I18NextAutoPath<LITERAL_PATH, LANGUAGE, NAMESPACE> | LITERAL_PATH>,
+      | I18NextAutoPath<PATH, LANGUAGE, NAMESPACE>
+      | PATH
+      | Array<I18NextAutoPath<PATH, LANGUAGE, NAMESPACE> | PATH>,
     options?: I18NextTOptions<LANGUAGE, NAMESPACE>,
-  ): I18NextResult<LITERAL_PATH, LANGUAGE, NAMESPACE>;
-  $t<RESULT extends I18NextTFunctionResult = string>(
-    path: string | string[],
-    options?: I18NextTFunctionOptions,
-  ): RESULT;
-  $t(path: string | string[], options?: I18NextTFunctionOptions): I18NextTFunctionResult {
-    return this.$app.i18n.t(path, options);
+  ): RETURN_TYPE {
+    return this.$app.i18n.t<FORCED_RESULT, PATH, LANGUAGE, NAMESPACE, RETURN_TYPE>(path, options);
   }
 
   async $send(outputTemplateOrMessage: OutputTemplate | OutputTemplate[] | string): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.4",
+    "ts-toolbelt": "9.5.13",
     "typescript": "^4.2.3"
   },
   "dependencies": {}


### PR DESCRIPTION
## Proposed changes
Previously, if a path was passed that could not be found, the assumed type was TFunctionResult, now it is string like expected. In case the return type has to be casted, it can be done by manually passing the desired type as first generic parameter.

ts-toolbelt also had to be downgraded due to changes in F.AutoPath that caused the last part of a path to not be shown in auto-completion.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed