### PR TITLE
📝 Update handle decorators docs

### DIFF
--- a/docs/handle-decorators.md
+++ b/docs/handle-decorators.md
@@ -364,7 +364,7 @@ Currently, they include:
 
 ### platforms
 
-You can specify that a handler is only responsible for specific platforms. The `platforms` property is an array of strings with the names of each platform in camel case:
+You can specify that a handler is only responsible for specific platforms. The `platforms` property is an array of strings with the names of each platform in camelCase:
 
 ```typescript
 @Handle({


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Usually when referring to a camelCase, its more reasonable to type camelCase instead of camel case.

