### PR TITLE
♻️ Use includedProperties instead of ignoredProperties

### DIFF
--- a/integrations/plugin-debugger/docs/README.md
+++ b/integrations/plugin-debugger/docs/README.md
@@ -57,7 +57,7 @@ Learn more about its configuration options in the [Debugger plugin configuration
 You can configure the Jovo Debugger plugin in the [app configuration](https://www.jovo.tech/docs/app-config). It includes everything that is needed from the app side for the Debugger to work properly ([for Debugger frontend customization, take a look here](#debugger-customization)).
 
 ```typescript
-import { JovoDebugger } from '@jovotech/plugin-debugger';
+import { JovoDebugger, DEFAULT_INCLUDED_PROPERTIES } from '@jovotech/plugin-debugger';
 // ...
 
 app.configure({
@@ -68,7 +68,8 @@ app.configure({
       webhookUrl: 'https://webhook.jovo.cloud',
       debuggerConfigPath: './jovo.debugger.js',
       modelsPath: './models',
-      ignoredProperties: ['$app', '$handleRequest', '$platform'],
+      includedProperties: DEFAULT_INCLUDED_PROPERTIES,
+      ignoredProperties: ['$app', '$handleRequest', '$platform'], // We recommend using includedProperties instead
     }),
     // ...
   ],
@@ -82,7 +83,8 @@ It includes the following properties:
 - `webhookUrl`: The webhook to pass to the Debugger. By default, your [Jovo Webhook](https://www.jovo.tech/docs/webhook) URL is used.
 - [`debuggerConfigPath`](#debugger-customization): The path to the Debugger Config file. Learn more in the [Debugger customization](#debugger-customization) section.
 - `modelsPath`: The path to the [Jovo Models](https://www.jovo.tech/docs/models) folder.
-- `ignoredProperties`: The [Jovo properties](https://www.jovo.tech/docs/jovo-properties) that should be ignored by the Debugger lifecycle view.
+- [`includedProperties`](#includedproperties): The [Jovo properties](https://www.jovo.tech/docs/jovo-properties) that should be included in the Debugger lifecycle view.
+- `ignoredProperties`: The [Jovo properties](https://www.jovo.tech/docs/jovo-properties) that should be ignored by the Debugger lifecycle view. This is an old config property. We recommend using [`includedProperties`](#includedproperties) instead.
 
 ### nlu
 
@@ -168,6 +170,30 @@ app.configure({
   ],
 });
 ```
+
+### includedProperties
+
+The Debugger lifecycle view displays updates to [Jovo properties](https://www.jovo.tech/docs/jovo-properties) that happen during a request-response lifecycle. This is helpful to track more detailed changes to your app's data.
+
+If you have an additional property that you want to track using the Debugger, you can add it using the `includedProperties` array. We recommend the following approach:
+
+```typescript
+import { DEFAULT_INCLUDED_PROPERTIES, JovoDebugger } from '@jovotech/plugin-debugger';
+// ...
+
+app.configure({
+  plugins: [
+    new JovoDebugger({
+      includedProperties: [...DEFAULT_INCLUDED_PROPERTIES, '$yourProperty'],
+      // ...
+    }),
+    // ...
+  ],
+});
+```
+
+Note: Properties that contain a reference to the `Jovo` object can cause `Maximum call stack size exceeded` exceptions.
+
 
 ## Debugger Customization
 


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Extending the `Jovo` class with additional properties caused `Maximum call stack size exceeded` exceptions in the JovoDebugger if they contained a reference to the jovo object. 

This PR proposes to change the approach to `includedProperties` instead of ignoring these properties via `ignoredProperties`.

`ignoredProperties` is still available to prevent a breaking change. 

Best practice if you want to extend the `includedProperties` array

```typescript
import { DEFAULT_INCLUDED_PROPERTIES, JovoDebugger } from '@jovotech/plugin-debugger';

...
 new JovoDebugger({
    includedProperties: [...DEFAULT_INCLUDED_PROPERTIES, '$foobar'],
  }),
...
```



## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
