### PR TITLE
:sparkles: Add type checking to resolve object

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -428,6 +428,53 @@ class YourComponent extends BaseComponent {
 
 ## Advanced Component Features
 
+### Type Safety
+
+You can pass the following interfaces and types to `BaseComponent`:
+
+- [Component options](#component-options)
+- [Component data](#component-data)
+- Component events when [delegating to a component](./handlers.md#delegate-to-components)
+
+For example, this could look like this:
+
+```typescript
+import { Component, BaseComponent, ComponentConfig, ComponentData } from '@jovotech/framework';
+
+export interface YourComponentConfig extends ComponentConfig {
+  someKey: string;
+}
+
+export interface YourComponentData extends ComponentData {
+  someKey: string;
+}
+
+export enum YourComponentEvents {
+  Yes = 'onYes',
+  No = 'onNo',
+}
+
+class YourComponent extends BaseComponent<YourComponentData, YourComponentConfig, YourComponentEvents> {
+  // ...
+}
+```
+
+You don't need to pass all three elements:
+
+```typescript
+import { Component, BaseComponent } from '@jovotech/framework';
+
+export enum YourComponentEvents {
+  Yes = 'onYes',
+  No = 'onNo',
+}
+
+class YourComponent extends BaseComponent<{}, {}, YourComponentEvents> {
+  // ...
+}
+```
+
+
 ### ComponentTree
 
 The [`ComponentTree`](https://github.com/jovotech/jovo-framework/blob/v4/latest/framework/src/ComponentTree.ts) contains all [registered components](#component-registration):

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -189,6 +189,13 @@ onNo() {
 }
 ```
 
+The following options can be added to `$delegate()`:
+
+- `resolve`: Handlers that should be called after the child component [resolves](#resolve-a-component) with certain data.
+  - Can include references to handler functions like `this.onYes` (doesn't work with anonymous functions)
+  - Can include a string to the handler key: `'onYes'`
+- `config`: The config that is used by the child component. Can be accessed inside the child component with `this.$component.config`.
+
 In the above example, the [`$state` stack](./state-stack.md) gets updated like this:
 
 ```typescript
@@ -237,12 +244,22 @@ yourHandler() {
 }
 ```
 
-The following options can be added to `$delegate()`:
+You can also pass that enum to the component for [type safety](./components.md#type-safety):
 
-- `resolve`: Handlers that should be called after the child component [resolves](#resolve-a-component) with certain data.
-  - Can include references to handler functions like `this.onYes` (doesn't work with anonymous functions)
-  - Can include a string to the handler key: `'onYes'`
-- `config`: The config that is used by the child component. Can be accessed inside the child component with `this.$component.config`.
+```typescript
+// src/components/YesNoComponent.ts
+
+export enum YesNoComponentEvent {
+  Yes = 'yes',
+  No = 'no',
+}
+
+class YesNoComponent extends BaseComponent<{}, {}, YesNoComponentEvent> {
+  // ...
+}
+```
+
+
 
 ### Resolve a Component
 

--- a/framework/src/BaseComponent.ts
+++ b/framework/src/BaseComponent.ts
@@ -12,10 +12,8 @@ export type ComponentConfig<COMPONENT extends BaseComponent = any> = Exclude<
   undefined
 >;
 
-export type ComponentEvents<COMPONENT extends BaseComponent = any> = Extract<
-  keyof Exclude<COMPONENT['$component']['resolve'], undefined>,
-  string
->;
+export type ComponentEvents<COMPONENT extends BaseComponent = any> =
+  COMPONENT extends BaseComponent<infer DATA, infer CONFIG, infer EVENTS> ? EVENTS : never;
 
 export type ComponentConstructor<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,14 +43,14 @@ export abstract class BaseComponent<
     super(jovo);
   }
 
-  get $component(): JovoComponentInfo<DATA, CONFIG, EVENTS> {
+  get $component(): JovoComponentInfo<DATA, CONFIG> {
     return {
       data: this.jovo.$component.data as DATA,
       config: { ...(this.options?.config || {}), ...(this.jovo.$component.config || {}) } as CONFIG,
-      resolve: this.jovo.$component.resolve as Record<
-        EVENTS,
-        string | ((this: BaseComponent, ...args: any[]) => any)
-      >,
     };
+  }
+
+  async $resolve<ARGS extends unknown[]>(eventName: EVENTS, ...eventArgs: ARGS): Promise<void> {
+    return super.$resolve(eventName, eventArgs);
   }
 }

--- a/framework/src/BaseComponent.ts
+++ b/framework/src/BaseComponent.ts
@@ -12,6 +12,11 @@ export type ComponentConfig<COMPONENT extends BaseComponent = any> = Exclude<
   undefined
 >;
 
+export type ComponentEvents<COMPONENT extends BaseComponent = any> = Extract<
+  keyof Exclude<COMPONENT['$component']['resolve'], undefined>,
+  string
+>;
+
 export type ComponentConstructor<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   COMPONENT extends BaseComponent = any,
@@ -34,15 +39,20 @@ export class ComponentDeclaration<COMPONENT extends BaseComponent = any> {
 export abstract class BaseComponent<
   DATA extends ComponentData = ComponentData,
   CONFIG extends UnknownObject = UnknownObject,
+  EVENTS extends string = string,
 > extends JovoProxy {
   constructor(jovo: Jovo, readonly options: ComponentOptions<CONFIG> | undefined) {
     super(jovo);
   }
 
-  get $component(): JovoComponentInfo<DATA, CONFIG> {
+  get $component(): JovoComponentInfo<DATA, CONFIG, EVENTS> {
     return {
       data: this.jovo.$component.data as DATA,
       config: { ...(this.options?.config || {}), ...(this.jovo.$component.config || {}) } as CONFIG,
+      resolve: this.jovo.$component.resolve as Record<
+        EVENTS,
+        string | ((this: BaseComponent, ...args: any[]) => any)
+      >,
     };
   }
 }

--- a/framework/src/Jovo.ts
+++ b/framework/src/Jovo.ts
@@ -66,11 +66,9 @@ export interface JovoPersistableData {
 export interface JovoComponentInfo<
   DATA extends ComponentData = ComponentData,
   CONFIG extends UnknownObject = UnknownObject,
-  EVENTS extends string = string,
 > {
   data: DATA;
   config?: CONFIG;
-  resolve?: Record<EVENTS, string | ((this: BaseComponent, ...args: any[]) => any)>;
 }
 
 export interface DelegateOptions<
@@ -220,11 +218,6 @@ export abstract class Jovo<
       },
       set config(value: UnknownObject | undefined) {
         latestStateStackItem.config = value;
-      },
-      get resolve():
-        | Record<string, string | ((this: BaseComponent, ...args: any[]) => any)>
-        | undefined {
-        return latestStateStackItem.resolve;
       },
     };
   }
@@ -441,10 +434,7 @@ export abstract class Jovo<
   }
 
   // TODO determine whether an error should be thrown if $resolve is called from a context outside a delegation
-  async $resolve<ARGS extends unknown[]>(
-    eventName: Extract<keyof Exclude<this['$component']['resolve'], undefined>, string> | string,
-    ...eventArgs: ARGS
-  ): Promise<void> {
+  async $resolve<ARGS extends unknown[]>(eventName: string, ...eventArgs: ARGS): Promise<void> {
     if (!this.$state) {
       return;
     }


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

closes #1591 

## Proposed Changes

<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->

Add type checking to `this.$delegate(...)` `resolve` object and to `this.$resolve(...)`.

If `EVENTS` type isn't passed to the extended BaseComponent, Jovo should behave as usual.

If `EVENTS` type is set, then IDE will provide autocompletion for `resolve` keys and for the event name in `this.$resolve(eventName)`.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
