### PR TITLE
:adhesive_bandage: only awaiting output.build if it returns promise

### DIFF
--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -3,6 +3,7 @@ import { JovoResponse, NormalizedOutputTemplate, OutputTemplate } from '@jovotec
 import _cloneDeep from 'lodash.clonedeep';
 import _merge from 'lodash.merge';
 import _set from 'lodash.set';
+import util from 'util';
 import { App, AppConfig } from './App';
 import { HandleRequest } from './HandleRequest';
 import {
@@ -263,7 +264,8 @@ export abstract class Jovo<
     let newOutput: OutputTemplate | OutputTemplate[];
     if (typeof outputConstructorOrTemplateOrMessage === 'function') {
       const outputInstance = new outputConstructorOrTemplateOrMessage(this, options);
-      const output = await outputInstance.build();
+      const outputRes = outputInstance.build();
+      const output = util.types.isPromise(outputRes) ? await outputRes : outputRes;
       // overwrite reserved properties of the built object i.e. message
       NormalizedOutputTemplate.getKeys().forEach((key) => {
         if (typeof options?.[key] !== 'undefined') {


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

This change tries to ensure the order of outputs to be consistent with the order of calls as much as possible, by preventing awaiting `build` calls of outputs that do not return a promise.
With this Output:

```
@Output()
export class YesNoOutput extends BaseOutput {
  build(): OutputTemplate | OutputTemplate[] {
    return {
      quickReplies: ['yes', 'no'],
      listen: true,
    };
  }
}
```
this handler 

```
  START() {
    this.$send(YesNoOutput, { message: 'Do you like Pizza?' });
    return this.$send('this should come after the YesNoOutput');
  }
```
would result in the outputs being in the order that they have been called, while without this, the order would be switched, as `YesNoOutput` is awaited even if the `build` does not return a Promise. I am aware that this can be fixed by awaiting every `$send` call (or at least the ones containing an Output class), but first guess was, that you would only have to await if the `build` method was returning a Promise. I thought that this, or something like this could possibly prevent similar mistakes being made in the future. Maybe this is also just how it is supposed to be though or is intended behavior, in that case, this can just be closed! 

One possible issue I found with this approach is, if I got that right, not only Promises, but all objects with a `then` function can be awaited (see [here](https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise)) but I think this should not be an issue, as type checking ensures for the return type to be an actual Promise. If you consider adding this, I could look into this further though!

While handling this issue I was also wondering, if the actual best approach would also just to be to keep the order always the same as it has been called (even for async `build` calls). Maybe that could be done by somehow adding the Promises to the `$output` array and awaiting the non resolved Promises at the end, or just storing the Promise with the order information and add it to `$output` in the correct order when it resolves. This might have other side effects, that I might not see right now though.

Does one of these approaches makes sense to you?

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
