### PR TITLE
🐛💥 Fixes `mergeInstances` in output strategies

### DIFF
--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -120,6 +120,9 @@ export function mergeInstances<D extends object, S extends any[]>(
     ...sources.map((source) => instanceToObject(source)),
     // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
     (value: any, srcValue: any, key: string, object: any) => {
+      if (Array.isArray(srcValue)) {
+        return srcValue.concat(value);
+      }
       if (typeof srcValue === 'undefined') {
         _unset(object, key);
       }

--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -120,7 +120,7 @@ export function mergeInstances<D extends object, S extends any[]>(
     ...sources.map((source) => instanceToObject(source)),
     // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
     (value: any, srcValue: any, key: string, object: any) => {
-      if (Array.isArray(srcValue)) {
+      if (Array.isArray(srcValue) && Array.isArray(value)) {
         return srcValue.concat(value);
       }
       if (typeof srcValue === 'undefined') {

--- a/output/test/utilities.test.ts
+++ b/output/test/utilities.test.ts
@@ -139,4 +139,26 @@ describe('mergeInstances', () => {
 
     expect(mergeInstances(b, a)).toEqual(merged);
   });
+
+  test('test merging of nested arrays', () => {
+    const a = {
+      obj: {
+        arr: ['a', 'b'],
+      },
+    };
+
+    const b = {
+      obj: {
+        arr: ['c', 'd'],
+      },
+    };
+
+    const merged = {
+      obj: {
+        arr: ['a', 'b', 'c', 'd'],
+      },
+    };
+
+    expect(mergeInstances(b, a)).toEqual(merged);
+  });
 });


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->


## Proposed Changes

Fixes merge handling for arrays in `nativeResponse`. Fixes #1356

This could break workarounds that try to bypass this bug. 


## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
