### PR TITLE
:technologist: throw error in DynamoDb.initialize

### DIFF
--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -99,6 +99,7 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
           );
         }
       }
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Proposed Changes

I had an issue where the connection to the dynamoDb could not be set up and it was only shown on the first request coming in, where loadData got called. As the error was not output or thrown in initialize, the information gets lost there and it seems, as if everything works fine. If there is no reason (an error that should be "ignored") for not throwing here, I think it might be helpful to have that error thrown right away in initialize.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
