### PR TITLE
:sparkles: Add addEventFilter for analytics-bigquery

### DIFF
--- a/integrations/analytics-bigquery/docs/README.md
+++ b/integrations/analytics-bigquery/docs/README.md
@@ -99,6 +99,8 @@ new BigQueryAnalytics({
   onAddEvent: async (jovo: Jovo, event: AnalyticsEvent) => {
     event.timeZone = '';
   },
+  addEventFilter: (jovo: Jovo, event: AnalyticsEvent) =>
+    event.eventType !== 'device_capabilities',
 }),
 ```
 
@@ -112,6 +114,7 @@ It includes these properties:
 - `insertRowOptions`: Used to configure the insert of rows into BigQuery. See [insertRowOptions](#insertrowoptions) for more information.
 - `logging`: Default is `false`. When `true`, logs plugin calls for `addEvent` and `sendEvents`. See [logging](#logging) for more information.
 - `onAddEvent`: Optional. Allows modification of the `event` before it is sent to BigQuery. See [onAddEvent](#onaddevent) for more information.
+- `addEventFilter`: Optional. Allows filtering an `event` before it is sent to BigQuery. See [addEventFilter](#addEventFilter) for more information.
 
 ### libraryConfig
 
@@ -197,7 +200,7 @@ new BigQueryAnalytics({
   // ...
 }),
 ```
-- `addEvent`: This logs the event just after the optional call to the `onAddEvent` function defined in config.
+- `addEvent`: This logs the event just after the optional call to the `onAddEvent` function defined in config, or before being filtered by the optional `addEventFilter` function.
 - `sendEvents`: Sends the events to BigQuery. If there are errors inserting the rows, they will be logged.
 
 ### onAddEvent
@@ -232,6 +235,23 @@ plugins: [
     // ...
   }),
 ]
+```
+
+### addEventFilter
+
+Define a `addEventFilter` function, in order to filter out events from being sent to BigQuery. This function returning or resolving to `false` will filter the event out.
+
+This shows how to filter out events with `eventType === 'device_capabilities'`:
+
+```typescript
+import { BigQueryAnalytics, AnalyticsEvent } from '@jovotech/analytics-bigquery';
+// ...
+
+new BigQueryAnalytics({
+  addEventFilter: (jovo: Jovo, event: AnalyticsEvent) =>
+    event.eventType !== 'device_capabilities',
+  // ...
+}),
 ```
 
 ## Event Tracking

--- a/integrations/analytics-bigquery/src/BigQueryAnalytics.ts
+++ b/integrations/analytics-bigquery/src/BigQueryAnalytics.ts
@@ -26,6 +26,7 @@ export interface BigQueryAnalyticsPluginConfig extends AnalyticsPluginConfig {
   insertRowsOptions: InsertRowsOptions;
   logging?: BigQueryLoggingConfig | boolean;
   onAddEvent?: (jovo: Jovo, event: AnalyticsEvent) => Promise<void> | void;
+  addEventFilter?: (jovo: Jovo, event: AnalyticsEvent) => Promise<boolean> | boolean;
 }
 
 export type BigQueryAnalyticsPluginInitConfig = RequiredOnlyWhere<

--- a/integrations/analytics-bigquery/src/JovoBigQuery.ts
+++ b/integrations/analytics-bigquery/src/JovoBigQuery.ts
@@ -91,6 +91,14 @@ export class JovoBigQuery {
       event.timeZone = this.jovo.$request.timeZone as string;
     }
 
+    if (this.config.addEventFilter && !this.config.addEventFilter(this.jovo, event)) {
+      if ((this.config.logging as BigQueryLoggingConfig).addEvent) {
+        // eslint-disable-next-line no-console
+        console.log('BigQuery addEvent filtered', { event });
+      }
+      return;
+    }
+
     if (this.config.onAddEvent) {
       await this.config.onAddEvent(this.jovo, event);
     }


### PR DESCRIPTION
## Proposed Changes

This change should give the user more control over what is to be sent to the BigQuery Table. When working with bigger voice apps, multiple events per request can lead to huge amounts of BigQuery table rows that might not be needed in a give case. This filter function gives the user the chance to filter out events by eventType, user, or whatever they want.

If there are any issues with this, feel free to let me know!

## Types of Changes



- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
