### PR TITLE
:bug: Fix CorePlatform in JovoDebugger

### DIFF
--- a/integrations/plugin-debugger/docs/README.md
+++ b/integrations/plugin-debugger/docs/README.md
@@ -63,6 +63,7 @@ app.configure({
   plugins: [
     new JovoDebugger({
       nlu: new NlpjsNlu(),
+      plugins: [],
       webhookUrl: 'https://webhook.jovo.cloud',
       debuggerConfigPath: './jovo.debugger.js',
       modelsPath: './models',
@@ -76,6 +77,7 @@ app.configure({
 It includes the following properties:
 
 - [`nlu`](#nlu): Lets you define which [NLU integration](https://www.jovo.tech/docs/nlu) should be used if the Debugger sends a text request. Learn more in the [NLU section](#nlu) below.
+- `plugins`: Under the hood, Jovo Debugger extends the [Jovo Core Platform](https://www.jovo.tech/marketplace/platform-core). You can add any plugin to the `plugins` array in the way you would add it to the Core platform.
 - `webhookUrl`: The webhook to pass to the Debugger. By default, your [Jovo Webhook](https://www.jovo.tech/docs/webhook) URL is used.
 - [`debuggerConfigPath`](#debugger-customization): The path to the Debugger Config file. Learn more in the [Debugger customization](#debugger-customization) section.
 - `modelsPath`: The path to the [Jovo Models](https://www.jovo.tech/docs/models) folder.

--- a/integrations/plugin-debugger/src/JovoDebugger.ts
+++ b/integrations/plugin-debugger/src/JovoDebugger.ts
@@ -38,12 +38,7 @@ import { LanguageModelDirectoryNotFoundError } from './errors/LanguageModelDirec
 import { SocketConnectionFailedError } from './errors/SocketConnectionFailedError';
 import { SocketNotConnectedError } from './errors/SocketNotConnectedError';
 import { WebhookIdNotFoundError } from './errors/WebhookIdNotFoundError';
-import {
-  JovoDebuggerPayload,
-  JovoStateMutationData,
-  JovoUpdateData,
-  StateMutatingJovoMethodKey,
-} from './interfaces';
+import { JovoDebuggerPayload, JovoStateMutationData, JovoUpdateData, StateMutatingJovoMethodKey, } from './interfaces';
 import { MockServer, MockServerRequest } from './MockServer';
 import _cloneDeep from 'lodash.clonedeep';
 
@@ -59,6 +54,7 @@ export interface JovoDebuggerConfig extends PluginConfig {
   debuggerConfigPath: string;
   modelsPath: string;
   ignoredProperties: Array<keyof Jovo | string>;
+  plugins: Plugin[];
 }
 
 export function getDefaultLanguageMap(): UnknownObject {
@@ -70,6 +66,8 @@ export function getDefaultLanguageMap(): UnknownObject {
     it: LangIt,
   };
 }
+
+export class JovoDebuggerPlatform extends CorePlatform<'JovoDebuggerPlatform'> {}
 
 export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
   socket?: typeof Socket;
@@ -89,6 +87,7 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
       debuggerConfigPath: './jovo.debugger.js',
       modelsPath: './models',
       ignoredProperties: ['$app', '$handleRequest', '$platform'],
+      plugins: [],
     };
   }
 
@@ -100,10 +99,12 @@ export class JovoDebugger extends Plugin<JovoDebuggerConfig> {
   }
 
   private installDebuggerPlatform(app: App) {
+    const plugins: Plugin[] = (this.config.plugins as Plugin[]) || [];
+
     app.use(
-      new CorePlatform({
+      new JovoDebuggerPlatform({
         platform: 'jovo-debugger',
-        plugins: [this.config.nlu],
+        plugins: [this.config.nlu, ...plugins],
       }),
     );
   }


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

The `JovoDebugger` plugin initializes the `CorePlatform` internally. An already registered `CorePlatform` via `app.use()` would be overwritten. This PR creates a separate JovoDebugger `CorePlatform` implementation, fixing this issue.

Additionally, it will be possible to add plugins to the JovoDebugger's CorePlatform.


Here's an example (from https://github.com/jovotech/jovo-framework/issues/1333)

```typescript
export class TtsPlugin extends Plugin {
  mount(parent: Extensible): Promise<void> | void {
    parent.middlewareCollection.use('response.tts', (jovo) => {
      console.log('TTS');
    });
  }

  getDefaultConfig() {
    return {};
  }
}
```

If you want to use this plugin in the JovoDebugger, you must add it to the `plugins` array in the config. 

```typescript

app.use(
 // ...
  new JovoDebugger({
    // ...
    plugins: [new TtsPlugin()],
  }),
);
```


## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
