### PR TITLE
:bug: fixes skipping of handlers with multiple prioritizedOverUnhandled handlers

### DIFF
--- a/framework/src/plugins/RoutingExecutor.ts
+++ b/framework/src/plugins/RoutingExecutor.ts
@@ -90,7 +90,10 @@ export class RoutingExecutor {
       i < lastRouteMatchIndexWithPrioritizedOverUnhandled;
       i++
     ) {
-      if (rankedRouteMatches[i].type === BuiltInHandler.Unhandled || !rankedRouteMatches[i].prioritizedOverUnhandled) {
+      if (
+        rankedRouteMatches[i].type === BuiltInHandler.Unhandled ||
+        !rankedRouteMatches[i].prioritizedOverUnhandled
+      ) {
         rankedRouteMatches[i].skip = true;
       }
     }

--- a/framework/src/plugins/RoutingExecutor.ts
+++ b/framework/src/plugins/RoutingExecutor.ts
@@ -90,7 +90,9 @@ export class RoutingExecutor {
       i < lastRouteMatchIndexWithPrioritizedOverUnhandled;
       i++
     ) {
-      rankedRouteMatches[i].skip = true;
+      if (rankedRouteMatches[i].type === BuiltInHandler.Unhandled || !rankedRouteMatches[i].prioritizedOverUnhandled) {
+        rankedRouteMatches[i].skip = true;
+      }
     }
   }
 

--- a/framework/test/Routing.test.ts
+++ b/framework/test/Routing.test.ts
@@ -1,4 +1,4 @@
-import { App, BaseComponent, Component, Global, InputType, Intents } from '../src';
+import {App, BaseComponent, Component, Global, InputType, Intents, PrioritizedOverUnhandled} from '../src';
 import { ExamplePlatform, ExampleServer } from './utilities';
 
 test('test handler decorator inheritance', async () => {
@@ -103,5 +103,72 @@ test('test handler decorator inheritance', async () => {
     {
       message: 'MyComponent.IntentC',
     },
+  ]);
+});
+
+test('test prioritized handlers not being skipped', async () => {
+  @Component({name: 'BottomComponent'})
+  class BottomComponent extends BaseComponent {
+    @PrioritizedOverUnhandled()
+    @Intents('IntentA')
+    handleIntentA() {
+      return this.$send('BottomComponent.IntentA');
+    }
+  }
+
+  @Component({name: 'MiddleComponent'})
+  class MiddleComponent extends BaseComponent {
+    @PrioritizedOverUnhandled()
+    @Intents('IntentA')
+    handleIntentA() {
+      return this.$send('MiddleComponent.IntentA');
+    }
+
+    UNHANDLED() {
+      return this.$send('MiddleComponent.UNHANDLED');
+    }
+  }
+
+  @Component({name: 'TopComponent'})
+  class TopComponent extends BaseComponent {
+    UNHANDLED() {
+      return this.$send('TopComponent.UNHANDLED');
+    }
+  }
+
+  const app = new App({
+    plugins: [new ExamplePlatform()],
+    components: [BottomComponent, MiddleComponent, TopComponent],
+  });
+  await app.initialize();
+
+  const server = new ExampleServer({
+    input: {
+      type: InputType.Intent,
+      intent: 'IntentA',
+    },
+    session: {
+      id: '1234',
+      data: {},
+      state: [
+        {
+          component: 'BottomComponent',
+        },
+        {
+          component: 'MiddleComponent',
+          resolve: {},
+        },
+        {
+          component: 'TopComponent',
+          resolve: {},
+        }
+      ]
+    }
+  });
+  await app.handle(server);
+  expect(server.response.output).toEqual([
+    {
+      message: 'MiddleComponent.IntentA',
+    }
   ]);
 });

--- a/framework/test/Routing.test.ts
+++ b/framework/test/Routing.test.ts
@@ -1,4 +1,12 @@
-import {App, BaseComponent, Component, Global, InputType, Intents, PrioritizedOverUnhandled} from '../src';
+import {
+  App,
+  BaseComponent,
+  Component,
+  Global,
+  InputType,
+  Intents,
+  PrioritizedOverUnhandled,
+} from '../src';
 import { ExamplePlatform, ExampleServer } from './utilities';
 
 test('test handler decorator inheritance', async () => {
@@ -107,7 +115,7 @@ test('test handler decorator inheritance', async () => {
 });
 
 test('test prioritized handlers not being skipped', async () => {
-  @Component({name: 'BottomComponent'})
+  @Component({ name: 'BottomComponent' })
   class BottomComponent extends BaseComponent {
     @PrioritizedOverUnhandled()
     @Intents('IntentA')
@@ -116,7 +124,7 @@ test('test prioritized handlers not being skipped', async () => {
     }
   }
 
-  @Component({name: 'MiddleComponent'})
+  @Component({ name: 'MiddleComponent' })
   class MiddleComponent extends BaseComponent {
     @PrioritizedOverUnhandled()
     @Intents('IntentA')
@@ -129,7 +137,7 @@ test('test prioritized handlers not being skipped', async () => {
     }
   }
 
-  @Component({name: 'TopComponent'})
+  @Component({ name: 'TopComponent' })
   class TopComponent extends BaseComponent {
     UNHANDLED() {
       return this.$send('TopComponent.UNHANDLED');
@@ -148,27 +156,27 @@ test('test prioritized handlers not being skipped', async () => {
       intent: 'IntentA',
     },
     session: {
-      id: '1234',
-      data: {},
-      state: [
-        {
-          component: 'BottomComponent',
-        },
-        {
-          component: 'MiddleComponent',
-          resolve: {},
-        },
-        {
-          component: 'TopComponent',
-          resolve: {},
-        }
-      ]
-    }
+      data: {
+        state: [
+          {
+            component: 'BottomComponent',
+          },
+          {
+            component: 'MiddleComponent',
+            resolve: {},
+          },
+          {
+            component: 'TopComponent',
+            resolve: {},
+          },
+        ],
+      },
+    },
   });
   await app.handle(server);
   expect(server.response.output).toEqual([
     {
       message: 'MiddleComponent.IntentA',
-    }
+    },
   ]);
 });

--- a/framework/test/utilities/platform.ts
+++ b/framework/test/utilities/platform.ts
@@ -74,7 +74,7 @@ export class ExamplePlatformRequest extends JovoRequest {
   }
 
   getSessionData(): UnknownObject | undefined {
-    return this.session;
+    return this.session?.data;
   }
 
   setSessionData(): void {

--- a/framework/test/utilities/platform.ts
+++ b/framework/test/utilities/platform.ts
@@ -74,7 +74,7 @@ export class ExamplePlatformRequest extends JovoRequest {
   }
 
   getSessionData(): UnknownObject | undefined {
-    return this.session?.data;
+    return this.session;
   }
 
   setSessionData(): void {


### PR DESCRIPTION
## Proposed Changes

<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
If there are multiple prioritizedOverUnhandled handlers in the state stack with unhandled handlers in between, under some conditions, handlers would be skipped in the selection of the best matching route even if they shouldn't be.

This PR fixes this issue by not marking prioritizedOverUnhandled handlers as skipped.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
