### PR TITLE
✨ Implement Slack plugin

### DIFF
--- a/framework/src/App.ts
+++ b/framework/src/App.ts
@@ -116,6 +116,17 @@ export class App extends Extensible<AppConfig, AppMiddlewares> {
     this.errorListeners.push(listener);
   }
 
+  addErrorListener(listener: AppErrorListener): void {
+    return this.onError(listener);
+  }
+
+  removeErrorListener(listener: AppErrorListener): void {
+    const index = this.errorListeners.indexOf(listener);
+    if (index >= 0) {
+      this.errorListeners.splice(index, 1);
+    }
+  }
+
   initializeMiddlewareCollection(): MiddlewareCollection<AppMiddlewares> {
     return new MiddlewareCollection(...APP_MIDDLEWARES);
   }

--- a/integrations/plugin-slack/.npmignore
+++ b/integrations/plugin-slack/.npmignore
@@ -1,0 +1,5 @@
+.idea
+node_modules
+npm-debug.log
+/src
+/test

--- a/integrations/plugin-slack/README.md
+++ b/integrations/plugin-slack/README.md
@@ -1,0 +1,20 @@
+# Jovo Slack Plugin
+
+[![Jovo Framework](https://www.jovo.tech/img/github-header.png)](https://www.jovo.tech)
+
+<p>
+<a href="https://www.jovo.tech" target="_blank">Website</a> -  <a href="https://www.jovo.tech/docs" target="_blank">Docs</a> - <a href="https://www.jovo.tech/marketplace" target="_blank">Marketplace</a> - <a href="https://github.com/jovotech/jovo-v4-template" target="_blank">Template</a>   
+</p>
+
+<p>
+<a href="https://www.npmjs.com/package/@jovotech/plugin-debugger" target="_blank"><img src="https://badge.fury.io/js/@jovotech%2Fplugin-debugger.svg"></a>      
+<a href="https://opencollective.com/jovo-framework" target="_blank"><img src="https://opencollective.com/jovo-framework/tiers/badge.svg"></a>
+</p>
+
+This package enables you to integrate your Jovo app with Slack.
+
+```bash
+$ npm install @jovotech/plugin-slack
+```
+
+> Learn more in the docs: https://www.jovo.tech/docs/slack

--- a/integrations/plugin-slack/README.md
+++ b/integrations/plugin-slack/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-<a href="https://www.npmjs.com/package/@jovotech/plugin-debugger" target="_blank"><img src="https://badge.fury.io/js/@jovotech%2Fplugin-debugger.svg"></a>      
+<a href="https://www.npmjs.com/package/@jovotech/plugin-slack" target="_blank"><img src="https://badge.fury.io/js/@jovotech%2Fplugin-slack.svg"></a>      
 <a href="https://opencollective.com/jovo-framework" target="_blank"><img src="https://opencollective.com/jovo-framework/tiers/badge.svg"></a>
 </p>
 

--- a/integrations/plugin-slack/README.md
+++ b/integrations/plugin-slack/README.md
@@ -17,4 +17,4 @@ This package enables you to integrate your Jovo app with Slack.
 $ npm install @jovotech/plugin-slack
 ```
 
-> Learn more in the docs: https://www.jovo.tech/docs/slack
+> Learn more in the docs: https://www.jovo.tech/marketplace/plugin-slack

--- a/integrations/plugin-slack/docs/README.md
+++ b/integrations/plugin-slack/docs/README.md
@@ -1,0 +1,135 @@
+---
+title: 'Slack Plugin'
+excerpt: 'Send error messages and other notifications from your Jovo app to Slack.'
+---
+
+# Slack Plugin
+
+Send error messages and other notifications from your Jovo app to Slack.
+
+## Introduction
+
+This plugin allows you to automatically log errors and other notifications to a Slack channel. This way, you can make sure that you know when something breaks in your Jovo app.
+
+Learn more how to set it up in the [installation](#installation) and [configuration](#configuration) sections.
+
+## Installation
+
+You can install the plugin like this:
+
+```sh
+$ npm install @jovotech/plugin-slack
+```
+
+Add it as plugin to any [app configuration](https://www.jovo.tech/docs/app-config) stage you like, e.g. `app.prod.ts`:
+
+```typescript
+import { SlackPlugin } from '@jovotech/plugin-slack';
+// ...
+
+app.configure({
+  plugins: [
+    new SlackPlugin({
+      webhookUrl: '<your-webhook-url>',
+      channel: '<your-channel>',
+    }),
+    // ...
+  ],
+});
+```
+
+The two configurations in the snippet above need to be added for the plugin to work. Learn more in the [configuration section](#configuration).
+
+## Configuration
+
+The following configurations can be added:
+
+```typescript
+new SlackPlugin({
+  webhookUrl: '',
+  channel: '',
+  logErrors: true,
+  fields: {
+    locale: false,
+    platform: true,
+    state: false,
+    userId: false,
+  },
+  customBlocks: /* ... */;
+  transformError: /* ... */;
+}),
+```
+
+- `webhookUrl`: Your Slack webhook URL.
+- `channel`: The Slack channel that should be used for the logging.
+- `logErrors`: Determines whether errors should be logged automatically. If not, you can use [manual messages](#send-messages-manually).
+- `fields`: Shows all fields that should be logged along the error messages.
+- [`customBlocks`](#customblocks): This offers the ability to add custom blocks (fields) to your error messages.
+- [`transformError`](#transformerror): Completely customize the error messages.
+
+### customBlocks
+
+The `customBlocks` property allows you to add additional blocks to the output of your error logs. Learn more about [blocks in the official Slack docs](https://api.slack.com/block-kit).
+
+Here is an example which will display the request object:
+
+```typescript
+new SlackPlugin({
+  customBlocks: (jovo) => [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Request*:\n\`\`\`${JSON.stringify(jovo.$request, undefined, 2)}\`\`\``,
+      },
+    },
+  ],
+  // ...
+});
+```
+
+
+### transformError
+
+It is possible to completely customize the message that is created on error by passing `transformError` in the config.
+
+Here's an example that will only display a header and the error message:
+
+```typescript
+new SlackPlugin({
+  transformError: (error: Error, jovo?: Jovo) => {
+    return {
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: 'An error occurred!',
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Error message*\n${error.message}`,
+          },
+        },
+      ],
+    };
+  },
+  // ...
+});
+```
+
+
+## Send Messages Manually
+
+In addition to the automatic error notifications, you can also send messages manually using these methods in your [handlers](https://www.jovo.tech/docs/handlers):
+
+```typescript
+this.$slack.sendError(error: Error, jovo?: Jovo)
+
+this.$slack.sendMessage(message: string | IncomingWebhookSendArguments)
+```
+
+The `IncomingWebhookSendArguments` are from the [official Slack SDK](https://slack.dev/node-slack-sdk/reference/webhook).

--- a/integrations/plugin-slack/jest.config.js
+++ b/integrations/plugin-slack/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config');

--- a/integrations/plugin-slack/package.json
+++ b/integrations/plugin-slack/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@jovotech/plugin-slack",
+  "version": "4.0.0",
+  "description": "",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm5/index.js",
+  "es2015": "dist/esm2015/index.js",
+  "types": "dist/types/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "tsc -b tsconfig.build.cjs.json tsconfig.build.esm5.json tsconfig.build.esm2015.json tsconfig.build.types.json --clean",
+    "build": "tsc -b tsconfig.build.cjs.json tsconfig.build.esm5.json tsconfig.build.esm2015.json tsconfig.build.types.json",
+    "watch": "tsc -b tsconfig.build.cjs.json tsconfig.build.esm5.json tsconfig.build.esm2015.json tsconfig.build.types.json --watch",
+    "prettier": "prettier -w -l src test",
+    "eslint": "eslint src test --fix --ext .ts",
+    "rimraf": "rimraf dist",
+    "test": "jest --runInBand"
+  },
+  "author": "jovotech",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@slack/webhook": "^6.0.0"
+  },
+  "devDependencies": {
+    "@jovotech/framework": "^4.0.0",
+    "@types/jest": "^26.0.20",
+    "@types/node": "^10.17.50",
+    "@typescript-eslint/eslint-plugin": "^4.12.0",
+    "@typescript-eslint/parser": "^4.12.0",
+    "eslint": "^7.17.0",
+    "eslint-config-prettier": "^7.1.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "jest": "^27.3.1",
+    "prettier": "^2.4.1",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^27.0.7",
+    "typescript": "~4.4.4"
+  },
+  "peerDependencies": {
+    "@jovotech/framework": "4.0.0"
+  },
+  "gitHead": "02f1a666ceff33f0907bff129f78be4088d87241",
+  "prettier": "../../.prettierrc.js",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/integrations/plugin-slack/src/JovoSlack.ts
+++ b/integrations/plugin-slack/src/JovoSlack.ts
@@ -1,0 +1,19 @@
+import { Jovo } from '@jovotech/framework';
+import { IncomingWebhookResult, IncomingWebhookSendArguments } from '@slack/webhook';
+import { SlackPlugin, SlackPluginConfig } from './SlackPlugin';
+
+export class JovoSlack {
+  constructor(readonly slackPlugin: SlackPlugin) {}
+
+  get config(): SlackPluginConfig {
+    return this.slackPlugin.config;
+  }
+
+  sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult | undefined> {
+    return this.slackPlugin.sendError(error, jovo);
+  }
+
+  sendNotification(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
+    return this.slackPlugin.sendNotification(message);
+  }
+}

--- a/integrations/plugin-slack/src/JovoSlack.ts
+++ b/integrations/plugin-slack/src/JovoSlack.ts
@@ -13,7 +13,7 @@ export class JovoSlack {
     return this.slackPlugin.sendError(error, jovo);
   }
 
-  sendNotification(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
-    return this.slackPlugin.sendNotification(message);
+  sendMessage(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
+    return this.slackPlugin.sendMessage(message);
   }
 }

--- a/integrations/plugin-slack/src/JovoSlack.ts
+++ b/integrations/plugin-slack/src/JovoSlack.ts
@@ -1,5 +1,5 @@
 import { Jovo } from '@jovotech/framework';
-import { IncomingWebhookResult, IncomingWebhookSendArguments } from '@slack/webhook';
+import { IncomingWebhookSendArguments } from '@slack/webhook';
 import { SlackPlugin, SlackPluginConfig } from './SlackPlugin';
 
 export class JovoSlack {
@@ -9,11 +9,11 @@ export class JovoSlack {
     return this.slackPlugin.config;
   }
 
-  sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult | undefined> {
+  sendError(error: Error, jovo?: Jovo): void {
     return this.slackPlugin.sendError(error, jovo);
   }
 
-  sendMessage(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
+  sendMessage(message: string | IncomingWebhookSendArguments): void {
     return this.slackPlugin.sendMessage(message);
   }
 }

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -9,7 +9,7 @@ import {
   Plugin,
   PluginConfig,
 } from '@jovotech/framework';
-import { IncomingWebhook, IncomingWebhookResult, IncomingWebhookSendArguments } from '@slack/webhook';
+import { IncomingWebhook, IncomingWebhookSendArguments } from '@slack/webhook';
 import { JovoSlack } from './JovoSlack';
 
 export type SlackBlock = ArrayElement<Exclude<IncomingWebhookSendArguments['blocks'], undefined>>;
@@ -89,21 +89,24 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
     if (!this.config.logErrors) {
       return;
     }
-    this.sendError(error, jovo)
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      .then(() => {})
-      // eslint-disable-next-line no-console
-      .catch((e) => console.warn(e));
+    this.sendError(error, jovo);
   };
 
-  async sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult | undefined> {
+  sendError(error: Error, jovo?: Jovo): void {
     const sendArgs = this.getErrorMessage(error, jovo);
     if (!sendArgs) return;
     return this.sendMessage(sendArgs);
   }
 
-  sendMessage(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
-    return this.client.send(message);
+  sendMessage(message: string | IncomingWebhookSendArguments): void {
+    this.client
+      .send(message)
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .then(() => {})
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.warn(e);
+      });
   }
 
   getErrorMessage(error: Error, jovo?: Jovo): string | IncomingWebhookSendArguments | undefined {

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -29,6 +29,8 @@ export interface SlackPluginConfig extends PluginConfig {
   webhookUrl: string;
   channel: string;
   fields: SlackFieldMap;
+
+  logErrors: boolean;
   transformError?: (error: Error, jovo?: Jovo) => IncomingWebhookSendArguments | undefined;
 }
 
@@ -47,6 +49,7 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
     return {
       webhookUrl: '',
       channel: '',
+      logErrors: true,
       fields: {
         locale: false,
         platform: true,
@@ -80,6 +83,9 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
   }
 
   onError = (error: Error, jovo?: Jovo): void => {
+    if (!this.config.logErrors) {
+      return;
+    }
     this.sendError(error, jovo)
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .then(() => {})

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -9,11 +9,7 @@ import {
   Plugin,
   PluginConfig,
 } from '@jovotech/framework';
-import {
-  IncomingWebhook,
-  IncomingWebhookResult,
-  IncomingWebhookSendArguments,
-} from '@slack/webhook';
+import { IncomingWebhook, IncomingWebhookResult, IncomingWebhookSendArguments } from '@slack/webhook';
 import { JovoSlack } from './JovoSlack';
 
 export type SlackBlock = ArrayElement<Exclude<IncomingWebhookSendArguments['blocks'], undefined>>;
@@ -101,7 +97,7 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
   };
 
   async sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult | undefined> {
-    const sendArgs = this.getErrorSendArguments(error, jovo);
+    const sendArgs = this.getErrorMessage(error, jovo);
     if (!sendArgs) return;
     return this.sendMessage(sendArgs);
   }
@@ -110,10 +106,7 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
     return this.client.send(message);
   }
 
-  private getErrorSendArguments(
-    error: Error,
-    jovo?: Jovo,
-  ): string | IncomingWebhookSendArguments | undefined {
+  getErrorMessage(error: Error, jovo?: Jovo): string | IncomingWebhookSendArguments | undefined {
     if (this.config.transformError) {
       return this.config.transformError(error, jovo);
     }

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -103,10 +103,10 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
   async sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult | undefined> {
     const sendArgs = this.getErrorSendArguments(error, jovo);
     if (!sendArgs) return;
-    return this.sendNotification(sendArgs);
+    return this.sendMessage(sendArgs);
   }
 
-  sendNotification(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
+  sendMessage(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
     return this.client.send(message);
   }
 

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -1,0 +1,106 @@
+import {
+  App,
+  DeepPartial,
+  Extensible,
+  HandleRequest,
+  InvalidParentError,
+  Jovo,
+  Plugin,
+  PluginConfig,
+} from '@jovotech/framework';
+import {
+  IncomingWebhook,
+  IncomingWebhookResult,
+  IncomingWebhookSendArguments,
+} from '@slack/webhook';
+
+// TODO implement customization of the error / notifications in general
+// Allow disabling of error propagation
+export interface SlackPluginConfig extends PluginConfig {
+  webhookUrl: string;
+  channel: string;
+  transformError?: (error: Error, jovo?: Jovo) => IncomingWebhookSendArguments;
+}
+
+export type SlackPluginInitConfig = DeepPartial<SlackPluginConfig> &
+  Pick<SlackPluginConfig, 'webhookUrl' | 'channel'>;
+
+export class SlackPlugin extends Plugin<SlackPluginConfig> {
+  private client: IncomingWebhook;
+
+  constructor(config: SlackPluginInitConfig) {
+    super(config);
+    this.client = new IncomingWebhook(config.webhookUrl);
+  }
+
+  getDefaultConfig(): SlackPluginConfig {
+    return {
+      webhookUrl: '',
+      channel: '',
+    };
+  }
+
+  install(parent: Extensible): void {
+    if (!(parent instanceof App)) {
+      throw new InvalidParentError(this.name, App);
+    }
+  }
+
+  mount(parent: Extensible): void {
+    if (!(parent instanceof HandleRequest)) {
+      throw new InvalidParentError(this.name, HandleRequest);
+    }
+    parent.app.onError(this.onError);
+  }
+
+  dismount(parent: Extensible): void {
+    if (!(parent instanceof HandleRequest)) {
+      throw new InvalidParentError(this.name, HandleRequest);
+    }
+    parent.app.removeErrorListener(this.onError);
+  }
+
+  onError = (error: Error, jovo?: Jovo): void => {
+    this.sendError(error, jovo)
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .then(() => {})
+      // eslint-disable-next-line no-console
+      .catch((e) => console.warn(e));
+  };
+
+  sendError(error: Error, jovo?: Jovo): Promise<IncomingWebhookResult> {
+    return this.sendNotification(this.getErrorSendArguments(error, jovo));
+  }
+
+  sendNotification(message: string | IncomingWebhookSendArguments): Promise<IncomingWebhookResult> {
+    return this.client.send(message);
+  }
+
+  private getErrorSendArguments(error: Error, jovo?: Jovo): IncomingWebhookSendArguments {
+    if (this.config.transformError) {
+      return this.config.transformError(error, jovo);
+    }
+    // TODO implement default filling
+    return {
+      channel: this.config.channel,
+      attachments: [
+        {
+          fallback: 'An error has occurred.',
+          color: '#ff0000',
+          pretext: '',
+          author_name: '',
+          author_link: '',
+          author_icon: '',
+          title: 'An error has occurred.',
+          title_link: '',
+          text: error.message,
+          image_url: '',
+          thumb_url: '',
+          footer: 'Jovo Slack Plugin',
+          footer_icon: '',
+          fields: [],
+        },
+      ],
+    };
+  }
+}

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -73,7 +73,7 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
       throw new InvalidParentError(this.name, HandleRequest);
     }
     parent.middlewareCollection.use('before.request.start', (jovo) => {
-      jovo.slack = new JovoSlack(this);
+      jovo.$slack = new JovoSlack(this);
     });
     parent.app.onError(this.onError);
   }

--- a/integrations/plugin-slack/src/SlackPlugin.ts
+++ b/integrations/plugin-slack/src/SlackPlugin.ts
@@ -31,7 +31,7 @@ export interface SlackPluginConfig extends PluginConfig {
   fields: SlackFieldMap;
 
   logErrors: boolean;
-  transformError?: (error: Error, jovo?: Jovo) => IncomingWebhookSendArguments | undefined;
+  transformError?: (error: Error, jovo?: Jovo) => string | IncomingWebhookSendArguments | undefined;
 }
 
 export type SlackPluginInitConfig = DeepPartial<SlackPluginConfig> &
@@ -106,7 +106,7 @@ export class SlackPlugin extends Plugin<SlackPluginConfig> {
   private getErrorSendArguments(
     error: Error,
     jovo?: Jovo,
-  ): IncomingWebhookSendArguments | undefined {
+  ): string | IncomingWebhookSendArguments | undefined {
     if (this.config.transformError) {
       return this.config.transformError(error, jovo);
     }

--- a/integrations/plugin-slack/src/index.ts
+++ b/integrations/plugin-slack/src/index.ts
@@ -1,3 +1,4 @@
+import { JovoSlack } from './JovoSlack';
 import { SlackPlugin, SlackPluginConfig } from './SlackPlugin';
 
 declare module '@jovotech/framework/dist/types/Extensible' {
@@ -7,6 +8,12 @@ declare module '@jovotech/framework/dist/types/Extensible' {
 
   interface ExtensiblePlugins {
     SlackPlugin?: SlackPlugin;
+  }
+}
+
+declare module '@jovotech/framework/dist/types/Jovo' {
+  interface Jovo {
+    slack: JovoSlack;
   }
 }
 

--- a/integrations/plugin-slack/src/index.ts
+++ b/integrations/plugin-slack/src/index.ts
@@ -13,7 +13,7 @@ declare module '@jovotech/framework/dist/types/Extensible' {
 
 declare module '@jovotech/framework/dist/types/Jovo' {
   interface Jovo {
-    slack: JovoSlack;
+    $slack: JovoSlack;
   }
 }
 

--- a/integrations/plugin-slack/src/index.ts
+++ b/integrations/plugin-slack/src/index.ts
@@ -1,0 +1,13 @@
+import { SlackPlugin, SlackPluginConfig } from './SlackPlugin';
+
+declare module '@jovotech/framework/dist/types/Extensible' {
+  interface ExtensiblePluginConfig {
+    SlackPlugin?: SlackPluginConfig;
+  }
+
+  interface ExtensiblePlugins {
+    SlackPlugin?: SlackPlugin;
+  }
+}
+
+export * from './SlackPlugin';

--- a/integrations/plugin-slack/test/dummy.test.ts
+++ b/integrations/plugin-slack/test/dummy.test.ts
@@ -1,0 +1,3 @@
+test('dummy test', () => {
+  expect(true).toBe(true);
+});

--- a/integrations/plugin-slack/tsconfig.build.cjs.json
+++ b/integrations/plugin-slack/tsconfig.build.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "commonjs"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/integrations/plugin-slack/tsconfig.build.esm2015.json
+++ b/integrations/plugin-slack/tsconfig.build.esm2015.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/esm2015",
+    "module": "es2015"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/integrations/plugin-slack/tsconfig.build.esm5.json
+++ b/integrations/plugin-slack/tsconfig.build.esm5.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/esm5",
+    "module": "es2015",
+    "target": "es5"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/integrations/plugin-slack/tsconfig.build.types.json
+++ b/integrations/plugin-slack/tsconfig.build.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/integrations/plugin-slack/tsconfig.json
+++ b/integrations/plugin-slack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
## Proposed changes
- Implement sending messages to Slack on errors which can also be turned off by passing `logErrors: false` in the config
- The plugin also adds a `slack`-object to `Jovo` which provides methods for sending messages
- The fields which should be logged beside the error can be controlled by passing a `fields`-object
- Custom blocks can be added to the message by using `customBlocks`. Here's an example which will display the request object:
```typescript
new SlackPlugin({
  webhookUrl: 'some-url',
  channel: 'some-channel',
  customBlocks: (jovo) => [
    {
      type: 'section',
      text: {
        type: 'mrkdwn',
        text: `*Request*:\n\`\`\`${JSON.stringify(jovo.$request, undefined, 2)}\`\`\``,
      },
    },
  ],
});
```
- It is possible to completely customize the message that is created on error by passing `transformError` in the config. Here's a simple example that will only display a header and the error message:
```typescript
new SlackPlugin({
  webhookUrl: 'some url',
  channel: 'some-channel',
  transformError: (error: Error, jovo?: Jovo) => {
    return {
      blocks: [
        {
          type: 'header',
          text: {
            type: 'plain_text',
            text: 'An error occurred!',
          },
        },
        {
          type: 'section',
          text: {
            type: 'mrkdwn',
            text: `*Error message*\n${error.message}`,
          },
        },
      ],
    };
  },
});
```

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed