### PR TITLE
💥♻️ Refactor `JovoLogger`

### DIFF
--- a/clients/client-web/scripts/build.js
+++ b/clients/client-web/scripts/build.js
@@ -2,34 +2,6 @@ const esbuild = require('esbuild');
 
 const formatMap = { iife: 'umd', cjs: 'cjs', esm: 'esm' };
 
-const tslogMockPlugin = {
-  name: 'tslogMock',
-  setup(build) {
-    let fs = require('fs');
-    let path = require('path');
-
-    // Intercept import paths called "JovoLogger" so esbuild doesn't attempt
-    // to map them to a file system location. Tag them with the "JovoLogger-ns"
-    // namespace to reserve them for this plugin.
-    build.onResolve({ filter: /^[.][/]JovoLogger$/ }, (args) => {
-      return {
-        path: args.path,
-        namespace: 'JovoLogger-ns',
-      };
-    });
-
-    build.onLoad({ filter: /.*/, namespace: 'JovoLogger-ns' }, async () => {
-      const jovoLoggerShimsFile = await fs.promises.readFile(
-        path.join(process.cwd(), 'JovoLogger-shims.js'),
-      );
-      return {
-        contents: jovoLoggerShimsFile,
-        loader: 'js',
-      };
-    });
-  },
-};
-
 const buildPromises = Object.entries(formatMap).map(([format, name]) => {
   return esbuild.build({
     entryPoints: ['src/index.ts'],
@@ -41,7 +13,6 @@ const buildPromises = Object.entries(formatMap).map(([format, name]) => {
     treeShaking: false,
     format,
     globalName: format === 'iife' ? 'JovoWebClient' : undefined,
-    plugins: [tslogMockPlugin],
   });
 });
 

--- a/common/package.json
+++ b/common/package.json
@@ -26,7 +26,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "ts-toolbelt": "9.5.13",
-    "tslog": "^3.3.1",
+    "loglevel": "^1.8.0",
     "type-fest": "^2.5.1"
   },
   "devDependencies": {

--- a/common/package.json
+++ b/common/package.json
@@ -23,15 +23,13 @@
   "author": "jovotech",
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
-    "ts-toolbelt": "9.5.13",
     "loglevel": "^1.8.0",
+    "ts-toolbelt": "9.5.13",
     "type-fest": "^2.5.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/node": "^12.20.37",
     "@typescript-eslint/eslint-plugin": "^4.12.0",

--- a/common/package.json
+++ b/common/package.json
@@ -23,14 +23,14 @@
   "author": "jovotech",
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2",
     "loglevel": "^1.8.0",
     "ts-toolbelt": "9.5.13",
     "type-fest": "^2.5.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.mergewith": "^4.6.6",
     "@types/node": "^12.20.37",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",

--- a/common/src/JovoError.ts
+++ b/common/src/JovoError.ts
@@ -16,21 +16,26 @@ export class JovoError extends Error {
   hint?: string;
   learnMore?: string;
 
-  constructor(options: JovoErrorOptions) {
-    super(options.message);
-    this.name = options.name || this.constructor.name;
+  constructor(messageOrOptions: string | JovoErrorOptions) {
+    super(typeof messageOrOptions === 'string' ? messageOrOptions : messageOrOptions.message);
 
-    if (options.package) {
-      this.package = options.package;
-    }
-    if (options.context) {
-      this.context = options.context;
-    }
-    if (options.hint) {
-      this.hint = options.hint;
-    }
-    if (options.learnMore) {
-      this.learnMore = options.learnMore;
+    if (typeof messageOrOptions === 'string') {
+      this.name = this.constructor.name;
+    } else {
+      this.name = messageOrOptions.name || this.constructor.name;
+
+      if (messageOrOptions.package) {
+        this.package = messageOrOptions.package;
+      }
+      if (messageOrOptions.context) {
+        this.context = messageOrOptions.context;
+      }
+      if (messageOrOptions.hint) {
+        this.hint = messageOrOptions.hint;
+      }
+      if (messageOrOptions.learnMore) {
+        this.learnMore = messageOrOptions.learnMore;
+      }
     }
   }
 

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -1,6 +1,6 @@
 import chalk, { Chalk } from 'chalk';
-import _merge from 'lodash.merge';
-import { levels, getLogger, Logger, LogLevelDesc } from 'loglevel';
+import _mergeWith from 'lodash.mergewith';
+import { getLogger, levels, Logger, LogLevelDesc } from 'loglevel';
 import { JovoError } from './JovoError';
 
 export interface JovoLoggerConfig {
@@ -20,11 +20,17 @@ export class JovoLogger {
     // if a config is passed, merge the default config with either the passed config or name
     // otherwise just use the default config
     this.config = nameOrConfig
-      ? _merge(
+      ? _mergeWith(
           defaultConfig,
           typeof nameOrConfig === 'string' ? { name: nameOrConfig } : nameOrConfig,
+          (value, srcValue) => {
+            if (Array.isArray(value) && Array.isArray(srcValue)) {
+              return srcValue;
+            }
+          },
         )
       : defaultConfig;
+
     // create the logger instance with the given name
     // if the name is used again, the same instance will be returned
     this.logger = getLogger(this.config.name);

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -6,7 +6,7 @@ import { JovoError } from './JovoError';
 export interface JovoLoggerConfig {
   name: string | symbol;
   level: LogLevelDesc;
-  disableStyling: boolean;
+  styling: boolean;
   // TODO determine name
   properties: Array<keyof JovoError>;
 }
@@ -49,7 +49,7 @@ export class JovoLogger {
   getDefaultConfig(): JovoLoggerConfig {
     return {
       name: 'JovoLogger',
-      disableStyling: false,
+      styling: true,
       level: (process.env.JOVO_LOG_LEVEL as LogLevelDesc | undefined) || levels.TRACE,
       properties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
     };
@@ -154,7 +154,7 @@ export class JovoLogger {
 
   // utility method that only applies the given chalk-function if styling is not disabled
   private style(text: string, chalkFn: Chalk): string {
-    if (this.config.disableStyling) {
+    if (!this.config.styling) {
       return text;
     }
     return chalkFn(text);
@@ -162,7 +162,7 @@ export class JovoLogger {
 
   // applies the given style to all strings in the given args if styling is not disabled
   private applyStyleIfEnabled<T extends unknown[]>(args: T, chalkFn: Chalk): void {
-    if (this.config.disableStyling) {
+    if (!this.config.styling) {
       return;
     }
     args.forEach((arg, index) => {

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -7,8 +7,7 @@ export interface JovoLoggerConfig {
   name: string | symbol;
   level: LogLevelDesc;
   styling: boolean;
-  // TODO determine name
-  properties: Array<keyof JovoError>;
+  errorProperties: Array<keyof JovoError>;
 }
 
 export class JovoLogger {
@@ -51,7 +50,7 @@ export class JovoLogger {
       name: 'JovoLogger',
       styling: true,
       level: (process.env.JOVO_LOG_LEVEL as LogLevelDesc | undefined) || levels.TRACE,
-      properties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
+      errorProperties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
     };
   }
 
@@ -147,7 +146,7 @@ export class JovoLogger {
     };
 
     // log each configured property
-    this.config.properties.forEach((property) => {
+    this.config.errorProperties.forEach((property) => {
       logProperty(property);
     });
   }

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -6,7 +6,6 @@ import { JovoError } from './JovoError';
 export interface JovoLoggerConfig {
   name: string | symbol;
   level: LogLevelDesc;
-  defaultLevel?: LogLevelDesc;
   disableStyling: boolean;
   // TODO determine name
   properties: Array<keyof JovoError>;
@@ -31,10 +30,6 @@ export class JovoLogger {
     this.logger = getLogger(this.config.name);
     // set the level of the logger depending on the config
     this.logger.setLevel(this.config.level);
-    // if defaultLevel was explicitly set, use it
-    if (this.config.defaultLevel) {
-      this.logger.setDefaultLevel(this.config.defaultLevel);
-    }
   }
 
   get level(): LogLevelDesc {

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -44,7 +44,7 @@ export class JovoLogger {
     return {
       name: 'JovoLogger',
       disableStyling: false,
-      level: 'trace',
+      level: (process.env.JOVO_LOG_LEVEL as LogLevelDesc | undefined) || 'trace',
       properties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
     };
   }

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -1,6 +1,6 @@
 import chalk, { Chalk } from 'chalk';
 import _merge from 'lodash.merge';
-import { getLogger, Logger, LogLevelDesc } from 'loglevel';
+import { levels, getLogger, Logger, LogLevelDesc } from 'loglevel';
 import { JovoError } from './JovoError';
 
 export interface JovoLoggerConfig {
@@ -44,7 +44,7 @@ export class JovoLogger {
     return {
       name: 'JovoLogger',
       disableStyling: false,
-      level: (process.env.JOVO_LOG_LEVEL as LogLevelDesc | undefined) || 'trace',
+      level: (process.env.JOVO_LOG_LEVEL as LogLevelDesc | undefined) || levels.TRACE,
       properties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
     };
   }

--- a/common/src/JovoLogger.ts
+++ b/common/src/JovoLogger.ts
@@ -1,120 +1,174 @@
-import {
-  Logger as TsLogger,
-  ISettingsParam,
-  TLogLevelName,
-  TUtilsInspectColors,
-  ILogObject,
-} from 'tslog';
+import chalk, { Chalk } from 'chalk';
 import _merge from 'lodash.merge';
-import _cloneDeep from 'lodash.clonedeep';
+import { getLogger, Logger, LogLevelDesc } from 'loglevel';
 import { JovoError } from './JovoError';
-import { inspect } from 'util';
-import { AnyObject } from './index';
-export class JovoLogger extends TsLogger {
-  constructor(settings?: ISettingsParam) {
-    super();
-    this.setSettings(_merge(this.settings, this.getDefaultConfig(), settings));
+
+export interface JovoLoggerConfig {
+  name: string | symbol;
+  level: LogLevelDesc;
+  defaultLevel?: LogLevelDesc;
+  disableStyling: boolean;
+  // TODO determine name
+  properties: Array<keyof JovoError>;
+}
+
+export class JovoLogger {
+  readonly logger: Logger;
+  config: JovoLoggerConfig;
+
+  constructor(nameOrConfig?: string | Partial<JovoLoggerConfig>) {
+    const defaultConfig = this.getDefaultConfig();
+    // if a config is passed, merge the default config with either the passed config or name
+    // otherwise just use the default config
+    this.config = nameOrConfig
+      ? _merge(
+          defaultConfig,
+          typeof nameOrConfig === 'string' ? { name: nameOrConfig } : nameOrConfig,
+        )
+      : defaultConfig;
+    // create the logger instance with the given name
+    // if the name is used again, the same instance will be returned
+    this.logger = getLogger(this.config.name);
+    // set the level of the logger depending on the config
+    this.logger.setLevel(this.config.level);
+    // if defaultLevel was explicitly set, use it
+    if (this.config.defaultLevel) {
+      this.logger.setDefaultLevel(this.config.defaultLevel);
+    }
   }
 
-  getDefaultConfig(): ISettingsParam {
-    return {
-      prettyInspectOptions: { depth: 3 },
-      prefix: [''],
-      displayDateTime: false,
-      minLevel: (process.env.JOVO_LOG_LEVEL as TLogLevelName) || 'info',
-    };
+  get level(): LogLevelDesc {
+    return this.logger.getLevel();
   }
-  private static getNoStyleConfig(): ISettingsParam {
+
+  set level(level: LogLevelDesc) {
+    this.logger.setLevel(level);
+  }
+
+  getDefaultConfig(): JovoLoggerConfig {
     return {
-      exposeErrorCodeFrame: false,
-      displayDateTime: false,
-      displayFilePath: 'hidden',
-      displayLogLevel: false,
-      displayFunctionName: false,
-      displayTypes: false,
-      delimiter: '',
+      name: 'JovoLogger',
+      disableStyling: false,
+      level: 'trace',
+      properties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'],
     };
   }
 
-  error(...args: unknown[]): ILogObject {
-    for (let i = 0; i < args.length; i++) {
-      if (args[i] instanceof JovoError) {
-        return this.jovoError(args[i] as JovoError);
+  trace(...args: unknown[]): void {
+    this.applyStyleIfEnabled(args, chalk.magenta);
+    this.logger.trace(...args);
+  }
+
+  log(...args: unknown[]): void {
+    this.applyStyleIfEnabled(args, chalk.white);
+    this.logger.log(...args);
+  }
+
+  debug(...args: unknown[]): void {
+    this.applyStyleIfEnabled(args, chalk.green);
+    this.logger.debug(...args);
+  }
+
+  info(...args: unknown[]): void {
+    this.applyStyleIfEnabled(args, chalk.blue);
+    this.logger.info(...args);
+  }
+
+  warn(...args: unknown[]): void {
+    this.applyStyleIfEnabled(args, chalk.yellow);
+    this.logger.warn(...args);
+  }
+
+  error(...args: unknown[]): void {
+    const logPart = (part: unknown[]) => {
+      if (part.length) {
+        this.applyStyleIfEnabled(part, chalk.red);
+        this.logger.error(...part);
       }
-    }
-    return super.error(...args);
+    };
+
+    // just looping args and using this.logger.error there would lead to more line breaks than expected,
+    // therefore the logic beneath only adds line breaks when a JovoError was found as arg
+    let currentPart: unknown[] = [];
+    args.forEach((value) => {
+      // if the value is a JovoError make sure to log the current part and reset it
+      if (value instanceof JovoError) {
+        logPart(currentPart);
+        currentPart = [];
+        // and also log the JovoError
+        this.jovoError(value);
+      } else {
+        // otherwise just add to the current part
+        currentPart.push(value);
+      }
+    });
+    // if there's anything left in the current part, log it as well
+    logPart(currentPart);
   }
 
-  jovoError(error: JovoError, settings?: ISettingsParam): ILogObject {
-    const jovoErrorSettings = settings || {};
-
-    const noStyleLogger = this.getChildLogger({
-      ...JovoLogger.getNoStyleConfig(),
-      ...jovoErrorSettings,
-    });
-
-    const lowStyleWithStackLogger = noStyleLogger.getChildLogger({
-      ...JovoLogger.getNoStyleConfig(),
-      exposeErrorCodeFrame: false,
-      exposeStack: true,
-      displayLogLevel: false,
-      ignoreStackLevels: 6,
-    });
-
-    noStyleLogger.error(
-      this.style('JOVO ERROR', 'redBright') +
-        ' ' +
-        this.style(' ' + error.name + ' ', 'bgRedBright'),
+  jovoError(error: JovoError): void {
+    this.logger.error(
+      this.style('\nJOVO ERROR', chalk.redBright),
+      this.style(` ${error.name} `, chalk.bgRedBright),
     );
+    // add empty line after error header
+    this.logger.error();
 
-    if (error.package) {
-      noStyleLogger.error(`\n${this.style('package:', 'underline')}`);
-      noStyleLogger.error(error.package);
-    }
+    // function for logging a property of JovoError if it exists and is a string
+    // an additional chalk method can be passed for customizing the value's text
+    const logStringProperty = (property: keyof JovoError, style: Chalk = chalk.whiteBright) => {
+      const value = error[property];
+      if (!value || typeof value !== 'string') {
+        return;
+      }
+      // format property: uppercase letters to lower case and add space before
+      // example: learnMore -> learn more; helloWorld -> hello world
+      const formattedProperty = property.replace(/([A-Z])/g, (text) => ' ' + text.toLowerCase());
+      this.logger.error(this.style(`${formattedProperty}:`, chalk.underline));
+      this.logger.error(this.style(value, style));
+    };
 
-    if (error.message) {
-      noStyleLogger.error(`\n${this.style('message:', 'underline')}`);
-      noStyleLogger.error(`${this.style(error.message, 'whiteBright')}`);
-    }
+    // function for logging the context of JovoError
+    const logContext = () => {
+      this.logger.error(this.style('context:', chalk.underline));
+      this.logger.error(error.context);
+    };
 
-    if (error.context) {
-      noStyleLogger.error(`\n${this.style('context:', 'underline')}`);
+    // function for logging a property of JovoError
+    const logProperty = (property: keyof JovoError, style?: Chalk) => {
+      if (property === 'context') {
+        logContext();
+      } else {
+        logStringProperty(property, style);
+      }
+      // add empty line after property block
+      this.logger.error();
+    };
 
-      const formatContext = (contextObject: AnyObject) => {
-        return Object.keys(contextObject).reduce((context, key) => {
-          if (typeof context[key] === 'undefined') {
-            delete context[key];
-          }
-          return context;
-        }, _cloneDeep(contextObject));
-      };
-      noStyleLogger.error(formatContext(error.context));
-    }
-
-    if (error.stack) {
-      lowStyleWithStackLogger.error('');
-    }
-    if (error.hint) {
-      noStyleLogger.error(`\n${this.style('hint:', 'underline')}`);
-      noStyleLogger.error(`${this.style(error.hint, 'whiteBright')}`);
-    }
-
-    if (error.learnMore) {
-      noStyleLogger.error(`\n${this.style('learn more:', 'underline')}`);
-      noStyleLogger.error(`${this.style(error.learnMore, 'whiteBright')}`);
-    }
-
-    return noStyleLogger.error('\n');
+    // log each configured property
+    this.config.properties.forEach((property) => {
+      logProperty(property);
+    });
   }
 
-  style(str: string, style: TUtilsInspectColors | TUtilsInspectColors[]): string {
-    const styles = Array.isArray(style) ? style : [style];
+  // utility method that only applies the given chalk-function if styling is not disabled
+  private style(text: string, chalkFn: Chalk): string {
+    if (this.config.disableStyling) {
+      return text;
+    }
+    return chalkFn(text);
+  }
 
-    return this.settings.colorizePrettyLogs
-      ? styles.reduce((str: string, style: TUtilsInspectColors) => {
-          const color: [number, number] = inspect.colors[style] ?? [0, 0];
-          return `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
-        }, str)
-      : str;
+  // applies the given style to all strings in the given args if styling is not disabled
+  private applyStyleIfEnabled<T extends unknown[]>(args: T, chalkFn: Chalk): void {
+    if (this.config.disableStyling) {
+      return;
+    }
+    args.forEach((arg, index) => {
+      // only style strings for now
+      if (typeof arg === 'string') {
+        args[index] = chalkFn(arg);
+      }
+    });
   }
 }

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -79,7 +79,6 @@ export type EnumLike<T extends string> = T | `${T}`;
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type PlainObjectType<T> = OmitWhere<T, Function>;
 
-export { ILogObject, ISettingsParam } from 'tslog';
 export * from './Configurable';
 export * from './Input';
 export * from './JovoError';

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -189,27 +189,30 @@ logging: {
 },
 ```
 
-The following properties can be passed:
+This is the default configuration for `logger`, simplified for readability:
 
 ```typescript
 {
-  name: 'some name'; // Name of the logger, see loglevel.getLogger
-  level: 'trace'; // Level of the logger, see logLevel.setLevel
-  styling: boolean; // Disable styling completely 
-  properties: ['package', 'message', 'context']; // Can be used to change order of properties that are displayed or even omit some
+  name: 'JovoLogger', // Name of the logger, see loglevel.getLogger
+  level: process.env.JOVO_LOG_LEVEL || 'trace', // Level of the logger, see logLevel.setLevel
+  styling: true, // Enable or disable styling completely 
+  errorProperties: ['package', 'message', 'context', 'stack', 'hint', 'learnMore'], // Can be used to change order of error properties that are displayed or even omit some
 }
 ```
+
+You can use the logger to log to various log levels, which can be set in the config or using the environment variable `JOVO_LOG_LEVEL`, for example like this:
+
+```typescript
+process.env.JOVO_LOG_LEVEL = 'warn';
+```
+
+You can also learn more about all `errorProperties` in the [`JovoError` documentation](./error-handling.md#jovoerror).
+
 
 You can import the Jovo Logger like this:
 
 ```typescript
 import { Logger } from '@jovotech/framework';
-```
-
-You can use the logger to log to various log levels, which can be set as environment variable `JOVO_LOG_LEVEL`, for example like this:
-
-```typescript
-process.env.JOVO_LOG_LEVEL = 'warn';
 ```
 
 The logs can be done like this:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -61,6 +61,8 @@ logging: {
 
 ## Basic Logging
 
+Basic logging is responsible for logging the the request and response of each interaction. Learn more about the lifecycle in the [RIDR documentation](./ridr-lifecycle.md).
+
 - [Request Logging](#request-logging)
 - [Response Logging](#response-logging)
 - [Masking](#masking)
@@ -176,26 +178,26 @@ logging: {
 
 Jovo has an internal `Logger` that can be used to display certain levels of logs. It uses [loglevel](https://github.com/pimterry/loglevel) and uses the levels described there.
 
-The `JovoLogger` allows a configuration to be passed that can contain any of the properties below but does not have to:
-
-```typescript
-{
-  name: 'some name'; // name of the logger, see loglevel.getLogger
-  level: 'trace'; // level of the logger, see logLevel.setLevel
-  disableStyling: boolean; // disable styling completely 
-  properties: ['package', 'message', 'context']; // can be used to change order of properties that are displayed or even omit some
-}
-```
-
-You can pass a configuration like that to the logging configuration to change the behavior of `Logger`:
+You can modify the `Logger` by using the `logger` property in the `logging` config:
 
 ```typescript
 logging: {
   logger: {
-    level: 'error' // show error only
+    level: 'error' // Show error only
   },
   // ...
 },
+```
+
+The following properties can be passed:
+
+```typescript
+{
+  name: 'some name'; // Name of the logger, see loglevel.getLogger
+  level: 'trace'; // Level of the logger, see logLevel.setLevel
+  disableStyling: boolean; // Disable styling completely 
+  properties: ['package', 'message', 'context']; // Can be used to change order of properties that are displayed or even omit some
+}
 ```
 
 You can import the Jovo Logger like this:
@@ -223,4 +225,4 @@ Logger.error(new Error()); // JOVO_LOG_LEVEL = 'error'
 
 Additionally, setting the log level to `'silent'` will cause no logs to be shown.
 
-Learn more about log levels in the [official loglevel documentation](https://github.com/pimterry/loglevel#documentation).
+Learn more about log levels in the [official `loglevel` documentation](https://github.com/pimterry/loglevel#documentation).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -49,7 +49,7 @@ logging: {
   indentation: '  ',
   styling: true,
   colorizeSettings: { /* ... */ },
-  tslog: { /* ... */ },
+  logger: { /* ... */ },
 },
 ```
 
@@ -57,7 +57,7 @@ logging: {
 - `request`: Configurations for [request logging](#request-logging).
 - `response`: Configurations for [response logging](#response-logging).
 - More information about `indentation`, `style`, and `colorizeSettings` can be found in the [styling](#styling) section.
-- `tslog`: Configurations for the logging library used by the [Jovo Logger](#jovo-logger).
+- `logger`: Configurations for the [Jovo Logger](#jovo-logger).
 
 ## Basic Logging
 
@@ -174,16 +174,25 @@ logging: {
 
 ## Jovo Logger
 
-Jovo has an internal `Logger` that can be used to display certain levels of logs. It is an instance of [tslog](https://tslog.js.org) and can use any features that library provides.
+Jovo has an internal `Logger` that can be used to display certain levels of logs. It uses [loglevel](https://github.com/pimterry/loglevel) and uses the levels described there.
 
-You can add tslog configurations ([learn more on their website](https://tslog.js.org/#/?id=settings)) to the `tslog` property, for example:
+The `JovoLogger` allows a configuration to be passed that can contain any of the properties below but does not have to:
+
+```typescript
+{
+  name: 'some name'; // name of the logger, see loglevel.getLogger
+  level: 'trace'; // level of the logger, see logLevel.setLevel
+  disableStyling: boolean; // disable styling completely 
+  properties: ['package', 'message', 'context']; // can be used to change order of properties that are displayed or even omit some
+}
+```
+
+You can pass a configuration like that to the logging configuration to change the behavior of `Logger`:
 
 ```typescript
 logging: {
-  tslog: {
-    prettyInspectOptions: { depth: 3 },
-    prefix: [''],
-    displayDateTime: false,
+  logger: {
+    level: 'error' // show error only
   },
   // ...
 },
@@ -204,13 +213,14 @@ process.env.JOVO_LOG_LEVEL = 'warn';
 The logs can be done like this:
 
 ```typescript
-Logger.silly(string); // JOVO_LOG_LEVEL = 'silly'
 Logger.trace(string); // JOVO_LOG_LEVEL = 'trace'
+Logger.log(string); // JOVO_LOG_LEVEL = 'debug'
 Logger.debug(string); // JOVO_LOG_LEVEL = 'debug'
 Logger.info(string); // JOVO_LOG_LEVEL = 'info'
 Logger.warn(string); // JOVO_LOG_LEVEL = 'warn'
 Logger.error(new Error()); // JOVO_LOG_LEVEL = 'error'
-Logger.fatal(new Error()); // JOVO_LOG_LEVEL = 'fatal'
 ```
 
-Learn more about log levels in the [official tslog documentation](https://tslog.js.org/#/?id=log-level).
+Additionally, setting the log level to `'silent'` will cause no logs to be shown.
+
+Learn more about log levels in the [official loglevel documentation](https://github.com/pimterry/loglevel#documentation).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -195,7 +195,7 @@ The following properties can be passed:
 {
   name: 'some name'; // Name of the logger, see loglevel.getLogger
   level: 'trace'; // Level of the logger, see logLevel.setLevel
-  disableStyling: boolean; // Disable styling completely 
+  styling: boolean; // Disable styling completely 
   properties: ['package', 'message', 'context']; // Can be used to change order of properties that are displayed or even omit some
 }
 ```

--- a/framework/src/App.ts
+++ b/framework/src/App.ts
@@ -1,4 +1,4 @@
-import { ArrayElement, ISettingsParam } from '@jovotech/common';
+import { ArrayElement, JovoLoggerConfig } from '@jovotech/common';
 import _merge from 'lodash.merge';
 import {
   ComponentTree,
@@ -55,7 +55,7 @@ export interface AppRoutingConfig {
 }
 
 export interface AppLoggingConfig extends BasicLoggingConfig {
-  tslog?: ISettingsParam;
+  logger?: Partial<JovoLoggerConfig>;
 }
 
 export interface AppConfig extends ExtensibleConfig {
@@ -80,8 +80,8 @@ export class App extends Extensible<AppConfig, AppMiddlewares> {
     if (typeof this.config.logging === 'boolean' && this.config.logging) {
       this.use(new BasicLogging({ request: true, response: true }));
     } else if (typeof this.config.logging === 'object') {
-      if (this.config.logging.tslog) {
-        Logger.setSettings(_merge(Logger.settings, this.config.logging.tslog));
+      if (this.config.logging.logger) {
+        _merge(Logger.config, this.config.logging.logger);
       }
       this.use(new BasicLogging(this.config.logging));
     }


### PR DESCRIPTION
## Proposed changes
- Refactor `JovoLogger` to use [loglevel](https://github.com/pimterry/loglevel) instead of [tslog](https://tslog.js.org/#/) due to issues with browser-compatibility when using tslog.
- Allow a string to be passed as constructor parameter `JovoError` to pass a message only
- The properties and order of properties of `JovoError` that should be listed when printing a `JovoError` with the `JovoLogger`  can be modified by passing `properties` to the config of `JovoLogger`. 
- Remove tslogMockPlugin from web-client build-script

> Before merging we will have to discuss how the current `properties`-property in `JovoLoggerConfig` is supposed to be named.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed