### PR TITLE
👔 `OutputTemplateConverterStrategy` correctly uses passed config in constructor

### DIFF
--- a/output/package.json
+++ b/output/package.json
@@ -22,7 +22,6 @@
     "@jovotech/common": "^4.0.3",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
-    "lodash.defaultsdeep": "^4.6.1",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "lodash.unset": "^4.5.2",
@@ -32,7 +31,6 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/lodash.defaultsdeep": "^4.6.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.mergewith": "^4.6.6",
     "@types/lodash.unset": "^4.5.6",

--- a/output/src/OutputTemplateConverterStrategy.ts
+++ b/output/src/OutputTemplateConverterStrategy.ts
@@ -1,5 +1,4 @@
 import { Constructor } from '@jovotech/common';
-import _defaultsDeep from 'lodash.defaultsdeep';
 import { PartialDeep } from 'type-fest';
 import {
   Carousel,
@@ -15,6 +14,7 @@ import {
   QuickReplyValue,
 } from '.';
 import { OutputHelpers } from './OutputHelpers';
+import _merge from 'lodash.merge';
 
 export interface SanitizationConfig {
   trimArrays: boolean;
@@ -44,7 +44,7 @@ export abstract class OutputTemplateConverterStrategy<
   abstract readonly responseClass: Constructor<RESPONSE>;
 
   constructor(config?: PartialDeep<CONFIG>) {
-    this.config = _defaultsDeep(this.getDefaultConfig(), config || {});
+    this.config = _merge(this.getDefaultConfig(), config || {});
   }
 
   getDefaultConfig(): CONFIG {


### PR DESCRIPTION
## Proposed changes
- Replace usage of `lodash.defaultsDeep` with `lodash.merge` because `defaultsDeep` does not replace trueish values with falsish values, i.e. `validation: true` will not be replaced by `validation: false`

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed