### PR TITLE
:bug: fixed type of JovoHistoryItem.state

### DIFF
--- a/framework/src/JovoHistory.ts
+++ b/framework/src/JovoHistory.ts
@@ -8,7 +8,7 @@ export interface JovoHistoryItem extends UnknownObject {
   request?: JovoRequest;
   input?: JovoInput;
 
-  state?: JovoSession['$state'];
+  state?: JovoSession['state'];
   entities?: EntityMap;
 
   output?: OutputTemplate[];


### PR DESCRIPTION
## Proposed Changes

I saw that JovoHistoryItem.state was unknown, due to a seemingly broken lookup type

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
