### PR TITLE
✨ Optimize LexSlu #1282 and expand NLU data #1283

### DIFF
--- a/integrations/slu-lex/src/LexSlu.ts
+++ b/integrations/slu-lex/src/LexSlu.ts
@@ -1,5 +1,6 @@
 import {
   Interpretation,
+  Message,
   LexRuntimeV2Client,
   RecognizeTextCommand,
   RecognizeTextCommandInput,
@@ -31,6 +32,22 @@ function asyncGunzip(buffer: GunzipBuffer): Promise<Buffer> {
   });
 }
 
+interface AsrOutput {
+  interpretations?: Interpretation[];
+  messages?: Message[];
+}
+
+export interface LexNluData extends NluData {
+  intent: {
+    name: string;
+    confidence?: number;
+    state?: string;
+    confirmationState?: string;
+  };
+  entities?: EntityMap;
+  messages?: Message[];
+}
+
 export interface LexSluConfig extends InterpretationPluginConfig {
   bot: {
     id: string;
@@ -51,6 +68,7 @@ export class LexSlu extends SluPlugin<LexSluConfig> {
   targetSampleRate = 16000;
 
   readonly client: LexRuntimeV2Client;
+  asrOutput: AsrOutput = {};
 
   constructor(config: LexSluInitConfig) {
     super(config);
@@ -105,50 +123,74 @@ export class LexSlu extends SluPlugin<LexSluConfig> {
     if (!response.inputTranscript) {
       return;
     }
-    // The return inputTranscript ist a gzipped string that is encoded with base64
+    // The return inputTranscript is a gzipped string that is encoded with base64
     // base64 -> gzip
-    const transcriptBuffer = Buffer.from(response.inputTranscript, 'base64');
-    // gzip -> string
-    const textBuffer = await asyncGunzip(transcriptBuffer);
-    // The string of textBuffer will always contain double quotes, therefore we can parse it with JSON to get rid of it.
-    const parsedText = JSON.parse(textBuffer.toString());
+    const parsedText = await this.extractValue(response.inputTranscript);
+    const interpretations: Interpretation[] = await this.extractValue(response.interpretations);
+    const messages: Message[] = await this.extractValue(response.messages);
+    this.asrOutput = { interpretations, messages };
+
     return {
       text: parsedText,
     };
   }
 
-  async processText(jovo: Jovo, text: string): Promise<NluData | undefined> {
+  async processText(jovo: Jovo, text: string): Promise<LexNluData | undefined> {
     if (!this.config.nlu || !jovo.$session.id) {
       return;
     }
-    const params: RecognizeTextCommandInput = {
-      botId: this.config.bot.id,
-      botAliasId: this.config.bot.aliasId,
-      text,
-      localeId: this.getLocale(jovo),
-      sessionId: jovo.$session.id,
-    };
-    const command = new RecognizeTextCommand(params);
-    const response = await this.client.send(command);
-    if (!response.interpretations) {
-      return;
+
+    if (this.asrOutput.interpretations) {
+      // Lex already returned output as part of ASR
+      // Skip the extra call to Lex and the extra $$
+
+      // Assuming the interpretations will be sorted by confidence,
+      return this.getNluDataFromInterpretation(
+        this.asrOutput.interpretations[0],
+        this.asrOutput.messages,
+      );
+    } else {
+      // Text input so ASR was skipped
+      const params: RecognizeTextCommandInput = {
+        botId: this.config.bot.id,
+        botAliasId: this.config.bot.aliasId,
+        text,
+        localeId: this.getLocale(jovo),
+        sessionId: jovo.$session.id,
+      };
+      const command = new RecognizeTextCommand(params);
+      const response = await this.client.send(command);
+      if (!response.interpretations) {
+        return;
+      }
+
+      // Assuming the interpretations will be sorted by confidence,
+      return this.getNluDataFromInterpretation(response.interpretations[0], response.messages);
     }
-    // Assuming the interpretations will be sorted by confidence,
-    return this.getNluDataFromInterpretation(response.interpretations[0]);
   }
 
-  private getNluDataFromInterpretation(interpretation: Interpretation): NluData | undefined {
+  private getNluDataFromInterpretation(
+    interpretation: Interpretation,
+    messages?: Message[],
+  ): LexNluData | undefined {
     if (!interpretation.intent) {
       return;
     }
 
-    const nluData: NluData = {
-      intent: interpretation.intent.name,
+    const nluData: LexNluData = {
+      intent: {
+        name: interpretation.intent.name || '',
+        confidence: interpretation.nluConfidence?.score,
+        state: interpretation.intent.state,
+        confirmationState: interpretation.intent.confirmationState,
+      },
+      messages: messages,
     };
+
     if (interpretation.intent.slots) {
       nluData.entities = Object.entries(interpretation.intent.slots).reduce(
         (entities: EntityMap, [name, slot]) => {
-          if (!slot.value) {
+          if (!slot?.value) {
             return entities;
           }
           const resolved = slot.value.resolvedValues?.[0] || slot.value.interpretedValue;
@@ -168,5 +210,19 @@ export class LexSlu extends SluPlugin<LexSluConfig> {
 
   private getLocale(jovo: Jovo): string {
     return this.config.locale || jovo.$request.getLocale() || this.config.fallbackLocale;
+  }
+
+  private async extractValue(input?: string): Promise<any> {
+    if (!input) {
+      return;
+    }
+    const buffer = Buffer.from(input, 'base64');
+    // gzip -> string
+    const textBuffer = await asyncGunzip(buffer);
+    // inputTranscript - The string of textBuffer will always contain double quotes, therefore we can parse it with JSON to get rid of it.
+    // interpretations - JSON array
+    // messages - JSON array
+    const value = JSON.parse(textBuffer.toString());
+    return value;
   }
 }


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

This PR adds an optimization so that the NLU API won't be called is the ASR output was called. This same time and $$.
Issue #1282 

Lex allows you to specify required slots and it will do the slot filling for you. The additional properties on NLU data needed for this are `state`, `confirmationState` and `messages`. Issue #1283 

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
