### PR TITLE
🐛 Fix bug that would cause invalid config property to be overwritten

### DIFF
--- a/framework/src/plugins/BasicLogging.ts
+++ b/framework/src/plugins/BasicLogging.ts
@@ -95,7 +95,7 @@ export class BasicLogging extends Plugin<BasicLoggingConfig> {
     }
 
     if (typeof config.response === 'boolean') {
-      this.config.request = {
+      this.config.response = {
         objects: [],
         maskedObjects: [],
         excludedObjects: [],


### PR DESCRIPTION
## Proposed changes
Fix a bug that would cause `BasicLogging` to overwrite the wrong config property.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed