### PR TITLE
Fixes merging of undefined values in output templates

### DIFF
--- a/docs/output-templates.md
+++ b/docs/output-templates.md
@@ -303,6 +303,23 @@ For each platform, you can add a `nativeResponse` object that is directly transl
 }
 ```
 
+If you want to explicitly remove a property, you can set it to `undefined`. In the following example, the `shouldEndSession` property is removed from the Alexa response:
+
+```typescript
+{
+  message: 'Hello world!',
+  platforms: {
+    alexa: {
+      nativeResponse: {
+        response: {
+          shouldEndSession: undefined,
+        },
+      },
+    },
+  },
+}
+```
+
 ## Array of Output Templates
 
 You can also have an array of output objects:

--- a/output/package.json
+++ b/output/package.json
@@ -24,6 +24,8 @@
     "class-validator": "^0.13.1",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.merge": "^4.6.2",
+    "lodash.unset": "^4.5.2",
+    "lodash.mergewith": "^4.6.2",
     "reflect-metadata": "^0.1.13",
     "ts-toolbelt": "9.5.13",
     "type-fest": "^2.5.1"
@@ -32,6 +34,8 @@
     "@types/jest": "^26.0.20",
     "@types/lodash.defaultsdeep": "^4.6.6",
     "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.mergewith": "^4.6.6",
+    "@types/lodash.unset": "^4.5.6",
     "@types/validator": "^13.7.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -140,7 +140,7 @@ export function mergeInstances<D extends object, S extends any[]>(
     },
   );
 }
-// objValue, srcValue, key, object, source, stack
+
 export function mergeListen(
   target: ListenValue | null | undefined,
   mergeWith: ListenValue | null | undefined,

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -1,6 +1,7 @@
 import { Constructor } from '@jovotech/common';
 import { Type } from 'class-transformer';
-import _merge from 'lodash.merge';
+import _mergeWith from 'lodash.mergewith';
+import _unset from 'lodash.unset';
 import type { A, O } from 'ts-toolbelt';
 import { IsOptional, ListenValue, ValidateNested, ValidationError } from '.';
 import { NormalizedOutputTemplatePlatforms } from './models/NormalizedOutputTemplatePlatforms';
@@ -128,9 +129,18 @@ export function mergeInstances<D extends object, S extends any[]>(
   destination: D,
   ...sources: S
 ): O.MergeAll<D, S, 'deep'> {
-  return _merge(destination, ...sources.map((source) => instanceToObject(source)));
+  return _mergeWith(
+    destination,
+    ...sources.map((source) => instanceToObject(source)),
+    // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+    (value: any, srcValue: any, key: string, object: any) => {
+      if (typeof srcValue === 'undefined') {
+        _unset(object, key);
+      }
+    },
+  );
 }
-
+// objValue, srcValue, key, object, source, stack
 export function mergeListen(
   target: ListenValue | null | undefined,
   mergeWith: ListenValue | null | undefined,

--- a/output/test/utilities.test.ts
+++ b/output/test/utilities.test.ts
@@ -1,4 +1,4 @@
-import { toSSML, removeSSML, removeSSMLSpeakTags } from '../src';
+import { toSSML, removeSSML, removeSSMLSpeakTags, mergeInstances } from '../src';
 
 describe('toSSML', () => {
   test('plain text', () => {
@@ -29,5 +29,114 @@ describe('removeSSMLSpeakTags', () => {
     expect(removeSSMLSpeakTags('<speak>foo<break time="300ms" /></speak>')).toBe(
       'foo<break time="300ms" />',
     );
+  });
+});
+
+describe('mergeInstances', () => {
+  test('test correct merging of two objects', () => {
+    const a = {
+      a: 'a',
+      aObj: {
+        a: 'a',
+      },
+    };
+
+    const b = {
+      a: 'b',
+      aObj: {
+        a: 'b',
+      },
+    };
+
+    const merged = {
+      a: 'b',
+      aObj: {
+        a: 'b',
+      },
+    };
+
+    expect(mergeInstances(a, b)).toEqual(merged);
+  });
+
+  test('test correct merging of three objects', () => {
+    const a = {
+      a: 'a',
+      aObj: {
+        a: 'a',
+      },
+    };
+
+    const b = {
+      a: 'b',
+      aObj: {
+        a: 'b',
+      },
+    };
+
+    const c = {
+      a: 'c',
+      aObj: {
+        a: 'c',
+      },
+    };
+
+    const merged = {
+      a: 'c',
+      aObj: {
+        a: 'c',
+      },
+    };
+
+    expect(mergeInstances(a, b, c)).toEqual(merged);
+  });
+
+  test('test merging of undefined values', () => {
+    const a = {
+      a: 'a',
+      aObj: {
+        a: 'a',
+      },
+    };
+
+    const b = {
+      a: undefined,
+      aObj: {
+        a: undefined,
+      },
+    };
+
+    const merged = {
+      a: undefined,
+      aObj: {
+        a: undefined,
+      },
+    };
+
+    expect(mergeInstances(a, b)).toEqual(merged);
+  });
+
+  test('test merging of undefined values <>', () => {
+    const a = {
+      a: 'a',
+      aObj: {
+        a: 'a',
+      },
+    };
+
+    const b = {
+      a: undefined,
+      aObj: {
+        a: undefined,
+      },
+    };
+
+    const merged = {
+      a: 'a',
+      aObj: {
+        a: 'a',
+      },
+    };
+
+    expect(mergeInstances(b, a)).toEqual(merged);
   });
 });


### PR DESCRIPTION
* Fixes merging of undefined values

Example: 
```
platforms: {
        alexa: {
          nativeResponse: {
            response: {
              shouldEndSession: undefined,
            },
          },
        },
      },
```
After this update `shouldEndSession` will be removed from the response object.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed