### PR TITLE
alexa-verifier-middleware v 2.x is not supported

### DIFF
--- a/jovo-framework/src/server.ts
+++ b/jovo-framework/src/server.ts
@@ -68,8 +68,13 @@ verifiedServer.listen = function () {
       Log.warn('  Please install module alexa-verifier-middleware');
       Log.warn('  $ npm install alexa-verifier-middleware');
       Log.warn();
+    } else if (error.code === 'ERR_REQUIRE_ESM') {
+      Log.warn();
+      Log.warn('  alexa-verifier-middleware version 2.x is now a pure es module');
+      Log.warn('  use alexa-verifier-middleware@1.x');
+      Log.warn();
     } else {
-      Log.error(error);
+     throw error;
     }
   }
 };


### PR DESCRIPTION
Version 2.x is now a pure es module, and requires node 12.17 or higher. If you want to run this via an older version of node, use alexa-verifier-middleware@1.x
If we change to version 2.x we also need to use an import statement instead of require.
It would also make sense to add it to the dependencies to have control over min/max version numbers.
And i prefer to finally throw an error here. Would have saved me 1hrs of debugging.

<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
