### PR TITLE
🐛 Fix bug related to component config

### DIFF
--- a/framework/src/BaseComponent.ts
+++ b/framework/src/BaseComponent.ts
@@ -1,17 +1,16 @@
-import { UnknownObject } from '@jovotech/common';
+import { DeepPartial, UnknownObject } from '@jovotech/common';
 import { ComponentData, JovoComponentInfo } from './index';
 import { Jovo } from './Jovo';
 import { JovoProxy } from './JovoProxy';
 import { ComponentOptions } from './metadata/ComponentMetadata';
 
-export type ComponentConstructor<COMPONENT extends BaseComponent = BaseComponent> = new (
-  jovo: Jovo,
-  options?: ComponentOptions<COMPONENT>,
-  ...args: unknown[]
-) => COMPONENT;
-
 export type ComponentConfig<COMPONENT extends BaseComponent = BaseComponent> =
   COMPONENT['$component']['config'];
+
+export type ComponentConstructor<COMPONENT extends BaseComponent = BaseComponent> = new (
+  jovo: Jovo,
+  config?: DeepPartial<ComponentConfig<COMPONENT>>,
+) => COMPONENT;
 
 export class ComponentDeclaration<
   COMPONENT_CONSTRUCTOR extends ComponentConstructor = ComponentConstructor,
@@ -26,7 +25,14 @@ export abstract class BaseComponent<
   DATA extends ComponentData = ComponentData,
   CONFIG extends UnknownObject = UnknownObject,
 > extends JovoProxy {
+  constructor(jovo: Jovo, readonly initConfig?: DeepPartial<CONFIG>) {
+    super(jovo);
+  }
+
   get $component(): JovoComponentInfo<DATA, CONFIG> {
-    return this.$component as { data: DATA; config: CONFIG | undefined };
+    return {
+      data: this.jovo.$component.data as DATA,
+      config: { ...this.initConfig, ...(this.jovo.$component.config || {}) } as CONFIG,
+    };
   }
 }

--- a/framework/src/BaseComponent.ts
+++ b/framework/src/BaseComponent.ts
@@ -1,15 +1,15 @@
 import { DeepPartial, UnknownObject } from '@jovotech/common';
-import { ComponentData, JovoComponentInfo } from './index';
+import { ComponentData, ComponentOptions, JovoComponentInfo } from './index';
 import { Jovo } from './Jovo';
 import { JovoProxy } from './JovoProxy';
-import { ComponentOptions } from './metadata/ComponentMetadata';
+import { ComponentOptionsOf } from './metadata/ComponentMetadata';
 
 export type ComponentConfig<COMPONENT extends BaseComponent = BaseComponent> =
   COMPONENT['$component']['config'];
 
 export type ComponentConstructor<COMPONENT extends BaseComponent = BaseComponent> = new (
   jovo: Jovo,
-  config?: DeepPartial<ComponentConfig<COMPONENT>>,
+  options?: ComponentOptionsOf<COMPONENT>,
 ) => COMPONENT;
 
 export class ComponentDeclaration<
@@ -17,7 +17,7 @@ export class ComponentDeclaration<
 > {
   constructor(
     readonly component: COMPONENT_CONSTRUCTOR,
-    readonly options?: ComponentOptions<InstanceType<COMPONENT_CONSTRUCTOR>>,
+    readonly options?: ComponentOptionsOf<InstanceType<COMPONENT_CONSTRUCTOR>>,
   ) {}
 }
 
@@ -25,14 +25,14 @@ export abstract class BaseComponent<
   DATA extends ComponentData = ComponentData,
   CONFIG extends UnknownObject = UnknownObject,
 > extends JovoProxy {
-  constructor(jovo: Jovo, readonly initConfig?: DeepPartial<CONFIG>) {
+  constructor(jovo: Jovo, readonly options?: ComponentOptions<CONFIG>) {
     super(jovo);
   }
 
   get $component(): JovoComponentInfo<DATA, CONFIG> {
     return {
       data: this.jovo.$component.data as DATA,
-      config: { ...this.initConfig, ...(this.jovo.$component.config || {}) } as CONFIG,
+      config: { ...(this.options?.config || {}), ...(this.jovo.$component.config || {}) } as CONFIG,
     };
   }
 }

--- a/framework/src/ComponentPlugin.ts
+++ b/framework/src/ComponentPlugin.ts
@@ -6,7 +6,7 @@ import {
   ComponentConstructor,
   ComponentDeclaration,
 } from './BaseComponent';
-import { ComponentOptions } from './metadata/ComponentMetadata';
+import { ComponentOptionsOf } from './metadata/ComponentMetadata';
 import { Plugin, PluginConfig } from './Plugin';
 
 export interface ComponentPluginConfig<COMPONENT extends BaseComponent = BaseComponent>
@@ -21,7 +21,7 @@ export abstract class ComponentPlugin<
   abstract readonly component: ComponentConstructor<COMPONENT>;
 
   install(app: App): void {
-    let options: ComponentOptions<COMPONENT> | undefined = undefined;
+    let options: ComponentOptionsOf<COMPONENT> | undefined = undefined;
 
     if (this.config.component) {
       options = {

--- a/framework/src/ComponentTreeNode.ts
+++ b/framework/src/ComponentTreeNode.ts
@@ -68,7 +68,7 @@ export class ComponentTreeNode<COMPONENT extends BaseComponent = BaseComponent> 
   }: ExecuteHandlerOptions<COMPONENT, HANDLER, ARGS>): Promise<void> {
     const componentInstance = new (this.metadata.target as ComponentConstructor<COMPONENT>)(
       jovo,
-      this.metadata.options?.config,
+      this.metadata.options,
     );
     try {
       if (!componentInstance[handler as keyof COMPONENT]) {

--- a/framework/src/JovoProxy.ts
+++ b/framework/src/JovoProxy.ts
@@ -1,4 +1,4 @@
-import { AnyObject } from './index';
+import { AnyObject, JovoComponentInfo } from './index';
 import { Jovo } from './Jovo';
 
 export class JovoProxy extends Jovo {
@@ -14,12 +14,8 @@ export class JovoProxy extends Jovo {
     Object.getOwnPropertyNames(Jovo.prototype).forEach((key) => keySet.add(key));
     Object.keys(this.jovo).forEach((key) => keySet.add(key));
     const keys = Array.from(keySet);
-    const indexOfConstructor = keys.indexOf('constructor');
-    if (indexOfConstructor >= 0) {
-      keys.splice(indexOfConstructor, 1);
-    }
     keys.forEach((key) => {
-      if (key !== 'jovo') {
+      if (key !== 'jovo' && key !== 'constructor' && key !== '$component') {
         // if the value is a function just return it as a value and not as getter and setter
         const propertyDescriptor: PropertyDescriptor =
           typeof this.jovo[key as keyof Jovo] === 'function'
@@ -35,6 +31,10 @@ export class JovoProxy extends Jovo {
         Object.defineProperty(this, key, propertyDescriptor);
       }
     });
+  }
+
+  get $component(): JovoComponentInfo {
+    return this.jovo.$component;
   }
 
   toJSON(): JovoProxy {

--- a/framework/src/decorators/Component.ts
+++ b/framework/src/decorators/Component.ts
@@ -1,14 +1,14 @@
 import { BaseComponent, ComponentConstructor } from '../BaseComponent';
 import { BuiltInHandler } from '../enums';
 import { DuplicateChildComponentsError } from '../errors/DuplicateChildComponentsError';
-import { ComponentMetadata, ComponentOptions } from '../metadata/ComponentMetadata';
+import { ComponentMetadata, ComponentOptionsOf } from '../metadata/ComponentMetadata';
 import { HandlerMetadata } from '../metadata/HandlerMetadata';
 import { HandlerOptionMetadata } from '../metadata/HandlerOptionMetadata';
 import { MetadataStorage } from '../metadata/MetadataStorage';
 import { getMethodKeys } from '../utilities';
 
 export function Component<COMPONENT extends BaseComponent = BaseComponent>(
-  options?: ComponentOptions<COMPONENT>,
+  options?: ComponentOptionsOf<COMPONENT>,
 ): (target: ComponentConstructor<COMPONENT>) => void {
   return function (target) {
     if (options?.components) {

--- a/framework/src/metadata/ComponentMetadata.ts
+++ b/framework/src/metadata/ComponentMetadata.ts
@@ -9,10 +9,10 @@ import { JovoConditionFunction } from '../index';
 import { ClassDecoratorMetadata } from './ClassDecoratorMetadata';
 import { ComponentOptionMetadata } from './ComponentOptionMetadata';
 
-export interface ComponentOptions<COMPONENT extends BaseComponent> extends UnknownObject {
+export interface ComponentOptions<CONFIG extends UnknownObject | undefined> extends UnknownObject {
   name?: string;
   global?: boolean;
-  config?: DeepPartial<ComponentConfig<COMPONENT>>;
+  config?: DeepPartial<CONFIG>;
   components?: Array<ComponentConstructor | ComponentDeclaration>;
   models?: AnyObject;
 
@@ -20,13 +20,17 @@ export interface ComponentOptions<COMPONENT extends BaseComponent> extends Unkno
   platforms?: string[];
 }
 
+export type ComponentOptionsOf<COMPONENT extends BaseComponent> = ComponentOptions<
+  ComponentConfig<COMPONENT>
+>;
+
 export class ComponentMetadata<
   COMPONENT extends BaseComponent = BaseComponent,
 > extends ClassDecoratorMetadata<COMPONENT> {
   constructor(
     // eslint-disable-next-line @typescript-eslint/ban-types
     readonly target: ComponentConstructor<COMPONENT> | Function,
-    readonly options: ComponentOptions<COMPONENT> = {},
+    readonly options: ComponentOptionsOf<COMPONENT> = {},
   ) {
     super(target);
   }

--- a/framework/src/metadata/ComponentOptionMetadata.ts
+++ b/framework/src/metadata/ComponentOptionMetadata.ts
@@ -1,10 +1,10 @@
 import { BaseComponent, ComponentConstructor } from '../BaseComponent';
 import { ClassDecoratorMetadata } from './ClassDecoratorMetadata';
-import { ComponentOptions } from './ComponentMetadata';
+import { ComponentOptionsOf } from './ComponentMetadata';
 import { MetadataStorage } from './MetadataStorage';
 
 export function createComponentOptionDecorator<COMPONENT extends BaseComponent = BaseComponent>(
-  options: Partial<ComponentOptions<COMPONENT>>,
+  options: Partial<ComponentOptionsOf<COMPONENT>>,
 ): ClassDecorator {
   return function (target) {
     MetadataStorage.getInstance().addComponentOptionMetadata(
@@ -19,7 +19,7 @@ export class ComponentOptionMetadata<
   constructor(
     // eslint-disable-next-line @typescript-eslint/ban-types
     readonly target: ComponentConstructor<COMPONENT> | Function,
-    readonly options: Partial<ComponentOptions<COMPONENT>> = {},
+    readonly options: Partial<ComponentOptionsOf<COMPONENT>> = {},
   ) {
     super(target);
   }


### PR DESCRIPTION
## Proposed changes
- Fix bug that caused config which was set in the decorator to not be applied.
- The options of the component can now be retrieved by using `this.options` from a component

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed