### PR TITLE
🐛 Fixes output config delegation

### DIFF
--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -1,5 +1,9 @@
 import { AnyObject, Constructor } from '@jovotech/common';
-import { JovoResponse, OutputTemplateConverterStrategy } from '@jovotech/output';
+import {
+  JovoResponse,
+  OutputTemplateConverterStrategy,
+  OutputTemplateConverterStrategyConfig,
+} from '@jovotech/output';
 import _merge from 'lodash.merge';
 import {
   App,
@@ -21,7 +25,7 @@ import { JovoDevice, JovoDeviceConstructor } from './JovoDevice';
 import { JovoRequest } from './JovoRequest';
 import { JovoUserConstructor } from './JovoUser';
 import { MiddlewareCollection } from './MiddlewareCollection';
-import { OutputTemplateConverterStrategyConfig } from '@jovotech/output/src';
+// import { OutputTemplateConverterStrategyConfig } from '@jovotech/output/src';
 
 export type PlatformMiddlewares = AppMiddlewares;
 
@@ -76,11 +80,13 @@ export abstract class Platform<
         return this.middlewareCollection.run(middlewareName, jovo);
       });
     });
-    const strategyConfig = parent.config.output as OutputTemplateConverterStrategyConfig;
-
-    this.outputTemplateConverterStrategy.config.validation = strategyConfig.validation;
-    this.outputTemplateConverterStrategy.config.sanitization = strategyConfig.sanitization;
-    this.outputTemplateConverterStrategy.config.omitWarnings = strategyConfig.omitWarnings;
+    const appOutputConfig = parent.config.output as OutputTemplateConverterStrategyConfig;
+    this.outputTemplateConverterStrategy.config.validation =
+      appOutputConfig?.validation || this.outputTemplateConverterStrategy.config.validation;
+    this.outputTemplateConverterStrategy.config.sanitization =
+      appOutputConfig?.sanitization || this.outputTemplateConverterStrategy.config.sanitization;
+    this.outputTemplateConverterStrategy.config.omitWarnings =
+      appOutputConfig?.omitWarnings || this.outputTemplateConverterStrategy.config.omitWarnings;
   }
 
   createJovoInstance<APP extends App>(app: APP, handleRequest: HandleRequest): JOVO {

--- a/framework/src/Platform.ts
+++ b/framework/src/Platform.ts
@@ -21,6 +21,7 @@ import { JovoDevice, JovoDeviceConstructor } from './JovoDevice';
 import { JovoRequest } from './JovoRequest';
 import { JovoUserConstructor } from './JovoUser';
 import { MiddlewareCollection } from './MiddlewareCollection';
+import { OutputTemplateConverterStrategyConfig } from '@jovotech/output/src';
 
 export type PlatformMiddlewares = AppMiddlewares;
 
@@ -75,6 +76,11 @@ export abstract class Platform<
         return this.middlewareCollection.run(middlewareName, jovo);
       });
     });
+    const strategyConfig = parent.config.output as OutputTemplateConverterStrategyConfig;
+
+    this.outputTemplateConverterStrategy.config.validation = strategyConfig.validation;
+    this.outputTemplateConverterStrategy.config.sanitization = strategyConfig.sanitization;
+    this.outputTemplateConverterStrategy.config.omitWarnings = strategyConfig.omitWarnings;
   }
 
   createJovoInstance<APP extends App>(app: APP, handleRequest: HandleRequest): JOVO {


### PR DESCRIPTION
## Proposed changes

Generic output template config was ignored. This has been fixed.

This should work again:

```typescript
const app = new App({
  // ...

  output: {
    omitWarnings: false,
    validation: true,
    sanitization: true,
  },
```

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed