### PR TITLE
add AplTemplates Override for Alexa Carousel and Card

### DIFF
--- a/platforms/platform-alexa/docs/output.md
+++ b/platforms/platform-alexa/docs/output.md
@@ -306,6 +306,7 @@ const app = new App({
         genericOutputToApl: true,
         aplTemplates: {
           carousel: CAROUSEL_APL
+          card: CARD_APL
         },
       },
     }),
@@ -317,3 +318,4 @@ It includes the following properties:
 
 - `genericOutputToApl`: Determines if generic output like [`quickReplies`](#quickreplies), [`card`](#card), and [`carousel`](#carousel) should automatically be converted into an APL directive.
 - `aplTemplates.carousel`: Allows the app to override the default APL template used for carousels.
+- `aplTemplates.card`: Allows the app to override the default APL template used for cards.

--- a/platforms/platform-alexa/docs/output.md
+++ b/platforms/platform-alexa/docs/output.md
@@ -162,7 +162,23 @@ Jovo automatically turns the [generic `card` element](https://www.jovo.tech/docs
 }
 ```
 
-For this to work, `genericOutputToApl` needs to be enabled in the [Alexa output configuration](#alexa-output-configuration).
+For this to work, `genericOutputToApl` needs to be enabled in the [Alexa output configuration](#alexa-output-configuration), which is the default. You can also override the default APL template used for `card`:
+
+```typescript
+const app = new App({
+  // ...
+
+  plugins: [
+    new AlexaPlatform({
+      output: {
+        aplTemplates: {
+          card: CARD_APL, // Add imported document here
+        },
+      },
+    }),
+  ],
+});
+```
 
 **Note**: If you want to send a home card to the Alexa mobile app instead, we recommend using the [`nativeResponse` property](#native-response).
 
@@ -188,9 +204,25 @@ Alexa does not natively support carousels. However, Jovo automatically turns the
 }
 ```
 
-For this to work, `genericOutputToApl` needs to be enabled in the [Alexa output configuration](#alexa-output-configuration).
+For this to work, `genericOutputToApl` needs to be enabled in the [Alexa output configuration](#alexa-output-configuration), which is the default. You can also override the default APL template used for `carousel`:
 
-You can make it clickable by adding a `selection` object. Once an element is selected by the user, the Jovo Router will automatically map the request to the provided `intent` (and potentially `entities`):
+```typescript
+const app = new App({
+  // ...
+
+  plugins: [
+    new AlexaPlatform({
+      output: {
+        aplTemplates: {
+          carousel: CAROUSEL_APL, // Add imported document here
+        },
+      },
+    }),
+  ],
+});
+```
+
+You can make the carousel clickable by adding a `selection` object. Once an element is selected by the user, the Jovo Router will automatically map the request to the provided `intent` (and potentially `entities`):
 
 ```typescript
 {
@@ -317,5 +349,4 @@ const app = new App({
 It includes the following properties:
 
 - `genericOutputToApl`: Determines if generic output like [`quickReplies`](#quickreplies), [`card`](#card), and [`carousel`](#carousel) should automatically be converted into an APL directive.
-- `aplTemplates.carousel`: Allows the app to override the default APL template used for carousels.
-- `aplTemplates.card`: Allows the app to override the default APL template used for cards.
+- `aplTemplates`: Allows the app to override the default APL templates used for [`carousel`](#carousel) and [`card`](#card).

--- a/platforms/platform-alexa/docs/output.md
+++ b/platforms/platform-alexa/docs/output.md
@@ -304,6 +304,9 @@ const app = new App({
     new AlexaPlatform({
       output: {
         genericOutputToApl: true,
+        aplTemplates: {
+          carousel: CAROUSEL_APL
+        },
       },
     }),
   ],
@@ -313,3 +316,4 @@ const app = new App({
 It includes the following properties:
 
 - `genericOutputToApl`: Determines if generic output like [`quickReplies`](#quickreplies), [`card`](#card), and [`carousel`](#carousel) should automatically be converted into an APL directive.
+- `aplTemplates.carousel`: Allows the app to override the default APL template used for carousels.

--- a/platforms/platform-alexa/src/AlexaPlatform.ts
+++ b/platforms/platform-alexa/src/AlexaPlatform.ts
@@ -18,6 +18,7 @@ import { AlexaOutputTemplateConverterStrategy } from './output';
 export interface AlexaConfig extends PlatformConfig {
   output: {
     genericOutputToApl: boolean;
+    aplTemplates?: Record<string, unknown>;
   };
   intentMap: Record<string, string>;
 }
@@ -90,6 +91,7 @@ export class AlexaPlatform extends Platform<
     this.outputTemplateConverterStrategy.config.genericOutputToApl = !!(
       jovo.$alexa?.$request?.isAplSupported() && this.config.output?.genericOutputToApl
     );
+    this.outputTemplateConverterStrategy.config.aplTemplates = this.config.output?.aplTemplates;
 
     if (jovo.$alexa?.$request?.request?.type === 'Alexa.Presentation.APL.UserEvent') {
       const requestArguments = jovo.$alexa.$request.request.arguments || [];

--- a/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
@@ -24,6 +24,7 @@ import { convertMessageToOutputSpeech } from './utilities';
 export interface AlexaOutputTemplateConverterStrategyConfig
   extends OutputTemplateConverterStrategyConfig {
   genericOutputToApl: boolean;
+  aplTemplates?: Record<string, unknown>;
 }
 
 export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTemplateConverterStrategy<
@@ -128,7 +129,9 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
 
     const carousel = output.carousel;
     if (carousel && this.config.genericOutputToApl) {
-      addToDirectives(carousel.toApl?.() as AplRenderDocumentDirective);
+      addToDirectives(
+        carousel.toApl?.(this.config.aplTemplates?.carousel) as AplRenderDocumentDirective,
+      );
     }
 
     const quickReplies = output.quickReplies;

--- a/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
+++ b/platforms/platform-alexa/src/output/AlexaOutputTemplateConverterStrategy.ts
@@ -121,7 +121,7 @@ export class AlexaOutputTemplateConverterStrategy extends SingleResponseOutputTe
     const card = output.card;
     if (card) {
       if (this.config.genericOutputToApl) {
-        addToDirectives(card.toApl?.() as AplRenderDocumentDirective);
+        addToDirectives(card.toApl?.(this.config.aplTemplates?.card) as AplRenderDocumentDirective);
       } else {
         response.response.card = card.toAlexaCard?.();
       }

--- a/platforms/platform-alexa/src/output/index.ts
+++ b/platforms/platform-alexa/src/output/index.ts
@@ -15,7 +15,7 @@ declare module '@jovotech/output/dist/types/models/Card' {
     backgroundImageUrl?: string;
 
     toAlexaCard?(): AlexaCard<CardType.Standard>;
-    toApl?(): AplRenderDocumentDirective;
+    toApl?(cardTemplate?: any): AplRenderDocumentDirective;
   }
 }
 

--- a/platforms/platform-alexa/src/output/index.ts
+++ b/platforms/platform-alexa/src/output/index.ts
@@ -24,7 +24,7 @@ declare module '@jovotech/output/dist/types/models/Carousel' {
     header?: AplHeader;
     backgroundImageUrl?: string;
 
-    toApl?(): AplRenderDocumentDirective;
+    toApl?(carouselTemplate?: any): AplRenderDocumentDirective;
   }
 }
 

--- a/platforms/platform-alexa/src/output/utilities.ts
+++ b/platforms/platform-alexa/src/output/utilities.ts
@@ -68,33 +68,34 @@ export function augmentModelPrototypes(): void {
     return card;
   };
 
-  Card.prototype.toApl = function (): AplRenderDocumentDirective {
-    AplCardJson.datasources.data.title = this.title;
+  Card.prototype.toApl = function (cardTemplate?: any): AplRenderDocumentDirective {
+    const cardJson = cardTemplate || AplCardJson;
+    cardJson.datasources.data.title = this.title;
 
     if (this.subtitle) {
-      AplCardJson.datasources.data.subtitle = this.subtitle;
+      cardJson.datasources.data.subtitle = this.subtitle;
     }
 
     if (this.content) {
-      AplCardJson.datasources.data.content = this.content;
+      cardJson.datasources.data.content = this.content;
     }
 
     if (this.imageUrl) {
-      AplCardJson.datasources.data.imageUrl = this.imageUrl;
+      cardJson.datasources.data.imageUrl = this.imageUrl;
     }
 
     if (this.header) {
-      AplCardJson.datasources.data.header = this.header;
+      cardJson.datasources.data.header = this.header;
     }
 
     if (this.backgroundImageUrl) {
-      AplCardJson.datasources.data.backgroundImageUrl = this.backgroundImageUrl;
+      cardJson.datasources.data.backgroundImageUrl = this.backgroundImageUrl;
     }
 
     return {
       type: 'Alexa.Presentation.APL.RenderDocument',
       token: 'token',
-      ...AplCardJson,
+      ...cardJson,
     };
   };
 

--- a/platforms/platform-alexa/src/output/utilities.ts
+++ b/platforms/platform-alexa/src/output/utilities.ts
@@ -98,20 +98,22 @@ export function augmentModelPrototypes(): void {
     };
   };
 
-  Carousel.prototype.toApl = function (): AplRenderDocumentDirective {
+  Carousel.prototype.toApl = function (carouselTemplate?: any): AplRenderDocumentDirective {
+    const carouselJson = carouselTemplate || AplCarouselJson;
+
     if (this.title) {
-      AplCarouselJson.datasources.data.title = this.title;
+      carouselJson.datasources.data.title = this.title;
     }
 
     if (this.header) {
-      AplCarouselJson.datasources.data.header = this.header;
+      carouselJson.datasources.data.header = this.header;
     }
 
     if (this.backgroundImageUrl) {
-      AplCarouselJson.datasources.data.backgroundImageUrl = this.backgroundImageUrl;
+      carouselJson.datasources.data.backgroundImageUrl = this.backgroundImageUrl;
     }
 
-    (AplCarouselJson.datasources.data.items as CarouselItem[]) = this.items.map((item) => ({
+    (carouselJson.datasources.data.items as CarouselItem[]) = this.items.map((item) => ({
       ...item,
       selection: item.selection
         ? {
@@ -119,12 +121,18 @@ export function augmentModelPrototypes(): void {
             ...item.selection,
           }
         : undefined,
+
+      // map generic carousel properties to AlexaImageList.listItems properties
+      // https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-alexa-image-list-layout.html#list-items
+      primaryText: item.title,
+      secondaryText: item.content,
+      imageSource: item.imageUrl,
     }));
 
     return {
       type: 'Alexa.Presentation.APL.RenderDocument',
       token: 'token',
-      ...AplCarouselJson,
+      ...carouselJson,
     };
   };
 


### PR DESCRIPTION

## Proposed changes

Add an option for projects to override the default APL template for generic output types.

```ts
new AlexaPlatform({
    output: {
      genericOutputToApl: true,
      aplTemplates: {
        carousel: CAROUSEL_APL,
        card: CARD_APL
      },
    },
}),
```

to use custom APL document instead of the [default template](https://github.com/jovotech/jovo-framework/blob/v4/dev/platforms/platform-alexa/src/output/apl/Carousel.json).

For example, I want to use this template for my project:

```json
{
  "document": {
    "type": "APL",
    "version": "1.6",
    "import": [
      {
        "name": "alexa-layouts",
        "version": "1.3.0"
      }
    ],
    "mainTemplate": {
      "parameters": [
        "data"
      ],
      "item": {
        "type": "AlexaImageList",
        "headerTitle": "${data.header.title}",
        "headerAttributionImage": "${data.header.logo}",
        "listItems": "${data.items}",
        "hideOrdinal": true,
        "backgroundImageSource": "${data.backgroundImageUrl}",
        "height": "100%",
        "width": "100%",
        "theme": "light",
        "primaryAction": {
          "type": "SendEvent",
          "arguments": [
            "${data.selection}"
          ]
        }
      }
    }
  },
  "datasources": {
    "data": {
      "title": "",
      "backgroundImageUrl": "",
      "header": {
        "title": "",
        "logo": ""
      },
      "items": []
    }
  }
}
```

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed