### PR TITLE
:bug: Fix Alexa request type transformation

### DIFF
--- a/platforms/platform-alexa/docs/output.md
+++ b/platforms/platform-alexa/docs/output.md
@@ -526,8 +526,8 @@ Similar to how it works with [quick replies](#quickreplies) and [carousel items]
 "arguments": [
   {
     "type": "Selection",
-	  "intent": "ElementIntent",
-	  "entities": {
+    "intent": "ElementIntent",
+    "entities": {
       "element": {
         "value": "A"
       }

--- a/platforms/platform-alexa/src/constants.ts
+++ b/platforms/platform-alexa/src/constants.ts
@@ -1,3 +1,3 @@
-export const SUPPORTED_APL_ARGUMENT_TYPES = ['QuickReply', 'Selection'];
+export const SUPPORTED_APL_ARGUMENT_TYPES = ['QuickReply', 'Selection']; // @see https://www.jovo.tech/marketplace/platform-alexa/output#apl-user-events
 export const STATIC_ENTITY_MATCHES_PREFIX = 'amzn1.er-authority.echo-sdk.amzn1';
 export const DYNAMIC_ENTITY_MATCHES_PREFIX = 'amzn1.er-authority.echo-sdk.dynamic';


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Requests of the type `Alexa.Presentation.APL.UserEvent` are transformed to the type `Intent` if the APL arguments contain intent information, as explained here: https://www.jovo.tech/marketplace/platform-alexa/output#apl-user-events

However, if the APL arguments didn't contain an intent, the type would still be transformed. This PR fixes that.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
