### PR TITLE
:sparkles: Add Alexa can fulfill intent support

### DIFF
--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -572,7 +572,11 @@ This would result in the following output template:
 ```
 
 ### Name-free Interaction
-You can handle [name-free interactions](https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html) by responding to `CanFulfillIntentRequest` requests. To do this, setup a handler with `AlexaHandles.onCanFulfillIntent` and respond with the `CanFulfillIntentOutput` output template.
+
+You can handle [name-free interactions](https://developer.amazon.com/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html) by responding to `CanFulfillIntentRequest` requests. To do this, you can use the following two helpers:
+
+- `AlexaHandles.onCanFulfillIntentRequest()`: A method for the [`@Handle` decorator](https://www.jovo.tech/docs/handle-decorators) that can be added to a handler to accept requests of the type `CanFulfillIntentRequest`
+- By returning [`CanFulfillIntentOutput`](https://github.com/jovotech/jovo-framework/blob/v4/latest/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts), a [convenience output class](https://www.jovo.tech/marketplace/platform-alexa/output#alexa-output-classes), you can send a response to Alexa that includes the `CanFulfillIntent` directive
 
 ```typescript
 import { Handle } from '@jovotech/framework';
@@ -583,7 +587,37 @@ import { CanFulfillIntentOutput, AlexaHandles } from '@jovotech/platform-alexa';
 someHandler() {
   // ...
   return this.$send(CanFulfillIntentOutput, {
-    canFulfill: "YES"
+    canFulfill: 'YES',
   });
+}
+```
+
+Under the hood, `onCanFulfillIntentRequest()` as part of [`AlexaHandles`](https://github.com/jovotech/jovo-framework/blob/v4/latest/platforms/platform-alexa/src/AlexaHandles.ts) looks like this:
+
+```typescript
+{
+  global: true,
+  types: ['CanFulfillIntentRequest'],
+  platforms: ['alexa'],
+}
+```
+
+[`CanFulfillIntentOutput`](https://github.com/jovotech/jovo-framework/blob/v4/latest/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts) looks like this:
+
+```typescript
+{
+  listen: false,
+  platforms: {
+    alexa: {
+      nativeResponse: {
+        response: {
+          canFulfillIntent: {
+            canFulfill: this.options.canFulfill,
+            slots: this.options.slots ?? {},
+          },
+        },
+      },
+    },
+  },
 }
 ```

--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -195,6 +195,7 @@ The following Alexa properties offer additional features:
 - [Entities (Slots)](#entities-slots-)
 - [ISP](#isp)
 - [Alexa Conversations](#alexa-conversations)
+- [Name-free Interaction](#name-free-interaction)
 
 ### Request
 
@@ -567,5 +568,22 @@ This would result in the following output template:
       },
     },
   },
+}
+```
+
+### Name-free Interaction
+You can handle [name-free interactions](https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html) by responding to `CanFulfillIntentRequest` requests. To do this, setup a handler with `AlexaHandles.onCanFulfillIntent` and respond with the `CanFulfillIntentOutput` output template.
+
+```typescript
+import { Handle } from '@jovotech/framework';
+import { CanFulfillIntentOutput, AlexaHandles } from '@jovotech/platform-alexa';
+// ...
+
+@Handle(AlexaHandles.onCanFulfillIntent())
+someHandler() {
+  // ...
+  return this.$send(CanFulfillIntentOutput, {
+    canFulfill: "YES"
+  });
 }
 ```

--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -579,7 +579,7 @@ import { Handle } from '@jovotech/framework';
 import { CanFulfillIntentOutput, AlexaHandles } from '@jovotech/platform-alexa';
 // ...
 
-@Handle(AlexaHandles.onCanFulfillIntent())
+@Handle(AlexaHandles.onCanFulfillIntentRequest())
 someHandler() {
   // ...
   return this.$send(CanFulfillIntentOutput, {

--- a/platforms/platform-alexa/src/AlexaHandles.ts
+++ b/platforms/platform-alexa/src/AlexaHandles.ts
@@ -85,4 +85,12 @@ export class AlexaHandles {
       platforms: ['alexa'],
     };
   }
+
+  static onCanFulfillIntent(): HandleOptions {
+    return {
+      global: true,
+      types: ['CanFulfillIntentRequest'],
+      platforms: ['alexa'],
+    };
+  }
 }

--- a/platforms/platform-alexa/src/AlexaHandles.ts
+++ b/platforms/platform-alexa/src/AlexaHandles.ts
@@ -86,7 +86,7 @@ export class AlexaHandles {
     };
   }
 
-  static onCanFulfillIntent(): HandleOptions {
+  static onCanFulfillIntentRequest(): HandleOptions {
     return {
       global: true,
       types: ['CanFulfillIntentRequest'],

--- a/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts
@@ -1,4 +1,4 @@
-import { axios, BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
+import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 
 export type CanFulfillResponse = 'YES' | 'NO' | 'MAYBE';
 

--- a/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/CanFulfillIntentOutput.ts
@@ -1,0 +1,34 @@
+import { axios, BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
+
+export type CanFulfillResponse = 'YES' | 'NO' | 'MAYBE';
+
+export interface CanFulfillIntentOutputSlotOptions {
+  canUnderstand?: CanFulfillResponse;
+  canFulfill?: CanFulfillResponse;
+}
+
+export interface CanFulfillIntentOutputOptions extends OutputOptions {
+  canFulfill: CanFulfillResponse;
+  slots?: Record<string, CanFulfillIntentOutputSlotOptions>;
+}
+
+@Output()
+export class CanFulfillIntentOutput extends BaseOutput<CanFulfillIntentOutputOptions> {
+  build(): OutputTemplate {
+    return {
+      listen: false,
+      platforms: {
+        alexa: {
+          nativeResponse: {
+            response: {
+              canFulfillIntent: {
+                canFulfill: this.options.canFulfill,
+                slots: this.options.slots ?? {},
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+}

--- a/platforms/platform-alexa/src/output/templates/index.ts
+++ b/platforms/platform-alexa/src/output/templates/index.ts
@@ -22,3 +22,4 @@ export * from './ConnectionTestStatusCodeOutput';
 export * from './ConnectionVerifyPersonOutput';
 export * from './ConnectionScheduleFoodEstablishmentReservationOutput';
 export * from './ProgressiveResponseOutput';
+export * from './CanFulfillIntentOutput';


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Adds support for handling name-free interactions as described [in the alexa developer documentation](https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html).

Usage

```typescript
import { Handle } from '@jovotech/framework';
import { CanFulfillIntentOutput, AlexaHandles } from '@jovotech/platform-alexa';
// ...

@Handle(AlexaHandles.onCanFulfillIntent())
someHandler() {
  // ...
  return this.$send(CanFulfillIntentOutput, {
    canFulfill: "YES"
  });
}
```

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
