### PR TITLE
✨ Get access to unit identifiers for Alexa Smart Properties

### DIFF
--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -188,12 +188,42 @@ if (this.$alexa) {
 
 The following Alexa properties offer additional features:
 
+- [Request](#request)
 - [User](#user)
 - [Output](#output)
 - [Device](#device)
 - [Entities (Slots)](#entities-slots-)
 - [ISP](#isp)
 - [Alexa Conversations](#alexa-conversations)
+
+
+### Request
+
+You can access the request using the following methods:
+
+```typescript
+// Generic request type
+this.$request
+
+// Alexa request type
+this.$alexa.$request
+```
+
+There are also some helper methods to help you retrieve information from Alexa requests.
+
+For example, you can retrieve the `unit` property from the [Alexa System object](https://developer.amazon.com/docs/alexa/custom-skills/request-and-response-json-reference.html#system-object) like this:
+
+```typescript
+this.$alexa.$request.getUnit();
+
+/* Result:
+  {
+    unitId: string;
+    persistentUnitId: string;
+  }
+*/
+```
+
 
 ### User
 

--- a/platforms/platform-alexa/src/AlexaRequest.ts
+++ b/platforms/platform-alexa/src/AlexaRequest.ts
@@ -202,7 +202,7 @@ export class AlexaRequest extends JovoRequest {
     return this.context!.System.apiAccessToken;
   }
 
-  getUnit(): Unit|undefined {
+  getUnit(): Unit | undefined {
     return this.context!.System!.unit;
   }
 

--- a/platforms/platform-alexa/src/AlexaRequest.ts
+++ b/platforms/platform-alexa/src/AlexaRequest.ts
@@ -14,7 +14,7 @@ import {
   STATIC_ENTITY_MATCHES_PREFIX,
   SUPPORTED_APL_ARGUMENT_TYPES,
 } from './constants';
-import { AlexaEntity, Context, Request, Session } from './interfaces';
+import { AlexaEntity, Context, Request, Session, Unit } from './interfaces';
 import { ResolutionPerAuthority, ResolutionPerAuthorityStatusCode, Slot } from './output';
 import _set from 'lodash.set';
 export const ALEXA_REQUEST_TYPE_TO_INPUT_TYPE_MAP: Record<string, InputTypeLike> = {
@@ -200,6 +200,10 @@ export class AlexaRequest extends JovoRequest {
 
   getApiAccessToken(): string {
     return this.context!.System.apiAccessToken;
+  }
+
+  getUnit(): Unit|undefined {
+    return this.context!.System!.unit;
   }
 
   getDeviceCapabilities(): AlexaCapabilityType[] | undefined {

--- a/platforms/platform-alexa/src/interfaces.ts
+++ b/platforms/platform-alexa/src/interfaces.ts
@@ -66,6 +66,11 @@ export interface Speed {
 
 export type PermissionStatus = 'DENIED' | 'ACCEPTED' | 'NOT_ANSWERED';
 
+export interface Unit {
+  unitId: string;
+  persistentUnitId: string;
+}
+
 export interface System {
   application: Application;
   user: User;
@@ -73,6 +78,7 @@ export interface System {
   device: Device;
   apiEndpoint: string;
   apiAccessToken: string;
+  unit?: Unit
 }
 
 export interface Viewport {


### PR DESCRIPTION
## Proposed Changes

When a skill is integrate in Alexa Smart Properties, Alexa add some extra informations in the request.
The System object contains new unit identifiers:
`
"unit": {
         "unitId": "xxx",
         "persistentUnitId": "yyyy"
       }
`
 more info: https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#system-object

the function getUnit allow us to get this new data.
this.$alexa.$request.getUnit() return the new unit object or undefined for "classic" skill

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
