### PR TITLE
🏷️ Add `FileDbInitConfig`

### DIFF
--- a/integrations/db-filedb/src/FileDb.ts
+++ b/integrations/db-filedb/src/FileDb.ts
@@ -1,4 +1,4 @@
-import { DbItem, DbPlugin, DbPluginConfig, Jovo } from '@jovotech/framework';
+import { DbItem, DbPlugin, DbPluginConfig, DeepPartial, Jovo } from '@jovotech/framework';
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
@@ -8,8 +8,10 @@ export interface FileDbConfig extends DbPluginConfig {
   primaryKeyColumn?: string;
 }
 
+export type FileDbInitConfig = DeepPartial<FileDbConfig>;
+
 export class FileDb extends DbPlugin<FileDbConfig> {
-  constructor(config?: FileDbConfig) {
+  constructor(config?: FileDbInitConfig) {
     super(config);
   }
 


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

In previous versions, it wasn't possible to add a config options to `FileDb` without adding the required `pathToFile` option to the constructor as well, although it has a default value.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
