### PR TITLE
:label: added apla directive

### DIFF
--- a/platforms/platform-alexa/src/output/models/Reprompt.ts
+++ b/platforms/platform-alexa/src/output/models/Reprompt.ts
@@ -1,9 +1,28 @@
 import { IsOptional, Type, ValidateNested } from '@jovotech/output';
+import { IsValidDirectivesArray } from '../decorators/validation/IsValidDirectivesArray';
+import { AplaRenderDocumentDirective } from './apla/AplaRenderDocumentDirective';
 import { OutputSpeech } from './common/OutputSpeech';
+import { Directive } from './Directive';
 
 export class Reprompt {
   @IsOptional()
   @ValidateNested()
   @Type(() => OutputSpeech)
   outputSpeech?: OutputSpeech;
+
+  @IsOptional()
+  @IsValidDirectivesArray()
+  @ValidateNested({
+    each: true,
+  })
+  @Type(() => Directive, {
+    keepDiscriminatorProperty: true,
+    discriminator: {
+      property: 'type',
+      subTypes: [
+        { value: AplaRenderDocumentDirective, name: 'Alexa.Presentation.APLA.RenderDocument' },
+      ],
+    },
+  })
+  directives?: Directive[];
 }

--- a/platforms/platform-alexa/src/output/models/Response.ts
+++ b/platforms/platform-alexa/src/output/models/Response.ts
@@ -5,6 +5,7 @@ import { AplLoadIndexListDataDirective } from './apl/AplLoadIndexListDataDirecti
 import { AplRenderDocumentDirective } from './apl/AplRenderDocumentDirective';
 import { AplSendIndexListDataDirective } from './apl/AplSendIndexListDataDirective';
 import { AplUpdateIndexListDirective } from './apl/AplUpdateIndexListDirective';
+import { AplaRenderDocumentDirective } from './apla/AplaRenderDocumentDirective';
 import { ApltExecuteCommandsDirective } from './aplt/ApltExecuteCommandsDirective';
 import { ApltRenderDocumentDirective } from './aplt/ApltRenderDocumentDirective';
 import { AudioPlayerClearQueueDirective } from './audio-player/AudioPlayerClearQueueDirective';
@@ -68,6 +69,7 @@ export class Response {
         { value: AplLoadIndexListDataDirective, name: 'Alexa.Presentation.APL.LoadIndexListData' },
         { value: ApltRenderDocumentDirective, name: 'Alexa.Presentation.APLT.RenderDocument' },
         { value: ApltExecuteCommandsDirective, name: 'Alexa.Presentation.APLT.ExecuteCommands' },
+        { value: AplaRenderDocumentDirective, name: 'Alexa.Presentation.APLA.RenderDocument' },
         { value: AudioPlayerPlayDirective, name: 'AudioPlayer.Play' },
         { value: AudioPlayerStopDirective, name: 'AudioPlayer.Stop' },
         { value: AudioPlayerClearQueueDirective, name: 'AudioPlayer.ClearQueue' },

--- a/platforms/platform-alexa/src/output/models/apla/AplaDataSource.ts
+++ b/platforms/platform-alexa/src/output/models/apla/AplaDataSource.ts
@@ -1,0 +1,3 @@
+export class AplaDataSource {
+  [key: string]: unknown;
+}

--- a/platforms/platform-alexa/src/output/models/apla/AplaRenderDocumentDirective.ts
+++ b/platforms/platform-alexa/src/output/models/apla/AplaRenderDocumentDirective.ts
@@ -1,0 +1,18 @@
+import { AnyObject } from '@jovotech/framework';
+import { Equals, IsObject, IsOptional, TransformMap, ValidateNested } from '@jovotech/output';
+import { AplDirective } from '../apl/AplDirective';
+import { AplaDataSource } from './AplaDataSource';
+
+export class AplaRenderDocumentDirective extends AplDirective<'Alexa.Presentation.APLA.RenderDocument'> {
+  @Equals('Alexa.Presentation.APLA.RenderDocument')
+  type!: 'Alexa.Presentation.APLA.RenderDocument';
+
+  @IsObject()
+  document!: (AnyObject & { type: 'APLA' | string }) | { type: 'Link'; src: string };
+
+  @IsOptional()
+  @IsObject()
+  @ValidateNested({ each: true })
+  @TransformMap(() => AplaDataSource)
+  datasources?: Record<string, AplaDataSource>;
+}

--- a/platforms/platform-alexa/src/output/models/index.ts
+++ b/platforms/platform-alexa/src/output/models/index.ts
@@ -28,6 +28,8 @@ export * from './aplt/ApltDocument';
 export * from './aplt/ApltDocumentSettings';
 export * from './aplt/ApltExecuteCommandsDirective';
 export * from './aplt/ApltRenderDocumentDirective';
+export * from './apla/AplaRenderDocumentDirective';
+export * from './apla/AplaDataSource';
 export * from './audio-player/AudioItem';
 export * from './audio-player/AudioItemMetadata';
 export * from './audio-player/AudioItemStream';


### PR DESCRIPTION
## Proposed Changes

I wanted to use the APLA Feature for Alexa Repromts and saw that the type did not exist yet on the Alexa reprompt type. I also could not find a class for the APLA Render Document in general, which is why I added that, and added the possibility to add this both in the response itself as well as in the reprompt directives. The reprompt directives can only contain this one directive (see [docs](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#reprompt-object)). I saw that these directives have corresponding classes with class-transformer decorators to transform JSON/Pojo Objects into instances. I was however not exactly sure when this transformation happens exactly. I tried to make my changes in a way that I saw in the other Directives / Response, but am not 100% sure, I have not forgotten. I tried using it with just adding a pojo directive to the reprompt, which seems to look good now. I'd be happy about feedback!

## Types of Changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
