### PR TITLE
Fix support for ask-cli 2.30.0 and above

### DIFF
--- a/platforms/platform-alexa/src/cli/interfaces.ts
+++ b/platforms/platform-alexa/src/cli/interfaces.ts
@@ -98,7 +98,7 @@ export interface ImportStatus {
 
 export interface ImportResponse {
   body: UnknownObject;
-  headers: { key: string; value: string }[];
+  headers: {[key: string]: string};
 }
 
 export interface SkillStatusError {

--- a/platforms/platform-alexa/src/cli/smapi/SkillPackageManagement.ts
+++ b/platforms/platform-alexa/src/cli/smapi/SkillPackageManagement.ts
@@ -94,9 +94,5 @@ export async function getImportStatus(
 }
 
 function parseImportUrl({ headers }: ImportResponse): string | undefined {
-  // Try to parse the import url from command result
-  return headers
-    .find((header) => header.key === 'location')
-    ?.value.split('/')
-    .pop();
+  return headers['location']?.split('/').pop();
 }

--- a/platforms/platform-alexa/src/cli/utilities.ts
+++ b/platforms/platform-alexa/src/cli/utilities.ts
@@ -21,10 +21,11 @@ import { AskSkillChoice, AskSkillList } from './interfaces';
 export async function checkForAskCli(): Promise<void> {
   try {
     const { stdout } = await execAsync('ask --version');
-    const majorVersion: string = stdout![0];
-    if (parseInt(majorVersion) < 2) {
+    const majorVersion: number = parseInt(stdout![0]);
+    const minorVersion: number = parseInt(stdout!.slice(2, 4));
+    if (majorVersion < 2 || (majorVersion == 2 && minorVersion < 30)) {
       throw new JovoCliError({
-        message: 'Jovo CLI requires ASK CLI @v2 or above.',
+        message: 'Jovo CLI requires ASK CLI @v2.30.0 or above.',
         module: 'AlexaCli',
         hint: 'Please update your ASK CLI using "npm install ask-cli -g".',
       });


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Since ask-cli 2.30.0 introduces a breaking change (see https://github.com/alexa/ask-cli/issues/485), I edited accordingly the headers parsing function.

**I also dropped support for ask-cli 2.29.2 and older.**

Fixes https://github.com/jovotech/jovo-framework/issues/1568, https://github.com/jovotech/jovo-cli/issues/357
Closes https://github.com/jovotech/jovo-framework/pull/1575 (not working)

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] **The code has been tested**
