### PR TITLE
:bug: Handle empty AskError detail object

### DIFF
--- a/platforms/platform-alexa/src/cli/utilities.ts
+++ b/platforms/platform-alexa/src/cli/utilities.ts
@@ -115,7 +115,7 @@ export function getAskError(method: string, stderr: string): JovoCliError {
       }
     }
 
-    if (payload.detail) {
+    if (payload.detail?.response?.message) {
       violations = payload.detail.response.message;
     }
 


### PR DESCRIPTION
## Proposed Changes

Sometimes the `detail` property in this case can be just an empty object. This happens for example, if I try to deploy while the build is still going on. It throws a 409 with an empty `detail`:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/52d3f770-4ee3-4d7a-8844-9d62f5c42169)

This will lead to an error, trying to access `payload.detail.response.message` and will cause an error message to be printed in the console that gives no information about what actually went wrong with the upload:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/6f260e7b-be7b-4ae9-8381-ab8ea0c8103e)

With the provided fix in place, it looks like this:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/5655fda8-2c67-4fb9-9b91-414f4d5cddb7)


## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
