### PR TITLE
:sparkles: Add mongodb libraryConfig - Jovo v3

### DIFF
--- a/jovo-integrations/jovo-db-mongodb/README.md
+++ b/jovo-integrations/jovo-db-mongodb/README.md
@@ -60,6 +60,7 @@ module.exports = {
             databaseName: 'yourDatabaseName',
         collectionName: 'yourCollectionName',
         uri: 'yourMongoDbURI',
+        libraryConfig: { /* MongoClientOptions */ },
         },
     },
 
@@ -87,6 +88,8 @@ const config = {
 ```
 
 If you don't specify a collection name, a default collection ```UserData``` will be created in your specified database.
+
+`libraryConfig`: Additional options that can be passed to the MongoDB client. You can find all options in the [official `MongoClientOptions` reference](https://mongodb.github.io/node-mongodb-native/3.6/api/global.html#MongoClientOptions).
 
 ## Troubleshooting
 

--- a/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
+++ b/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
@@ -16,9 +16,9 @@ export class MongoDb implements Db {
   config: Config = {
     collectionName: 'UserData',
     databaseName: undefined,
+    libraryConfig: { useNewUrlParser: true, useUnifiedTopology: true },
     primaryKeyColumn: 'userId',
     uri: undefined,
-    libraryConfig: { useNewUrlParser: true, useUnifiedTopology: true },
   };
   needsWriteFileAccess = false;
   isCreating = false;

--- a/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
+++ b/jovo-integrations/jovo-db-mongodb/src/MongoDb.ts
@@ -1,13 +1,15 @@
 import { BaseApp, Db, ErrorCode, Jovo, JovoError, PluginConfig } from 'jovo-core';
 import _get = require('lodash.get');
 import _merge = require('lodash.merge');
-import { MongoClient } from 'mongodb';
+import { MongoClient, MongoClientOptions } from 'mongodb';
 
 export interface Config extends PluginConfig {
   uri?: string;
   databaseName?: string;
   collectionName?: string;
   primaryKeyColumn?: string;
+  /** Client options for the official `mongodb` package that is used */
+  libraryConfig?: MongoClientOptions;
 }
 
 export class MongoDb implements Db {
@@ -16,6 +18,7 @@ export class MongoDb implements Db {
     databaseName: undefined,
     primaryKeyColumn: 'userId',
     uri: undefined,
+    libraryConfig: { useNewUrlParser: true, useUnifiedTopology: true },
   };
   needsWriteFileAccess = false;
   isCreating = false;
@@ -46,7 +49,7 @@ export class MongoDb implements Db {
   }
 
   async getConnectedMongoClient(uri: string): Promise<MongoClient> {
-    return MongoClient.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+    return MongoClient.connect(uri, this.config.libraryConfig);
   }
 
   errorHandling() {


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

For Jovo v3

Adds optional libraryConfig with the native MongoClientOptions that are passed to the official mongodb library on initialization.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
