### PR TITLE
:sparkles: Add billingMode option on DynamoDbConfig to allow on-demand mode

### DIFF
--- a/integrations/db-dynamodb/docs/README.md
+++ b/integrations/db-dynamodb/docs/README.md
@@ -117,6 +117,7 @@ new DynamoDb({
     primaryKeyColumn: 'userId',
     readCapacityUnits: 2, // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
     writeCapacityUnits: 2, // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
+    billingMode: 'PROVISIONED', // @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
   },
   // ...
 }),

--- a/integrations/db-dynamodb/docs/README.md
+++ b/integrations/db-dynamodb/docs/README.md
@@ -117,7 +117,7 @@ new DynamoDb({
     primaryKeyColumn: 'userId',
     readCapacityUnits: 2, // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
     writeCapacityUnits: 2, // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
-    billingMode: 'PROVISIONED', // @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
+    billingMode: 'PROVISIONED', // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
   },
   // ...
 }),

--- a/integrations/db-dynamodb/src/DynamoDb.ts
+++ b/integrations/db-dynamodb/src/DynamoDb.ts
@@ -26,6 +26,7 @@ export interface DynamoDbConfig extends DbPluginConfig {
     primaryKeyColumn?: string; // Name of primary key column
     readCapacityUnits?: number; // @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
     writeCapacityUnits?: number; // @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html
+    billingMode?: 'PROVISIONED' | 'PAY_PER_REQUEST'; // @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
   };
   libraryConfig?: {
     dynamoDbClient?: DynamoDBClientConfig;
@@ -60,6 +61,7 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
         createTableOnInit: true,
         readCapacityUnits: 2,
         writeCapacityUnits: 2,
+        billingMode: 'PROVISIONED',
       },
       libraryConfig: {
         marshall: {
@@ -121,6 +123,7 @@ export class DynamoDb extends DbPlugin<DynamoDbConfig> {
         ReadCapacityUnits: this.config.table.readCapacityUnits!,
         WriteCapacityUnits: this.config.table.writeCapacityUnits!,
       },
+      BillingMode: this.config.table.billingMode!,
       TableName: this.config.table.name!,
     };
 


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Allows to create a DynamoDb table with the on-demand mode.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
