### PR TITLE
:bug: fixed js require in NlpjsNlu

### DIFF
--- a/integrations/nlu-nlpjs/src/NlpjsNlu.ts
+++ b/integrations/nlu-nlpjs/src/NlpjsNlu.ts
@@ -135,7 +135,7 @@ export class NlpjsNlu extends NluPlugin<NlpjsNluConfig> {
 
       let jovoModelData;
       if (extension === 'js') {
-        jovoModelData = require(filePath);
+        jovoModelData = require(join(process.cwd(), filePath));
       } else if (extension === 'json') {
         const fileBuffer = await promises.readFile(filePath);
         jovoModelData = JSON.parse(fileBuffer.toString());


### PR DESCRIPTION
## Proposed Changes

When I change my lang model to a javascript file (in order to benefit from type definitions and comment function) the JovoDebugger (more concretely NlpjsNlu) throws an Error `Cannot find module 'models/en.js'`. 

When using `.json` this works well, as this is imported with `fs.readFile(filePath)` which uses the current working directory for relative paths:

> Relative paths will be resolved relative to the current working directory as determined by calling process.cwd().

see [docs](https://nodejs.org/api/fs.html#fs_string_paths)

`require` does not do that out of the box, which is why I added this in that case.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
