### PR TITLE
:sparkles: support for generic locale alexa manifest definition

### DIFF
--- a/platforms/platform-alexa/docs/project-config.md
+++ b/platforms/platform-alexa/docs/project-config.md
@@ -67,6 +67,58 @@ new AlexaCli({
 });
 ```
 
+In combination with the [`files` property](#files), you can use the generic `locales` to populate publishing and privacy & compliance information in the Alexa Skill Manifest:
+
+```js
+new AlexaCli({
+  locales: {
+    en: ['en-US', 'en-GB', 'en-IN'],
+    de: ['de-DE'],
+  },
+  files: {
+    'skill-package/skill.json': {
+      manifest: {
+        publishingInformation: {
+          locales: {
+            en: {
+              info: "All EN locales have this"
+            },
+            de: {
+              info: "All DE locales have this"
+            }
+          }
+        },
+        privacyAndCompliance: {
+          locales: {
+            'de': {
+              privacyPolicyUrl: 'https://test.com/de/datenschutz/',
+              termsOfUseUrl: 'https://test.com/de/agb/',
+            },
+            // Will be applied to en-US and en-IN
+            'en': {
+              privacyPolicyUrl: 'https://test.com/en/privacy/',
+              termsOfUseUrl: 'https://test.com/en/tos/',
+            },
+            // It's still possible to add locale-specific information like below
+            'en-GB': {
+              privacyPolicyUrl: 'https://test-au.com/en/privacy-australia/',
+              termsOfUseUrl: 'https://test-au.com/en/tos-australia/',
+            },
+          },
+          allowsPurchases: false,
+          containsAds: false,
+          isChildDirected: false,
+          isExportCompliant: true,
+          usesPersonalInfo: false,
+        },
+      },
+    },
+  }
+  // ...
+});
+```
+
+
 ## skillId
 
 The first time you run the [`deploy` command](./cli-commands.md#deploy) for a new project, a new Alexa Skill project with a new ID is created in the [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask#/).


### PR DESCRIPTION
## Proposed Changes

I think it would be handy to support the generic locales defined in the AlexaCliConfig (`AlexaCliConfig.locales`) to be applied to the specific locales for the localized sections of the manifest `publishingInformations` and `privacyAndCompliance`.

My Commit would make it possible, to either define one of those properties for a specific locale (e. g. just for `en-AU`) while also being able to define one `en` generic locale, that gets applied to all other `en` locales that don't have a specific entry.

So with a config like this:

```typescript
    new AlexaCli({
      locales: {
        en: ['en-AU', 'en-US', 'en-IN'],
        de: ['de-DE']
      },
      files: {
        'skill-package/skill.json': {
          manifest: {
            publishingInformation: {
              locales: {
                en: {
                  info: "All en have this"
                },
                de: {
                  info: "All de have this"
                }
              }
            },
            privacyAndCompliance: {
              locales: {
                'de': {
                  privacyPolicyUrl: 'https://test.com/de/datenschutz/',
                  termsOfUseUrl: 'https://test.com/de/agb/',
                },
                // Will be applied to en-US and en-IN
                'en': {
                  privacyPolicyUrl: 'https://test.com/en/privacy/',
                  termsOfUseUrl: 'https://test.com/en/tos/',
                },
                'en-AU': {
                  privacyPolicyUrl: 'https://test-au.com/en/privacy-australia/',
                  termsOfUseUrl: 'https://test-au.com/en/tos-australia/',
                },
              },
              allowsPurchases: false,
              containsAds: false,
              isChildDirected: false,
              isExportCompliant: true,
              usesPersonalInfo: false,
            },
          },
        },
      }
    })
```

So it will lead to: 
```json
{
  "manifest": {
    "publishingInformation": {
      "locales": {
        "de-DE": {
          "info": "All de have this"
        },
        "en-AU": {
          "info": "All en have this"
        },
        "en-US": {
          "info": "All en have this"
        },
        "en-IN": {
          "info": "All en have this"
        }
      }
    },
    "privacyAndCompliance": {
      "locales": {
        "en-AU": {
          "privacyPolicyUrl": "https://test-au.com/en/privacy-australia/",
          "termsOfUseUrl": "https://test-au.com/en/tos-australia/"
        },
        "de-DE": {
          "privacyPolicyUrl": "https://test.com/de/datenschutz/",
          "termsOfUseUrl": "https://test.com/de/agb/"
        },
        "en-US": {
          "privacyPolicyUrl": "https://test.com/en/privacy/",
          "termsOfUseUrl": "https://test.com/en/tos/"
        },
        "en-IN": {
          "privacyPolicyUrl": "https://test.com/en/privacy/",
          "termsOfUseUrl": "https://test.com/en/tos/"
        }
      },
      "allowsPurchases": false,
      "containsAds": false,
      "isChildDirected": false,
      "isExportCompliant": true,
      "usesPersonalInfo": false
    },
    "apis": {
      "custom": {
        "endpoint": {
          "sslCertificateType": "Wildcard",
          "uri": "[URL]"
        }
      }
    }
  }
}
```

It also makes sure to remove the generic locales from the properties, as this would break in the deployment



## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
