### PR TITLE
:bug: Fix merge order for arrays in mergeInstances

### DIFF
--- a/output/src/utilities.ts
+++ b/output/src/utilities.ts
@@ -104,7 +104,7 @@ export function mergeInstances<D extends object, S extends any[]>(
     // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
     (value: any, srcValue: any, key: string, object: any) => {
       if (Array.isArray(srcValue) && Array.isArray(value)) {
-        return srcValue.concat(value);
+        return value.concat(srcValue);
       }
       if (typeof srcValue === 'undefined') {
         _unset(object, key);

--- a/output/test/utilities.test.ts
+++ b/output/test/utilities.test.ts
@@ -105,7 +105,7 @@ describe('mergeInstances', () => {
       },
     };
 
-    expect(mergeInstances(b, a)).toEqual(merged);
+    expect(mergeInstances(a, b)).toEqual(merged);
   });
 
   test('test merging of nested arrays', () => {
@@ -127,6 +127,6 @@ describe('mergeInstances', () => {
       },
     };
 
-    expect(mergeInstances(b, a)).toEqual(merged);
+    expect(mergeInstances(a, b)).toEqual(merged);
   });
 });

--- a/output/test/utilities.test.ts
+++ b/output/test/utilities.test.ts
@@ -105,7 +105,7 @@ describe('mergeInstances', () => {
       },
     };
 
-    expect(mergeInstances(a, b)).toEqual(merged);
+    expect(mergeInstances(b, a)).toEqual(merged);
   });
 
   test('test merging of nested arrays', () => {


### PR DESCRIPTION
## Proposed Changes

Taking this code snippet in a handler:

```typescript
  await this.$send({
      platforms: {
        alexa: {
          nativeResponse: {
            response: {
              directives: [
                {
                  type: 'Alexa.Presentation.APL.ExecuteCommands',
                  token: this.$session.id,
                  commands: [
                    {
                      type: 'SetPage',
                      componentId: 'rootPager',
                      value: 1,
                    },
                  ],
                },
              ],
            },
          },
        },
      },
    });
    await this.$send({
      platforms: {
        alexa: {
          nativeResponse: {
            response: {
              directives: [
                {
                  type: 'Alexa.Presentation.APL.ExecuteCommands',
                  token: this.$session.id,
                  commands: [
                    {
                      type: 'SetPage',
                      componentId: 'rootPager',
                      value: 2,
                    },
                  ],
                },
              ],
            },
          },
        },
      },
    });
```

Currently leads to the directive with value 2 to be placed first in the resulting alexa response:

```json
    [
            {
                "type": "Alexa.Presentation.APL.ExecuteCommands",
                "token": "amzn1.echo-api.session.6c0b46c5-6db8-4f48-a71b-feb268d3b51c",
                "commands": [
                    {
                        "type": "SetPage",
                        "componentId": "rootPager",
                        "value": 2
                    }
                ]
            },
            {
                "type": "Alexa.Presentation.APL.ExecuteCommands",
                "token": "amzn1.echo-api.session.6c0b46c5-6db8-4f48-a71b-feb268d3b51c",
                "commands": [
                    {
                        "type": "SetPage",
                        "componentId": "rootPager",
                        "value": 1
                    }
                ]
            }
        ]
```

The order is very important for some combination of directives, and to me there is no logical reason to reverse the order here. Feel free to let me know, if this was not implemented this way by accident, but for some specific reason, where putting array elements of the following output to the front. Maybe instead of changing the `mergeInstances` function, one could also just switch the argument order in `SingleResponseOutputTemplateConverterStrategy`.


## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
