### PR TITLE
:bug: Reset $request data in TestSuite

### DIFF
--- a/framework/src/testsuite/TestSuite.ts
+++ b/framework/src/testsuite/TestSuite.ts
@@ -42,15 +42,9 @@ export type PlatformTypes<PLATFORM extends Platform> = PLATFORM extends Platform
 /**
  * Determines whether the provided response type is of type array or not
  */
-export type PlatformResponseType<
-  PLATFORM extends Platform,
-  RESPONSE extends JovoResponse,
-> = PLATFORM['outputTemplateConverterStrategy'] extends SingleResponseOutputTemplateConverterStrategy<
-  RESPONSE,
-  OutputTemplateConverterStrategyConfig
->
-  ? RESPONSE
-  : RESPONSE | RESPONSE[];
+export type PlatformResponseType<PLATFORM extends Platform> = ReturnType<
+  PLATFORM['outputTemplateConverterStrategy']['toResponse']
+>;
 
 /**
  * Return type of TestSuite.prototype.run().
@@ -59,7 +53,7 @@ export type PlatformResponseType<
  */
 export type TestSuiteResponse<PLATFORM extends Platform> = {
   output: OutputTemplate[];
-  response: PlatformResponseType<PLATFORM, PlatformTypes<PLATFORM>['response']>;
+  response: PlatformResponseType<PLATFORM>;
 };
 
 export type RequestOrInput<PLATFORM extends Platform> =

--- a/framework/src/testsuite/TestSuite.ts
+++ b/framework/src/testsuite/TestSuite.ts
@@ -213,6 +213,7 @@ export class TestSuite<PLATFORM extends Platform = TestPlatform> extends Plugin<
   clearData(): void {
     this.$user = this.$platform.createUserInstance(this);
     this.$session = new JovoSession();
+    this.$request = this.$platform.createRequestInstance({});
   }
 
   private prepareRequest(jovo: Jovo) {


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

#1256 introduced the ability to merge `$request`, but it needs to be reset in `clearData()` as well.  
This PR also adjusts the inference of the response type when providing a platform by checking for the return type of `toResponse()`, which is more accurate.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
