### PR TITLE
:sparkles: Add --skip-validation flag

### DIFF
--- a/platforms/platform-alexa/docs/alexa-conversations.md
+++ b/platforms/platform-alexa/docs/alexa-conversations.md
@@ -74,7 +74,7 @@ $ jovo build:platform alexa
 
 As a convention, the Jovo `build` folder should not be pushed to e.g. your Git repository. The `jovo.project.js` can be seen as a single source of truth that generates the contents of the `build` folder. For additional files like ACDL files (or maybe outsourcing some of the `jovo.project.js` contents into separate files), we recommend sticking to the `resources/alexa` folder convention.
 
-It is, however, also possible to work from the `build/platform.alexa` folder and managee the files there.
+It is, however, also possible to work from the `build/platform.alexa` folder and manage the files there.
 
 The [`deploy` command](./cli-commands.md#deploy) uploads the contents of the Alexa project in the `build` folder to the Alexa Developer Console. Before doing that, it compiles the ACDL files into JSON. Since the building of the Alexa Conversations model can take a while during deployment, we recommend adding the `--async` flag.
 

--- a/platforms/platform-alexa/docs/alexa-conversations.md
+++ b/platforms/platform-alexa/docs/alexa-conversations.md
@@ -47,6 +47,7 @@ new AlexaCli({
     sessionStartDelegationStrategy: {
       target: 'skill',
     },
+    skipValidation: false,
   },
   // ...
 });
@@ -56,6 +57,7 @@ new AlexaCli({
 - `acdlDirectory`: The folder for ACDL files inside the `directory`. Default: `acdl`, which means that the files are stored in a `resources/alexa/conversations/acdl` folder.
 - `responsesDirectory`: The folder for response files inside the `directory`. Default: `responses`, which means that the files are stored in a `resources/alexa/conversations/responses` folder.
 - `sessionStartDelegationStrategy`: The `target` means where a new session should be directed to,either the `skill` (your app code) or `AMAZON.Conversations`. Default: `skill`.
+- `skipValidation`: If this is set to `true`, the ACDL compiler does not run a validation of the ACDL files before turning them into JSON during deployment. Learn more in the [manage files section](#manage-files).
 
 ## Manage Files
 
@@ -64,7 +66,7 @@ The Jovo integration for Alexa Conversations allows you to store the following f
 - [ACDL](https://developer.amazon.com/docs/alexa/conversations/acdl-files.html): Alexa Conversations Description Language (ACDL) files can be stored in a folder called `resources/alexa/conversations/acdl` in the root of your Jovo project.
 - [Responses](https://developer.amazon.com/docs/alexa/conversations/acdl-response-prompt-files.html): Response prompt files can be stored in a folder called `resources/alexa/conversations/responses` in the root of your Jovo project.
 
-The [`build` command](./cli-commands.md#build) then copies these files over to the `build` folder along with other operations.
+The [`build` command](./cli-commands.md#build) then copies these files over to the `build/platform.alexa` folder along with other operations. The files can then be found in `conversations` (for ACDL files) and `response` (for responses) subfolders inside the `skill-package` directory.
 
 ```sh
 $ jovo build:platform alexa
@@ -72,10 +74,15 @@ $ jovo build:platform alexa
 
 As a convention, the Jovo `build` folder should not be pushed to e.g. your Git repository. The `jovo.project.js` can be seen as a single source of truth that generates the contents of the `build` folder. For additional files like ACDL files (or maybe outsourcing some of the `jovo.project.js` contents into separate files), we recommend sticking to the `resources/alexa` folder convention.
 
-The [`deploy` command](./cli-commands.md#deploy) uploads the contents of the Alexa project in the `build` folder to the Alexa Developer Console. Before doing that, it compiles the ACDL files into JSON.
+It is, however, also possible to work from the `build/platform.alexa` folder and managee the files there.
+
+The [`deploy` command](./cli-commands.md#deploy) uploads the contents of the Alexa project in the `build` folder to the Alexa Developer Console. Before doing that, it compiles the ACDL files into JSON. Since the building of the Alexa Conversations model can take a while during deployment, we recommend adding the `--async` flag.
 
 ```sh
-$ jovo deploy:platform alexa
+$ jovo deploy:platform alexa --async
+
+# You can also skip the validation step of the ACDL compiler
+$ jovo deploy:platform alexa --async --skip-validation
 ```
 
 Learn more about all [Alexa CLI commands here](./cli-commands.md).

--- a/platforms/platform-alexa/docs/cli-commands.md
+++ b/platforms/platform-alexa/docs/cli-commands.md
@@ -75,6 +75,8 @@ The Alexa CLI plugin adds the following flags to the [`deploy:platform` command]
 | Flag            | Description                                                                                                                   | Examples                |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `--ask-profile` | Deploy to using the specified ASK profile. [Learn more about ASK profile configuration here](./project-config.md#askprofile). | `--ask-profile default` |
+| `--async` | Don't wait for the model building process to be finished. Recommended for [Alexa Conversations](./alexa-conversations.md#manage-files). |  |
+| `--skip-validation` | Skip the validation step of the [Alexa Conversations](./alexa-conversations.md#manage-files) ACDL compiler. |  |
 
 ### deploy:code 
 
@@ -91,7 +93,6 @@ If you run into problems while bundling the code, make sure that the `bundle` sc
 ```
 
 The reason for this is that `esbuild` can't resolve `vscode`, a dependency used in `@alexa/acdl`, which is used for the [Alexa Conversations integration](./alexa-conversations.md).
-
 
 
 ## get

--- a/platforms/platform-alexa/src/cli/hooks/DeployHook.ts
+++ b/platforms/platform-alexa/src/cli/hooks/DeployHook.ts
@@ -34,6 +34,7 @@ export interface DeployPlatformContextAlexa extends AlexaContext, DeployPlatform
     'ask-profile'?: string;
     'skill-id'?: string;
     'async'?: boolean;
+    'skip-validation'?: boolean;
   };
   alexa: AlexaContext['alexa'] & {
     skillCreated?: boolean;
@@ -73,6 +74,9 @@ export class DeployHook extends AlexaHook<DeployPlatformEvents> {
     });
     context.flags['skill-id'] = flags.string({ char: 's', description: 'Alexa skill ID' });
     context.flags.async = flags.boolean({ description: 'Deploys Alexa skill asynchronously' });
+    context.flags['skip-validation'] = flags.boolean({
+      description: 'Skips validation of Alexa Conversations files',
+    });
   }
 
   /**
@@ -130,7 +134,10 @@ export class DeployHook extends AlexaHook<DeployPlatformEvents> {
       );
       const project = await loadProject(projectConfig);
 
-      if (!this.$plugin.config.conversations?.skipValidation) {
+      if (
+        !this.$context.flags['skip-validation'] &&
+        !this.$plugin.config.conversations?.skipValidation
+      ) {
         const validationTask: Task = new Task('Validating ACDL files', async () => {
           const errors: ParseError[] = validateProject(project, true);
 

--- a/platforms/platform-alexa/src/cli/index.ts
+++ b/platforms/platform-alexa/src/cli/index.ts
@@ -57,6 +57,7 @@ export class AlexaCli extends JovoCliPlugin<AlexaCliConfig> {
         },
         acdlDirectory: 'acdl',
         responsesDirectory: 'responses',
+        skipValidation: false,
       },
     };
   }


### PR DESCRIPTION
## Proposed changes
This PR adds a `--skip-validation` flag to `jovo deploy:platform` when using `AlexaCli`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed