### PR TITLE
Added currentLocation to Device Interface

### DIFF
--- a/jovo-platforms/jovo-platform-googleassistantconv/src/core/Interfaces.ts
+++ b/jovo-platforms/jovo-platform-googleassistantconv/src/core/Interfaces.ts
@@ -449,13 +449,21 @@ export interface Session {
   typeOverrides?: TypeOverride[];
   languageCode?: string;
 }
+
 export interface Home {
   params: Params;
 }
 
 export interface Device {
   capabilities: Capability[];
+  currentLocation?: CurrentLocation;
 }
+
+export interface CurrentLocation {
+  coordinates?: LatLng,
+  postalAddress?: PostalAddress
+}
+
 export interface Expected {
   speech: string[];
   languageCode: string;
@@ -609,8 +617,8 @@ export interface Merchant {
 }
 
 export interface LatLng {
-  latitude: number;
-  longitude: number;
+  latitude?: number;
+  longitude?: number;
 }
 export interface Location {
   coordinates?: LatLng;


### PR DESCRIPTION
The device location of the user can be requested by Permissions. Note, this is only populated in the response JSON after location permissions are granted by the end user.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed