### PR TITLE
Improve Types for $delegate and $resolve function

### DIFF
--- a/framework/src/BaseDelegateComponent.ts
+++ b/framework/src/BaseDelegateComponent.ts
@@ -1,5 +1,5 @@
 import { UnknownObject } from '@jovotech/common';
-import { BaseComponent, ComponentData } from './';
+import { BaseComponent, ComponentData } from './index';
 
 export type ExtractDelegatedEventData<
     T extends BaseDelegateComponent<Record<string, unknown>>,

--- a/framework/src/BaseDelegateComponent.ts
+++ b/framework/src/BaseDelegateComponent.ts
@@ -1,0 +1,30 @@
+import { UnknownObject } from '@jovotech/common';
+import { BaseComponent, ComponentData } from './';
+
+export type ExtractDelegatedEventData<
+    T extends BaseDelegateComponent<Record<string, unknown>>,
+    KEY extends keyof T['__resolve'],
+> = T extends BaseDelegateComponent<infer RESOLVE> ? RESOLVE[KEY] : never;
+
+export abstract class BaseDelegateComponent<
+    RESOLVE extends UnknownObject,
+    DATA extends ComponentData = ComponentData,
+    CONFIG extends UnknownObject = UnknownObject,
+> extends BaseComponent<DATA, CONFIG> {
+    // used to permit the ExtractDelegatedEventData work.
+    // If you find a better way that not require "declare", be my guest! :D
+    declare __resolve: RESOLVE;
+
+    override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
+        eventName: Extract<KEY, string>,
+        ...eventArgs: ARGS extends Array<unknown> ? ARGS : ARGS[]
+    ): Promise<void>;
+    override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
+        eventName: Extract<KEY, string>,
+        eventArg: ARGS,
+    ): Promise<void> {
+        // because of the JovoProxy class, this implementation of the $resolve will not be called.
+        // But it's ok, we need only types work.
+        return super.$resolve(eventName as string, ...(eventArg as unknown[]));
+    }
+}

--- a/framework/src/BaseDelegateComponent.ts
+++ b/framework/src/BaseDelegateComponent.ts
@@ -17,7 +17,7 @@ export abstract class BaseDelegateComponent<
 
     override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
         eventName: Extract<KEY, string>,
-        ...eventArgs: ARGS extends Array<unknown> ? ARGS : ARGS[]
+        ...eventArgs: ARGS extends Array<unknown> ? [...ARGS] : [ARGS]
     ): Promise<void> {
         // because of the JovoProxy class, this implementation of the $resolve will not be called.
         // But it's ok, we need only types work.

--- a/framework/src/BaseDelegateComponent.ts
+++ b/framework/src/BaseDelegateComponent.ts
@@ -1,5 +1,5 @@
-import { UnknownObject } from '@jovotech/common';
-import { BaseComponent, ComponentData } from './index';
+import {UnknownObject} from '@jovotech/common';
+import {BaseComponent, ComponentData} from './index';
 
 export type ExtractDelegatedEventData<
     T extends BaseDelegateComponent<Record<string, unknown>>,
@@ -18,13 +18,9 @@ export abstract class BaseDelegateComponent<
     override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
         eventName: Extract<KEY, string>,
         ...eventArgs: ARGS extends Array<unknown> ? ARGS : ARGS[]
-    ): Promise<void>;
-    override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
-        eventName: Extract<KEY, string>,
-        eventArg: ARGS,
     ): Promise<void> {
         // because of the JovoProxy class, this implementation of the $resolve will not be called.
         // But it's ok, we need only types work.
-        return super.$resolve(eventName as string, ...(eventArg as unknown[]));
+        return super.$resolve(eventName as string, ...(eventArgs as unknown[]));
     }
 }

--- a/framework/src/BaseDelegateComponent.ts
+++ b/framework/src/BaseDelegateComponent.ts
@@ -6,8 +6,10 @@ export type ExtractDelegatedEventData<
     KEY extends keyof T['__resolve'],
 > = T extends BaseDelegateComponent<infer RESOLVE> ? RESOLVE[KEY] : never;
 
+type IsTuple<T> = T extends [any, ...any] ? true : false
+
 export abstract class BaseDelegateComponent<
-    RESOLVE extends UnknownObject,
+    RESOLVE extends Record<string, any>,
     DATA extends ComponentData = ComponentData,
     CONFIG extends UnknownObject = UnknownObject,
 > extends BaseComponent<DATA, CONFIG> {
@@ -17,10 +19,10 @@ export abstract class BaseDelegateComponent<
 
     override async $resolve<ARGS extends RESOLVE[KEY], KEY extends keyof RESOLVE = keyof RESOLVE>(
         eventName: Extract<KEY, string>,
-        ...eventArgs: ARGS extends Array<unknown> ? [...ARGS] : [ARGS]
+        ...eventArgs: ARGS extends Array<unknown> ? (IsTuple<ARGS> extends true ? ARGS : [ARGS]) : [ARGS]
     ): Promise<void> {
         // because of the JovoProxy class, this implementation of the $resolve will not be called.
         // But it's ok, we need only types work.
-        return super.$resolve(eventName as string, ...(eventArgs as unknown[]));
+        return super.$resolve(eventName as string, ...eventArgs);
     }
 }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -40,6 +40,8 @@ import { JovoRoute } from './plugins/RouterPlugin';
 import { forEachDeep } from './utilities';
 import { DependencyInjector } from './DependencyInjector';
 import { v4 as uuidv4 } from 'uuid';
+import {BaseDelegateComponent} from "./BaseDelegateComponent";
+
 const DELEGATE_MIDDLEWARE = 'event.$delegate';
 const RESOLVE_MIDDLEWARE = 'event.$resolve';
 const REDIRECT_MIDDLEWARE = 'event.$redirect';
@@ -431,7 +433,8 @@ export abstract class Jovo<
   }
 
   // TODO determine whether an error should be thrown if $resolve is called from a context outside a delegation
-  async $resolve<ARGS extends unknown[]>(eventName: string, ...eventArgs: ARGS): Promise<void> {
+    // TODO Move the implementation to the BaseDelegatedComponent. So also the previously TODO can be removed.
+    async $resolve<ARGS extends any[]>(eventName: string, ...eventArgs: ARGS): Promise<void> {
     if (!this.$state) {
       return;
     }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -438,7 +438,7 @@ export abstract class Jovo<
 
   // TODO determine whether an error should be thrown if $resolve is called from a context outside a delegation
     // TODO Move the implementation to the BaseDelegatedComponent. So also the previously TODO can be removed.
-    async $resolve<ARGS extends any[]>(eventName: string, ...eventArgs: ARGS): Promise<void> {
+    async $resolve<ARGS extends [any]>(eventName: string, ...eventArgs: ARGS): Promise<void> {
     if (!this.$state) {
       return;
     }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -7,7 +7,7 @@ import util from 'util';
 import { App, AppConfig } from './App';
 import { HandleRequest } from './HandleRequest';
 import {
-  BaseComponent,
+  BaseComponent, BaseDelegateComponent,
   BaseOutput,
   ComponentConfig,
   ComponentConstructor,
@@ -40,7 +40,6 @@ import { JovoRoute } from './plugins/RouterPlugin';
 import { forEachDeep } from './utilities';
 import { DependencyInjector } from './DependencyInjector';
 import { v4 as uuidv4 } from 'uuid';
-import {BaseDelegateComponent} from "./BaseDelegateComponent";
 
 const DELEGATE_MIDDLEWARE = 'event.$delegate';
 const RESOLVE_MIDDLEWARE = 'event.$resolve';
@@ -356,6 +355,12 @@ export abstract class Jovo<
     });
   }
 
+  async $delegate<COMPONENT extends BaseDelegateComponent<any>>(
+      component: ComponentConstructor<COMPONENT> | string,
+      options: DelegateOptions<ComponentConfig<COMPONENT>, COMPONENT extends BaseDelegateComponent<infer RESOLVE, any, any>
+          ? keyof RESOLVE
+          : never>,
+  ): Promise<void>
   async $delegate<COMPONENT extends BaseComponent>(
     constructor: ComponentConstructor<COMPONENT>,
     options: DelegateOptions<ComponentConfig<COMPONENT>>,

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -40,7 +40,6 @@ import { JovoRoute } from './plugins/RouterPlugin';
 import { forEachDeep } from './utilities';
 import { DependencyInjector } from './DependencyInjector';
 import { v4 as uuidv4 } from 'uuid';
-
 const DELEGATE_MIDDLEWARE = 'event.$delegate';
 const RESOLVE_MIDDLEWARE = 'event.$resolve';
 const REDIRECT_MIDDLEWARE = 'event.$redirect';

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -47,6 +47,7 @@ export {
 export * from './App';
 export * from './AsyncJovo';
 export * from './BaseComponent';
+export * from './BaseDelegateComponent';
 export * from './BaseOutput';
 export * from './ComponentPlugin';
 export * from './ComponentTree';


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Added a new abstract Class `BaseDelegateComponent` and an `ExtractDelegatedEventData` type to permit better use of $delegate and $resolve functions.

The `BaseDelegateComponent`, used in a similar way as the BaseComponent, is there to add the typing to events/resolve. 
The `ExtractDelegatedEventData` is used to extract the data from the event. 

Examples (pseudo code): 

```typescript
// components/DelegatedComponent.ts
class DelegatedComponent extends BaseDelegatedComponent<{
  completed: boolean, // completed is the event, boolean is the parameter, for multiple params, use array like: [boolean, string, string[]]
}> {
 async START() {
   return this.$resolve('completed', true) // <-- Typed
   
  //return this.$resolve('wrongEvent', "orWrongType")  <-- Error type from typescript
 }

}

// components/GlobalComponent
class GlobalComponent extends BaseComponent {

  async intent(){
    this.delegate(DelegatedComponent, {
    resolve: {
          completed: this.onDelegateCompleted // completed will be suggested by IDE
          // For back-compatibility, adding something wrong will NOT result in an error. We can discuss it if we think this can be useful.
    }
    })
  }
  
  onDelegateCompleted(result: ExtractDelegatedEventData<DelegatedComponent, 'completed'>){
  //  result is typed  
  if(result) return this.$send("Result frue");
  return this.$send("Result false");
  }

}
```

Completely open to discussing it in any way. 

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [-] I have added tests to cover my changes
- [X] All new and existing tests passed
