### PR TITLE
👔 Implement separate sanitization of `text` and `speech`

### DIFF
--- a/platforms/platform-alexa/docs/output.md
+++ b/platforms/platform-alexa/docs/output.md
@@ -68,6 +68,8 @@ Under the hood, Jovo translates the `message` into an `outputSpeech` object ([se
 }
 ```
 
+The `outputSpeech` response format is [limited to 8,000 characters](https://developer.amazon.com/docs/alexa/custom-skills/request-and-response-json-reference.html#response-format). By default, Jovo output trims the content of the `message` property to that length. Learn more in the [output sanitization documentation](https://www.jovo.tech/docs/output-config#sanitization).
+
 ### reprompt
 
 The [generic `reprompt` element](https://www.jovo.tech/docs/output-templates#message) is used to ask again if the user does not respond to a prompt after a few seconds:

--- a/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
@@ -4,6 +4,7 @@ import {
   DynamicEntity,
   DynamicEntityMap,
   mergeInstances,
+  MessageMaxLength,
   MessageValue,
   NormalizedOutputTemplate,
   OutputTemplateConverterStrategyConfig,
@@ -63,7 +64,7 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
   protected sanitizeMessage(
     message: MessageValue,
     path: string,
-    maxLength = ALEXA_STRING_MAX_LENGTH,
+    maxLength: MessageMaxLength = ALEXA_STRING_MAX_LENGTH,
     offset = SSML_OFFSET,
   ): MessageValue {
     return super.sanitizeMessage(message, path, maxLength, offset);

--- a/platforms/platform-dialogflow/src/output/DialogflowOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-dialogflow/src/output/DialogflowOutputTemplateConverterStrategy.ts
@@ -4,6 +4,7 @@ import {
   DynamicEntity,
   DynamicEntityMap,
   mergeInstances,
+  MessageMaxLength,
   MessageValue,
   NormalizedOutputTemplate,
   OutputTemplateConverterStrategyConfig,
@@ -38,7 +39,7 @@ export class DialogflowOutputTemplateConverterStrategy extends SingleResponseOut
   protected sanitizeMessage(
     message: MessageValue,
     path: string,
-    maxLength = TEXT_MAX_LENGTH,
+    maxLength: MessageMaxLength = TEXT_MAX_LENGTH,
     offset?: number,
   ): MessageValue {
     return super.sanitizeMessage(message, path, maxLength, offset);

--- a/platforms/platform-facebookmessenger/src/output/FacebookMessengerOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-facebookmessenger/src/output/FacebookMessengerOutputTemplateConverterStrategy.ts
@@ -1,5 +1,6 @@
 import {
   Carousel,
+  MessageMaxLength,
   MessageValue,
   MultipleResponsesOutputTemplateConverterStrategy,
   NormalizedOutputTemplate,
@@ -60,7 +61,7 @@ export class FacebookMessengerOutputTemplateConverterStrategy extends MultipleRe
   protected sanitizeMessage(
     message: MessageValue,
     path: string,
-    maxLength = MESSAGE_TEXT_MAX_LENGTH,
+    maxLength: MessageMaxLength = MESSAGE_TEXT_MAX_LENGTH,
     offset?: number,
   ): MessageValue {
     return super.sanitizeMessage(message, path, maxLength, offset);

--- a/platforms/platform-googleassistant/docs/output.md
+++ b/platforms/platform-googleassistant/docs/output.md
@@ -96,6 +96,8 @@ This is then turned into the following response:
 }
 ```
 
+The `text` property is [limited to 640 characters](https://developers.google.com/assistant/conversational/prompts-simple#SimpleResponseProperties). By default, Jovo output trims the content to that length. Learn more in the [output sanitization documentation](https://www.jovo.tech/docs/output-config#sanitization).
+
 ### reprompt
 
 The [generic `reprompt` element](https://www.jovo.tech/docs/output-templates#message) is used to ask again if the user does not respond to a prompt after a few seconds:

--- a/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -5,11 +5,17 @@ import {
   DynamicEntity,
   DynamicEntityMap,
   mergeInstances,
+  MessageMaxLength,
   MessageValue,
   NormalizedOutputTemplate,
+  OutputTemplate,
   OutputTemplateConverterStrategyConfig,
   QuickReplyValue,
+  removeSSML,
   SingleResponseOutputTemplateConverterStrategy,
+  SpeechMessage,
+  TextMessage,
+  toSSML,
 } from '@jovotech/output';
 import { GoogleAssistantResponse } from '../GoogleAssistantResponse';
 import {
@@ -36,6 +42,33 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
   platformName = 'googleAssistant' as const;
   responseClass = GoogleAssistantResponse;
 
+  normalizeOutput(output: OutputTemplate | OutputTemplate[]): NormalizedOutputTemplate {
+    // make sure the message always is an object for Google Assistant
+    const makeMessageObj = (message: string): TextMessage | SpeechMessage => {
+      return {
+        text: removeSSML(message),
+        speech: toSSML(message),
+      };
+    };
+
+    const updateMessage = (outputTemplate: OutputTemplate) => {
+      if (outputTemplate.message && typeof outputTemplate.message === 'string') {
+        outputTemplate.message = makeMessageObj(outputTemplate.message);
+      } else if (Array.isArray(outputTemplate.message)) {
+        outputTemplate.message = outputTemplate.message.map((message) =>
+          typeof message === 'string' ? makeMessageObj(message) : message,
+        );
+      }
+    };
+    if (Array.isArray(output)) {
+      output.forEach(updateMessage);
+    } else {
+      updateMessage(output);
+    }
+    console.log(JSON.stringify(output, undefined, 2));
+    return super.normalizeOutput(output);
+  }
+
   protected sanitizeOutput(output: NormalizedOutputTemplate): NormalizedOutputTemplate {
     if (output.message) {
       output.message = this.sanitizeMessage(output.message, 'message');
@@ -59,7 +92,9 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
   protected sanitizeMessage(
     message: MessageValue,
     path: string,
-    maxLength = TEXT_MAX_LENGTH,
+    maxLength: MessageMaxLength = {
+      text: TEXT_MAX_LENGTH,
+    },
     offset?: number,
   ): MessageValue {
     return super.sanitizeMessage(message, path, maxLength, offset);

--- a/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -42,7 +42,7 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
   platformName = 'googleAssistant' as const;
   responseClass = GoogleAssistantResponse;
 
-  // make sure the message always is an object for Google Assistant
+  // make sure the (content of) message and reprompt always is an object for Google Assistant
   normalizeOutput(output: OutputTemplate | OutputTemplate[]): NormalizedOutputTemplate {
     const makeMessageObj = (message: string): TextMessage | SpeechMessage => {
       return {

--- a/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-googleassistant/src/output/GoogleAssistantOutputTemplateConverterStrategy.ts
@@ -65,7 +65,6 @@ export class GoogleAssistantOutputTemplateConverterStrategy extends SingleRespon
     } else {
       updateMessage(output);
     }
-    console.log(JSON.stringify(output, undefined, 2));
     return super.normalizeOutput(output);
   }
 


### PR DESCRIPTION
## Proposed changes
Currently, only a single max length can be set for `message` and `reprompt` which is then applied to both `text` and `speech` if they exist.

Now, an object can also be passed to the `maxLength` parameter of `OutputTemplateConverterStrategy.sanitizeMessage` for more control over separate max lengths for `text` and `speech`:
```
{
  speech?: number;
  text?: number;
}
```
If only a string is found as message, it will be handled as `speech` if SSML tags are found, otherwise it is treated as `text`.

`GoogleAssistantOutputTemplateConverterStrategy` overrides `normalizeOutput` to make Message-objects out of every string in `message` and `reprompt` before calling the parent's `normalizeOutput` method. \
This is done because later, a string will be converted to an object with `speech` and `text` anyways and this way the object will also get properly sanitized.

Related to #1176

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed