### PR TITLE
:label: added missing alexa request body type

### DIFF
--- a/platforms/platform-alexa/src/interfaces.ts
+++ b/platforms/platform-alexa/src/interfaces.ts
@@ -208,6 +208,10 @@ export interface Request {
     arguments: Record<string, string>;
     slots: Record<string, Slot>;
   };
+  body?: {
+    acceptedPermissions?: { scope: string }[];
+    acceptedPersonPermissions?: { scope: string }[];
+  };
 }
 
 // Defines a target for Alexa Conversations


### PR DESCRIPTION

## Proposed Changes

In a project I am working on, I need to access the body of an AlexaRequest. Here I found out, that this is not yet in the types of the platform-alexa in the jovo framework. The [Alexa Dev Docs](https://developer.amazon.com/en-US/docs/alexa/smapi/skill-events-in-alexa-skills.html) show, where the acceptedPermissions and acceptedPersonPermissions are located in the body. I therefore added the types to the interfaces.

## Types of Changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
