### PR TITLE
🐛 Fix Alexa import status error message retrieval

### DIFF
--- a/platforms/platform-alexa/src/cli/interfaces.ts
+++ b/platforms/platform-alexa/src/cli/interfaces.ts
@@ -89,7 +89,7 @@ export interface ImportResource {
 export interface ImportStatus {
   skill: {
     eTag: string;
-    resources: [ImportResource];
+    resources: ImportResource[];
     skillId: string;
   };
   status: SkillStatus;

--- a/platforms/platform-alexa/src/cli/smapi/SkillPackageManagement.ts
+++ b/platforms/platform-alexa/src/cli/smapi/SkillPackageManagement.ts
@@ -80,12 +80,11 @@ export async function getImportStatus(
     await wait(500);
     return await getImportStatus(importId, askProfile);
   } else if (status.status === 'FAILED') {
+    const errorResource = status.skill.resources.find((r) => r.errors);
     throw new JovoCliError({
       message: 'Errors occured while importing your skill package',
-      hint: status.skill.resources.length
-        ? status.skill.resources[0].errors.length
-          ? status.skill.resources[0].errors[0].message
-          : JSON.stringify(status.skill.resources, null, 2)
+      hint: errorResource
+        ? errorResource.errors[0].message
         : JSON.stringify(status.skill.resources, null, 2),
     });
   }


### PR DESCRIPTION
## Proposed Changes
Currently Jovo assumes `ImportStatus.skill.resources` to never have a length > 1. Therefore, if the array is not empty, it tries to look the `error` property in the first element of `resources`. In reality however, the `resources` can consist of >1 elements, where the `error` property might not be present in the first element. This leads to the folowing error:

```
🚀 Deploying Alexa Skill
  ✖ Uploading skill package
                                                                                
x Error: --------------------------------------------------------------------------------
›                                                                                 
› Message:
›  Cannot read properties of undefined (reading 'length')
›                                                                                 
› Module:
›  JovoCliCore
›                                                                                 
›                                                                                 
› If you think this is not on you, you can submit an issue here: https://github.com/jovotech/jovo-cli/issues.
```

This is caused by this expression: `status.skill.resources[0].errors.length`.

This is the `resources` property in my test, when I set `privacyPolicyUrl` to `abc` to test this behaviour:

```JSON
[
    {
        "action": "UPDATE",
        "info": [
            {
                "message": "No change in resource and its dependencies detected. Resource version is up to date with imported package version. Update skipped."
            }
        ],
        "name": "InteractionModel.en-US",
        "status": "SKIPPED"
    },
    {
        "action": "UPDATE",
        "errors": [
            {
                "message": "String instance with value \"abc\" at property path \"$.manifest.privacyAndCompliance.locales.en-US.privacyPolicyUrl\" is not a valid URL."
            }
        ],
        "name": "Manifest",
        "status": "FAILED"
    }
]
```

Here you can see the `error` property being present on `resources[1]` instead of `resources[0]`.

Therefore I changed the type of `resources` to a normal array instead of a tuple with one element. Also it now looks up the element with an error present instead of assuming it to be the first element.

With these changes you get the following output in the cli:

```
🚀 Deploying Alexa Skill
  ✖ Uploading skill package
                                                                                
x Error: --------------------------------------------------------------------------------
›                                                                                 
› Message:
›  Errors occured while importing your skill package
›                                                                                 
› Module:
›  JovoCliCore
›                                                                                 
› Hint:
›  String instance with value "abc" at property path "$.manifest.privacyAndCompliance.locales.en-US.privacyPolicyUrl" is not a valid URL.
›                                                                                 
›                                                                                 
› If you think this is not on you, you can submit an issue here: https://github.com/jovotech/jovo-cli/issues.
```

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
