### PR TITLE
:bug: Add sessionId to each Dashbot response

### DIFF
--- a/integrations/analytics-dashbot/src/plugins/DashbotUniversal.ts
+++ b/integrations/analytics-dashbot/src/plugins/DashbotUniversal.ts
@@ -88,6 +88,7 @@ export class DashbotUniversal extends DashbotAnalyticsPlugin {
         userId: jovo.$user.id || '',
         platformJson: response,
         buttons: this.getButtons(output.quickReplies),
+        sessionId: jovo.$session.id || '',
       };
 
       await this.sendDashbotRequest(url, responseLog);


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

This commit adds the sessionId to the Dashbot response so that both request and response contain a sessionId, this ensures Dashbot links the incoming and outgoing messages to the same userId and sessionId (currently this does not always happen)


## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
