### PR TITLE
📦 Update i18next version

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -82,6 +82,7 @@ You can add any configuration that is available for `i18next`. [You can find all
 ```typescript
 interpolation: { // https://www.i18next.com/translation-function/interpolation
   escapeValue: false,
+  skipOnVariables: false,
 },
 returnObjects: true, // https://www.i18next.com/translation-function/objects-and-arrays
 ```

--- a/framework/package.json
+++ b/framework/package.json
@@ -27,7 +27,7 @@
     "@jovotech/output": "^4.2.15",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
-    "i18next": "^20.3.1",
+    "i18next": "^21.8.11",
     "json-colorizer": "^2.2.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",

--- a/framework/src/I18Next.ts
+++ b/framework/src/I18Next.ts
@@ -84,6 +84,7 @@ export class I18Next extends Plugin<I18NextConfig> {
     return {
       interpolation: {
         escapeValue: false,
+        skipOnVariables: false,
       },
       returnObjects: true,
     };


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

This PR updates `i18next` to v21.8.11 which supports the new [JSON v4 format](https://www.i18next.com/misc/json-format#i18next-json-v4).

I added `skipOnVariables: false` to the default plugin config, because its default value has been changed from `false` to `true` in v21. I also changed the Jovo docs accordingly.

Addresses #1366.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This PR doesn't break the framework itself, but may change the behaviour of the `jovo.$t` method if backwards compatibility isn't enabled for older versions of the JSON format.

[This](https://i18next.github.io/i18next-v4-format-converter-web/) tool can help to convert from v3 to v4 JSON format.

Anyway, backwards compatibility can be set via plugin config in the following way:

```typescript
const app = new App({
  // ...

  i18n: {
    compatibilityJSON: 'v3', // v3 is the current JSON format version
  },
});
```

Other changes from v20 to v21 of `i18next` are listed [here](https://www.i18next.com/misc/migration-guide#v20.x.x-to-v21.0.0).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
