### PR TITLE
Response to Slots invalid

### DIFF
--- a/jovo-platforms/jovo-platform-alexa/src/modules/CanFulfillIntent.ts
+++ b/jovo-platforms/jovo-platform-alexa/src/modules/CanFulfillIntent.ts
@@ -67,8 +67,8 @@ export class CanFulfillIntent implements Plugin {
         throw new Error('canFulfill must be one the following values: YES | NO');
       }
       _set(this.$output, `Alexa.CanFulfillSlot.${slotName}`, {
-        canUnderstandSlot,
-        canFulfillSlot,
+        canUnderstand: canUnderstandSlot,
+        canFulfill: canFulfillSlot,
       });
       return this;
     };


### PR DESCRIPTION
As per https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html#sample-intent-response the property name should be "canUnderstand" instead of "canUnderstandSlot" and "canFulfill" instead of "canFulfillSlot"

<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
