### PR TITLE
🔧 Make AlexaHandles.onTask global

### DIFF
--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -668,6 +668,7 @@ Under the hood, `onTask()` as part of [`AlexaHandles`](https://github.com/jovote
 ```typescript
 {
   types: [InputType.Launch],
+  global: true,
   if: (jovo: Jovo) => {
     const task = jovo.$alexa?.task.getTask();
     if (!task) return false;

--- a/platforms/platform-alexa/src/AlexaHandles.ts
+++ b/platforms/platform-alexa/src/AlexaHandles.ts
@@ -97,6 +97,7 @@ export class AlexaHandles {
   static onTask(taskName: string, taskVersion?: number | string): HandleOptions {
     return {
       types: [InputType.Launch],
+      global: true,
       if: (jovo: Jovo) => {
         const task = jovo.$alexa?.task.getTask();
         if (!task) return false;

--- a/platforms/platform-alexa/src/cli/utilities.ts
+++ b/platforms/platform-alexa/src/cli/utilities.ts
@@ -104,22 +104,15 @@ export function getAskError(method: string, stderr: string): JovoCliError {
   const errorIndex: number = stderr.indexOf(splitter);
   if (errorIndex > -1) {
     const errorString: string = getRawString(stderr.substring(errorIndex + splitter.length));
-    const parsedError = JSON.parse(errorString);
-    const payload = _get(parsedError, 'detail.response', parsedError);
-    const message: string = payload.message;
-    let violations = '';
+    try {
+      const parsedError = JSON.parse(errorString);
+      const payload = _get(parsedError, 'detail.response', parsedError);
+      const details = getViolations(payload);
 
-    if (payload.violations) {
-      for (const violation of payload.violations) {
-        violations += violation.message;
-      }
+      return new JovoCliError({ message: `${method}: ${payload.message}`, module, details });
+    } catch (error) {
+      return new JovoCliError({ message: `${method}: ${errorString}`, module });
     }
-
-    if (payload.detail) {
-      violations = payload.detail.response.message;
-    }
-
-    return new JovoCliError({ message: `${method}: ${message}`, module, details: violations });
   } else {
     // Try parsing for alternative error message.
     let i: number, pathRegex: RegExp;
@@ -158,6 +151,20 @@ export function getAskError(method: string, stderr: string): JovoCliError {
   }
 
   return new JovoCliError({ message: stderr, module });
+}
+
+function getViolations(payload: any): string {
+  let violations = '';
+  if (payload.violations) {
+    for (const violation of payload.violations) {
+      violations += violation.message;
+    }
+  }
+
+  if (payload.detail) {
+    violations = payload.detail.response.message;
+  }
+  return violations;
 }
 
 export function copyFiles(src: string, dest: string): void {


### PR DESCRIPTION
## Proposed Changes

This adds the `global` flag to the `onTask` `HanldeOptions`, so the user won't have to manually add this, in case the handler is not placed in a global Component. This is the example request from the [docs](https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-amazon-predefined-tasks-in-your-skill.html#example-task-request):

```json
{
    "type": "LaunchRequest",
    "requestId": "string",
    "timestamp": "string",
    "locale": "string",
    "task": {
        "name": "AMAZON.PrintPDF",
        "version": "1",
        "input": {
            "@type": "PrintPDFRequest",
            "@version": "1",
            "title": "Flywheel",
            "description": "Flywheel",
            "url": "http://www.example.com/flywheel.pdf"
        }
    }
}
```

As can be seen, a task comes in with a `LaunchRequest`, therefore should never be possible within a session. This is why I think it'd be easier to already include the `global` flag in the `onTask` function.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
