### PR TITLE
:sparkles: allow matching of handlers in superclasses of components

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -408,3 +408,37 @@ You can also access the active component like this:
 ```typescript
 this.$handleRequest.activeComponentNode;
 ```
+
+### Inheritance
+
+Components can inherit handlers from their superclass. This is useful for example if many of your components offer a similar workflow, like a help handler.
+
+```typescript
+import { BaseComponent } from '@jovotech/framework';
+
+abstract class ComponentWithHelp extends BaseComponent {
+  abstract showHelp(): Promise<void>;
+  
+  async repeatLastResponse() {
+    // ...
+  }
+  
+  @Intents('HelpIntent')
+  async help() {
+    await this.showHelp();
+    await this.repeatLastResponse();
+  }
+}
+
+@Component()
+class YourComponent extends ComponentWithHelp {
+  async showHelp() {
+    // ...
+  }
+}
+```
+
+When using inheritance, the following rules apply:
+
+- The subclass has to be annotated with `@Component` and registered in app. If the superclass is annotated with `@Component`, any options provided there will be ignored.
+- Handlers in the subclass will override handlers **and their decorators** in the superclass. This means that when overriding a handler for a specific intent, it will have to be annotated with `@Intents` / `@Handle` again.

--- a/framework/src/metadata/MetadataStorage.ts
+++ b/framework/src/metadata/MetadataStorage.ts
@@ -192,12 +192,44 @@ export class MetadataStorage {
 
     const prototype = Object.getPrototypeOf(target);
     // Object.getPrototypeOf of the topmost class in the superclass chain is {} (empty object)
-    // and Object.getPrototypeOf({}) of {} is Object.prototype.
+    // and Object.getPrototypeOf({}) is Object.prototype.
     if (prototype && Object.getPrototypeOf(prototype) !== Object.prototype) {
       const parentMergedMetadata = this.getMergedHandlerMetadataOfComponent(prototype);
-      return [...mergedMetadata, ...parentMergedMetadata];
+      return this.mergeHandlerMetadataWithParent(mergedMetadata, parentMergedMetadata);
     }
 
+    return mergedMetadata;
+  }
+
+  /**
+   * Merges the handler metadata of a component with the handler metadata of its superclass.
+   * When a child class declares a handler with the same name as a handler of its superclass,
+   * the child class handler overrides the superclass handler and replaces all of its annotations.
+   *
+   * @param handlerMetadata
+   * @param parentMetadata
+   * @private
+   */
+  private mergeHandlerMetadataWithParent<COMPONENT extends BaseComponent>(
+    handlerMetadata: HandlerMetadata<COMPONENT, keyof COMPONENT>[],
+    parentMetadata: HandlerMetadata<COMPONENT, keyof COMPONENT>[],
+  ): HandlerMetadata<COMPONENT, keyof COMPONENT>[] {
+    const mergedMetadata = [...handlerMetadata];
+    for (const parentHandler of parentMetadata) {
+      const isOverride =
+        handlerMetadata.findIndex((meta) => {
+          if (meta.propertyKey !== parentHandler.propertyKey) {
+            return false;
+          }
+          return (
+            meta.target === parentHandler.target ||
+            Object.getPrototypeOf(meta.target) === parentHandler.target
+          );
+        }) >= 0;
+      if (!isOverride) {
+        mergedMetadata.push(parentHandler);
+      }
+    }
     return mergedMetadata;
   }
 

--- a/framework/src/metadata/MetadataStorage.ts
+++ b/framework/src/metadata/MetadataStorage.ts
@@ -189,6 +189,15 @@ export class MetadataStorage {
         relatedHandlerMetadata.mergeWith(optionMetadata);
       }
     });
+
+    const prototype = Object.getPrototypeOf(target);
+    // Object.getPrototypeOf of the topmost class in the superclass chain is {} (empty object)
+    // and Object.getPrototypeOf({}) of {} is Object.prototype.
+    if (prototype && Object.getPrototypeOf(prototype) !== Object.prototype) {
+      const parentMergedMetadata = this.getMergedHandlerMetadataOfComponent(prototype);
+      return [...mergedMetadata, ...parentMergedMetadata];
+    }
+
     return mergedMetadata;
   }
 

--- a/framework/test/Routing.test.ts
+++ b/framework/test/Routing.test.ts
@@ -1,0 +1,40 @@
+import { App, BaseComponent, Component, Global, InputType, Intents } from '../src';
+import { ExamplePlatform, ExampleServer } from './utilities';
+
+test('test handler decorator inheritance', async () => {
+  @Global()
+  @Component()
+  class MyComponent extends BaseComponent {
+    @Intents('IntentA')
+    handleIntentA() {
+      return this.$send('MyComponent.IntentA');
+    }
+  }
+
+  @Global()
+  @Component()
+  class ComponentA extends MyComponent {
+    handleIntentA() {
+      return this.$send('ComponentA.IntentC');
+    }
+  }
+
+  const app = new App({
+    plugins: [new ExamplePlatform()],
+    components: [ComponentA],
+  });
+  await app.initialize();
+
+  const server = new ExampleServer({
+    input: {
+      type: InputType.Intent,
+      intent: 'IntentA',
+    },
+  });
+  await app.handle(server);
+  expect(server.response.output).toEqual([
+    {
+      message: 'ComponentA.IntentC',
+    },
+  ]);
+});

--- a/framework/test/Routing.test.ts
+++ b/framework/test/Routing.test.ts
@@ -9,13 +9,41 @@ test('test handler decorator inheritance', async () => {
     handleIntentA() {
       return this.$send('MyComponent.IntentA');
     }
+
+    @Intents('IntentB')
+    handleIntentB() {
+      return this.$send('MyComponent.IntentB');
+    }
+
+    @Intents('IntentC')
+    handleIntentC() {
+      return this.$send('MyComponent.IntentC');
+    }
+
+    UNHANDLED() {
+      return this.$send('MyComponent.UNHANDLED');
+    }
   }
 
   @Global()
   @Component()
   class ComponentA extends MyComponent {
+    @Intents('IntentA')
     handleIntentA() {
-      return this.$send('ComponentA.IntentC');
+      return this.$send('ComponentA.IntentA');
+    }
+
+    @Intents('IntentD')
+    handleIntentC() {
+      return super.handleIntentC();
+    }
+  }
+
+  @Global()
+  @Component()
+  class ComponentB extends BaseComponent {
+    someHandler() {
+      return this.$send('test');
     }
   }
 
@@ -25,7 +53,7 @@ test('test handler decorator inheritance', async () => {
   });
   await app.initialize();
 
-  const server = new ExampleServer({
+  let server = new ExampleServer({
     input: {
       type: InputType.Intent,
       intent: 'IntentA',
@@ -34,7 +62,46 @@ test('test handler decorator inheritance', async () => {
   await app.handle(server);
   expect(server.response.output).toEqual([
     {
-      message: 'ComponentA.IntentC',
+      message: 'ComponentA.IntentA',
+    },
+  ]);
+
+  server = new ExampleServer({
+    input: {
+      type: InputType.Intent,
+      intent: 'IntentB',
+    },
+  });
+  await app.handle(server);
+  expect(server.response.output).toEqual([
+    {
+      message: 'MyComponent.IntentB',
+    },
+  ]);
+
+  server = new ExampleServer({
+    input: {
+      type: InputType.Intent,
+      intent: 'IntentC',
+    },
+  });
+  await app.handle(server);
+  expect(server.response.output).toEqual([
+    {
+      message: 'MyComponent.UNHANDLED',
+    },
+  ]);
+
+  server = new ExampleServer({
+    input: {
+      type: InputType.Intent,
+      intent: 'IntentD',
+    },
+  });
+  await app.handle(server);
+  expect(server.response.output).toEqual([
+    {
+      message: 'MyComponent.IntentC',
     },
   ]);
 });


### PR DESCRIPTION
## Proposed Changes

This PR adds code that checks the superclass chain of a component for handlers.
This allows for example abstract components with handlers to be used.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
