### PR TITLE
Remove table view on `jovo run` + undefined properties in logger

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -23,12 +23,16 @@
   "author": "jovotech",
   "license": "Apache-2.0",
   "dependencies": {
+    "lodash.merge": "^4.6.2",
+    "lodash.clonedeep": "^4.5.0",
     "ts-toolbelt": "9.5.13",
     "tslog": "^3.2.2",
     "type-fest": "^2.5.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
+    "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^10.17.50",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -8,6 +8,7 @@ import {
 import _merge from 'lodash.merge';
 import { JovoError } from './JovoError';
 import { inspect } from 'util';
+import { AnyObject } from './index';
 export class JovoLogger extends TsLogger {
   constructor(settings?: ISettingsParam) {
     super();
@@ -77,7 +78,20 @@ export class JovoLogger extends TsLogger {
 
     if (error.context) {
       noStyleLogger.error(`\n${this.style('context:', 'underline')}`);
-      noStyleLogger.error(JSON.parse(JSON.stringify(error.context)));
+
+      const removeUndefined = (obj: AnyObject) => {
+        const nObj: AnyObject = {};
+        Object.keys(obj).forEach((key) => {
+          if (obj[key] === Object(obj[key])) {
+            nObj[key] = removeUndefined(obj[key]);
+          } else if (obj[key] !== undefined) {
+            nObj[key] = obj[key];
+          }
+        });
+        return nObj;
+      };
+
+      noStyleLogger.error(removeUndefined(error.context));
     }
 
     if (error.stack) {

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -77,7 +77,7 @@ export class JovoLogger extends TsLogger {
 
     if (error.context) {
       noStyleLogger.error(`\n${this.style('context:', 'underline')}`);
-      noStyleLogger.error(error.context);
+      noStyleLogger.error(JSON.parse(JSON.stringify(error.context)));
     }
 
     if (error.stack) {

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -6,6 +6,7 @@ import {
   ILogObject,
 } from 'tslog';
 import _merge from 'lodash.merge';
+import _cloneDeep from 'lodash.clonedeep';
 import { JovoError } from './JovoError';
 import { inspect } from 'util';
 import { AnyObject } from './index';
@@ -79,19 +80,15 @@ export class JovoLogger extends TsLogger {
     if (error.context) {
       noStyleLogger.error(`\n${this.style('context:', 'underline')}`);
 
-      const removeUndefined = (obj: AnyObject) => {
-        const nObj: AnyObject = {};
-        Object.keys(obj).forEach((key) => {
-          if (obj[key] === Object(obj[key])) {
-            nObj[key] = removeUndefined(obj[key]);
-          } else if (obj[key] !== undefined) {
-            nObj[key] = obj[key];
+      const formatContext = (contextObject: AnyObject) => {
+        return Object.keys(contextObject).reduce((context, key) => {
+          if (typeof context[key] === 'undefined') {
+            delete context[key];
           }
-        });
-        return nObj;
+          return context;
+        }, _cloneDeep(contextObject));
       };
-
-      noStyleLogger.error(removeUndefined(error.context));
+      noStyleLogger.error(formatContext(error.context));
     }
 
     if (error.stack) {

--- a/integrations/plugin-debugger/package.json
+++ b/integrations/plugin-debugger/package.json
@@ -29,7 +29,6 @@
     "@nlpjs/lang-es": "^4.22.0",
     "@nlpjs/lang-fr": "^4.22.0",
     "@nlpjs/lang-it": "^4.22.0",
-    "cli-table": "^0.3.6",
     "fast-deep-equal": "^3.1.3",
     "open": "^8.0.7",
     "socket.io-client": "^2.4.0",

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -44,7 +44,6 @@ import {
 } from './interfaces';
 import { MockServer } from './MockServer';
 import open from 'open';
-import Table from 'cli-table';
 import { inspect } from 'util';
 
 export interface JovoDebuggerConfig extends PluginConfig {
@@ -330,26 +329,22 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
   }
 
   private async onConnected(): Promise<void> {
-    const color: [number, number] = inspect.colors['gray'] ?? [0, 0];
-    const grayText = (str: string) => `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
+    const color: [number, number] = inspect.colors['blue'] ?? [0, 0];
+    const blueText = (str: string) => `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
+    const underlineColor: [number, number] = inspect.colors['underline'] ?? [0, 0];
+    const underline = (str: string) =>
+      `\u001b[${underlineColor[0]}m${str}\u001b[${underlineColor[1]}m`;
 
     const webhookId = await this.retrieveLocalWebhookId();
     const debuggerUrl = `${this.config.webhookUrl}/${webhookId}`;
 
-    const projectFolderArray = process.cwd().split(sep);
-    const projectFolder = projectFolderArray[projectFolderArray.length - 1];
-    const table = new Table({
-      head: [grayText('Project'), grayText('Server')],
-    });
-    table.push([projectFolder, `☁️ ${debuggerUrl} => 💻 localhost:3000`]);
-
-    console.log('\n' + table.toString());
+    console.log('\nThis is your webhook url ☁️ ' + underline(blueText(debuggerUrl)));
     // Check if the current output is being piped to somewhere.
     if (process.stdout.isTTY) {
       // Check if we can enable raw mode for input stream to capture raw keystrokes.
       if (process.stdin.setRawMode) {
         setTimeout(() => {
-          console.log(`\n To open Jovo Debugger in your browser, press the "." key.\n`);
+          console.log(`\nTo open Jovo Debugger in your browser, press the "." key.\n`);
         }, 500);
 
         // Capture unprocessed key input.


### PR DESCRIPTION
This PR removes the table view of the project name and the Jovo Debugger url + prevent logging undefined properties in context object.