### PR TITLE
:sparkle: Determine when Sanity queries are loaded

### DIFF
--- a/integrations/cms-sanity/docs/README.md
+++ b/integrations/cms-sanity/docs/README.md
@@ -21,7 +21,8 @@ Learn more about the Sanity Jovo integration in the following sections:
 
 - [Installation](#installation): Set up Sanity and connect it to your Jovo app
 - [Configuration](#configuration): All configuration options for this integration
-- [Query transformers](#query-transformers): Change the structure of a query result before it is saved in the `$cms` property in Jovo
+- [Query Transformers](#query-transformers): Change the structure of a query result before it is saved in the `$cms` property in Jovo
+- [`$sanity` Object](#sanity-object): Access Sanity-specific features
 
 ## Installation
 
@@ -100,6 +101,26 @@ You need the `projectId` and `dataset` from your Sanity project which can be fou
 You will also need at least one query which consists of a key and a [GROQ](https://www.sanity.io/docs/groq) statement. The example adds `translations` for [i18n](https://www.jovo.tech/docs/i18n) (using the [`TranslationsQueryTransformer`](#translationsquerytransformer)), which can be accessed with `this.$t()`. For other data types, take a look at the [`queries` section](#queries).
 
 All configuration options can be found in the [configuration section](#configuration).
+
+### Ignore $sanity in Debugger
+
+If using the [Jovo Debugger](https://www.jovo.tech/docs/debugger), you must add `$sanity` to the list of properties the Debugger ignores:
+
+```ts
+// app.dev.ts
+
+new JovoDebugger({
+  ignoredProperties: ['$app', '$handleRequest', '$platform', '$sanity'],
+}),
+```
+
+Otherwise, the app could throw an error that looks like this:
+
+```
+RangeError: Maximum call stack size exceeded
+    at hasBinary ([...]/jovo-framework/node_modules/has-binary2/index.js:30:20)
+```
+
 
 ## Configuration
 
@@ -244,7 +265,7 @@ Information on query transformers can be found in the [query transformers sectio
 
 ### autoLoad
 
-An array of query names to automatically load during the `request.start` middleware. Not setting this property will auto load all queries. Set to an empty array to not auto load any query.
+An array of query names to automatically load during the [`request.start` middleware](https://www.jovo.tech/docs/middlewares#ridr-middlewares). Not setting this property will auto load all queries. Set to an empty array to not auto load any query.
 
 ```typescript
 new SanityCms({
@@ -258,7 +279,15 @@ new SanityCms({
 }),
 ```
 
-To load a query by name (with any associated query transformer) in a hook or handler, use `this.$sanity.load(['products', 'articles'])` and then access from `$cms`: `this.$cms.products`.
+Below is an example how to explicitly [load](#load) a query by name (with any associated query transformer) in a hook or handler:
+
+```typescript
+// Load queries into $cms
+await this.$sanity.load(['products', 'articles']);
+
+// Access query from $cms
+this.$cms.products
+```
 
 ## Query Transformers
 
@@ -448,11 +477,17 @@ export class SampleQueryTransformer extends BaseSanityQueryTransformer<SampleTra
 }
 ```
 
-## Usage
+## $sanity Object
+
+The `$sanity` object contains the following Sanity-specific features:
+
+- [load](#load)
+- [client](#client)
+
 
 ### load
 
-Manually load one or more queries named in configuration:
+Manually load one or more queries named in [configuration](#configuration):
 
 ```typescript
 await this.$sanity.load('products');
@@ -468,15 +503,3 @@ Access the [Sanity SDK](https://github.com/sanity-io/client) client using `this.
 ```typescript
 const result = await this.$sanity.client.fetch("*[_type == 'appSettings']")
 ```
-
-## Jovo Debugger
-If using the Jovo Debugger, you must add `$sanity` to the list of properties the debugger ignores:
-
-```ts
-// app.dev.ts
-
-new JovoDebugger({
-  ignoredProperties: ['$app', '$handleRequest', '$platform', '$sanity'],
-}),
-```
-

--- a/integrations/cms-sanity/docs/README.md
+++ b/integrations/cms-sanity/docs/README.md
@@ -125,6 +125,7 @@ new SanityCms({
     articles: "*[_type == 'article' && !(_id in path('drafts.**'))]",
     siteSettings: "*[_type == 'siteSettings' && !(_id in path('drafts.**'))][0]",
   },
+  autoLoad: ['translations', 'siteSettings'],
 }),
 ```
 
@@ -135,6 +136,7 @@ new SanityCms({
   - [`apiVersion`](#apiversion): The version of the API. Uses the current date as default.
   - [`useCdn`](#usecdn): Determines whether to used the Sanity cached API CDN for faster response times. The default is `true`.
 - [`queries`](#queries): Define this list of GROQ queries to execute and the key under `$cms` to store the resulting JSON.
+- [`autoLoad`](#autoload): Optional. Define a list of query names that will be loaded at `request.start`.
 
 ### projectId
 
@@ -239,6 +241,24 @@ In this example:
 - `siteSettings` - a object for the single `siteSettings` type. Access with `this.$cms.siteSettings`.
 
 Information on query transformers can be found in the [query transformers section](#query-transformers).
+
+### autoLoad
+
+An array of query names to automatically load during the `request.start` middleware. Not setting this property will auto load all queries. Set to an empty array to not auto load any query.
+
+```typescript
+new SanityCms({
+  queries: {
+    translations: //...
+    products: //...
+    articles: //...
+    siteSettings: //...
+  },
+  autoLoad: ['translations', 'siteSettings'],
+}),
+```
+
+To load a query by name (with any associated query transformer) in a hook or handler, use `this.$sanity.load(['products', 'articles'])` and then access from `$cms`: `this.$cms.products`.
 
 ## Query Transformers
 
@@ -427,3 +447,36 @@ export class SampleQueryTransformer extends BaseSanityQueryTransformer<SampleTra
   // ...
 }
 ```
+
+## Usage
+
+### load
+
+Manually load one or more queries named in configuration:
+
+```typescript
+await this.$sanity.load('products');
+await this.$sanity.load(['products', 'articles']);
+
+const products = this.$cms.products;
+```
+
+### client
+
+Access the [Sanity SDK](https://github.com/sanity-io/client) client using `this.$sanity.client`:
+
+```typescript
+const result = await this.$sanity.client.fetch("*[_type == 'appSettings']")
+```
+
+## Jovo Debugger
+If using the Jovo Debugger, you must add `$sanity` to the list of properties the debugger ignores:
+
+```ts
+// app.dev.ts
+
+new JovoDebugger({
+  ignoredProperties: ['$app', '$handleRequest', '$platform', '$sanity'],
+}),
+```
+

--- a/integrations/cms-sanity/src/JovoSanity.ts
+++ b/integrations/cms-sanity/src/JovoSanity.ts
@@ -1,0 +1,51 @@
+import { Jovo, JovoError } from '@jovotech/framework';
+import SanityClient from '@sanity/client';
+import { SanityCms, SanityCmsConfig } from './SanityCms';
+import { BaseSanityQueryTransformer } from './transformers';
+
+export class JovoSanity {
+  readonly client: any;
+
+  constructor(readonly sanityCms: SanityCms, readonly jovo: Jovo) {
+    this.client = new SanityClient(this.config.client);
+  }
+
+  get config(): SanityCmsConfig {
+    return this.sanityCms.config;
+  }
+
+  async load(queryKeys: string | string[]): Promise<void> {
+    const names = Array.isArray(queryKeys) ? queryKeys : [queryKeys];
+    const promises = [];
+
+    for (const [name, value] of Object.entries(this.config.queries)) {
+      if (names.includes(name)) {
+        const transformer =
+          typeof value === 'string' ? null : (value as BaseSanityQueryTransformer);
+        const query: string = transformer ? transformer.config.query : (value as string);
+
+        if (!query) continue;
+
+        promises.push({ name, transformer, query, data: this.client.fetch(query) });
+      }
+    }
+
+    if (promises.length > 0) {
+      const allPromises = await Promise.all(promises);
+
+      for (const p of allPromises) {
+        try {
+          const data = await p.data;
+
+          if (p.transformer) {
+            this.jovo.$cms[p.name] = p.transformer.execute(data, this.jovo);
+          } else {
+            this.jovo.$cms[p.name] = data;
+          }
+        } catch (error) {
+          throw new JovoError({ message: (error as Error).message });
+        }
+      }
+    }
+  }
+}

--- a/integrations/cms-sanity/src/index.ts
+++ b/integrations/cms-sanity/src/index.ts
@@ -1,2 +1,21 @@
+import { JovoSanity } from './JovoSanity';
+import { SanityCms, SanityCmsConfig } from './SanityCms';
+
+declare module '@jovotech/framework/dist/types/Extensible' {
+  interface ExtensiblePluginConfig {
+    SanityCms?: SanityCmsConfig;
+  }
+
+  interface ExtensiblePlugins {
+    SanityCms?: SanityCms;
+  }
+}
+
+declare module '@jovotech/framework/dist/types/Jovo' {
+  interface Jovo {
+    $sanity: JovoSanity;
+  }
+}
+
 export * from './SanityCms';
 export * from './transformers';


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Add `autoLoad` property to configuration to control if queries are loaded automatically or manually.

Add `$sanity` to access `load` and `client`.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
