### PR TITLE
🐛 Fix missing connection to webhook after CLI changes

### DIFF
--- a/integrations/plugin-debugger/src/MockServer.ts
+++ b/integrations/plugin-debugger/src/MockServer.ts
@@ -1,7 +1,13 @@
 import { AnyObject, Headers, QueryParams, Server } from '@jovotech/framework';
 
+export interface MockServerRequest {
+  data: AnyObject;
+  headers?: Headers;
+  params?: QueryParams;
+}
+
 export class MockServer extends Server {
-  constructor(readonly req: AnyObject) {
+  constructor(readonly req: MockServerRequest) {
     super();
   }
 
@@ -9,15 +15,15 @@ export class MockServer extends Server {
   fail(error: Error): void {}
 
   getQueryParams(): QueryParams {
-    return {};
+    return this.req.params || {};
   }
 
   getNativeRequestHeaders(): Headers {
-    return {};
+    return this.req.headers || {};
   }
 
   getRequestObject(): Record<string, string> {
-    return this.req;
+    return this.req.data;
   }
 
   hasWriteFileAccess(): boolean {

--- a/integrations/plugin-debugger/src/enums.ts
+++ b/integrations/plugin-debugger/src/enums.ts
@@ -10,6 +10,8 @@ export enum JovoDebuggerEvent {
   AppRequest = 'app.request',
   AppResponse = 'app.response',
 
+  ServerRequest = 'server.request',
+
   AppJovoUpdate = 'app.jovo-update',
   AppStateMutation = 'app.state-mutation',
 }


### PR DESCRIPTION
## Proposed changes
- The socket of the JovoDebugger plugin is now directly connected to the webhook and directly accepts requests from there

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed