### PR TITLE
:bug: Add missing non JSON ask error handling

### DIFF
--- a/platforms/platform-alexa/src/cli/utilities.ts
+++ b/platforms/platform-alexa/src/cli/utilities.ts
@@ -104,22 +104,15 @@ export function getAskError(method: string, stderr: string): JovoCliError {
   const errorIndex: number = stderr.indexOf(splitter);
   if (errorIndex > -1) {
     const errorString: string = getRawString(stderr.substring(errorIndex + splitter.length));
-    const parsedError = JSON.parse(errorString);
-    const payload = _get(parsedError, 'detail.response', parsedError);
-    const message: string = payload.message;
-    let violations = '';
+    try {
+      const parsedError = JSON.parse(errorString);
+      const payload = _get(parsedError, 'detail.response', parsedError);
+      const details = getViolations(payload);
 
-    if (payload.violations) {
-      for (const violation of payload.violations) {
-        violations += violation.message;
-      }
+      return new JovoCliError({ message: `${method}: ${payload.message}`, module, details });
+    } catch (error) {
+      return new JovoCliError({ message: `${method}: ${errorString}`, module });
     }
-
-    if (payload.detail) {
-      violations = payload.detail.response.message;
-    }
-
-    return new JovoCliError({ message: `${method}: ${message}`, module, details: violations });
   } else {
     // Try parsing for alternative error message.
     let i: number, pathRegex: RegExp;
@@ -158,6 +151,20 @@ export function getAskError(method: string, stderr: string): JovoCliError {
   }
 
   return new JovoCliError({ message: stderr, module });
+}
+
+function getViolations(payload: any): string {
+  let violations = '';
+  if (payload.violations) {
+    for (const violation of payload.violations) {
+      violations += violation.message;
+    }
+  }
+
+  if (payload.detail) {
+    violations = payload.detail.response.message;
+  }
+  return violations;
 }
 
 export function copyFiles(src: string, dest: string): void {


### PR DESCRIPTION
## Proposed Changes
Provoking an error in alexa ask deployment sometimes results in an error in the `getAskError` function.

Example:
Using a non existent ask profile like so:

```
new AlexaCli({askProfile: 'does-not-exist', locales: {en: ['en-US']}})
```
This leads to the `stderr`: 

```
Command failed: ask smapi create-upload-url -p does-not-exist
Debugger listening on ws://127.0.0.1:42595/25792652-dbcc-412d-bf9d-4db5fcbd8620
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Debugger listening on ws://127.0.0.1:39601/8953403c-efec-4e66-a3c0-89661f15f337
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
[Error]: Can't resolve profile [does-not-exist] as it doesn't exist. Please run "ask configure --profile does-not-exist" first.
```

The current version of `getAskError` tries to parse the substring after `[Error]`, in this case this text `Can't resolve profile [does-not-exist] as it doesn't exist. Please run "ask configure --profile does-not-exist" first.`. As this clearly is no JSON object/array. This `JSON.parse` throws an error resulting in this being displayed after running `jovo deploy:platform alexa`:

```
🚀 Deploying Alexa Skill
  ✖ Uploading skill package
                                                                                
x Error: --------------------------------------------------------------------------------
›                                                                                 
› Message:
›  Unexpected token C in JSON at position 0
›                                                                                 
› Module:
›  JovoCliCore
›                                                                                 
›                                                                                 
› If you think this is not on you, you can submit an issue here: https://github.com/jovotech/jovo-cli/issues.
```

This is why I built a block to catch the error from `JSON.parse`, which creates the `JovoCliError` in a different way, leading to the actual helpful error message being displayed after running the jovo deploy, in this case:

```
🚀 Deploying Alexa Skill
  ✖ Uploading skill package
                                                                                
x Error: --------------------------------------------------------------------------------
›                                                                                 
› Message:
›  smapiCreateUploadUrl: Can't resolve profile [does-not-exist] as it doesn't exist. Please run "ask configure --profile does-not-exist" first.
›  
›                                                                                 
› Module:
›  AlexaCli
›                                                                                 
›                                                                                 
› If you think this is not on you, you can submit an issue here: https://github.com/jovotech/jovo-cli/issues.
```

As this further increased the size of the function I also refactored some logic into its own function `getViolation` to improve readability.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
