### PR TITLE
🐛 Fix bug that would cause requests to the local endpoint to result in an error

### DIFF
--- a/integrations/plugin-debugger/package.json
+++ b/integrations/plugin-debugger/package.json
@@ -30,7 +30,6 @@
     "@nlpjs/lang-fr": "^4.22.0",
     "@nlpjs/lang-it": "^4.22.0",
     "fast-deep-equal": "^3.1.3",
-    "lodash.clonedeep": "^4.5.0",
     "open": "^8.0.7",
     "socket.io-client": "^2.4.0",
     "uuid": "^8.3.2"
@@ -39,7 +38,6 @@
     "@jovotech/framework": "^4.1.0",
     "@types/cli-table": "^0.3.0",
     "@types/jest": "^26.0.20",
-    "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^12.20.37",
     "@types/socket.io-client": "^1.4.36",
     "@types/uuid": "^8.3.0",

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -25,7 +25,6 @@ import { LangFr } from '@nlpjs/lang-fr';
 import { LangIt } from '@nlpjs/lang-it';
 import isEqual from 'fast-deep-equal/es6';
 import { promises } from 'fs';
-import _cloneDeep from 'lodash.clonedeep';
 import open from 'open';
 import { homedir } from 'os';
 import { join, resolve } from 'path';
@@ -49,6 +48,7 @@ import {
 import { MockServer, MockServerRequest } from './MockServer';
 
 type AugmentedServer = Server & {
+  [key: string]: any;
   __augmented?: boolean;
   originalSetResponse?: Server['setResponse'];
 };
@@ -184,7 +184,12 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
   // Augment the server of HandleRequest to emit a response with a debugger request id if setResponse is called.
   // If the server was already augmented by augmentServerForApp, the original method will be used instead of the already augmented one.
   private augmentServerForRequest(handleRequest: HandleRequest): void {
-    const serverCopy: AugmentedServer = _cloneDeep(handleRequest.server);
+    const serverCopy: AugmentedServer = Object.create(handleRequest.server);
+    for (const prop in handleRequest.server) {
+      if (handleRequest.server.hasOwnProperty(prop)) {
+        serverCopy[prop] = handleRequest.server[prop as keyof Server];
+      }
+    }
     const setResponse =
       (serverCopy.__augmented && serverCopy.originalSetResponse) || serverCopy.setResponse;
     serverCopy.setResponse = (response) => {


### PR DESCRIPTION
## Proposed changes
- Fix a bug that would cause requests to the local endpoint to result in an error
  - Instead of using `lodash.clonedeep` to make a deep copy, a shallow copy is now created. This will preserve properties that can not be cloned like `req` and `res` of `ExpressJs`

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed