### PR TITLE
:bug: Handle empty AskError detail object

### DIFF
--- a/platforms/platform-alexa/src/cli/utilities.ts
+++ b/platforms/platform-alexa/src/cli/utilities.ts
@@ -161,7 +161,7 @@ function getViolations(payload: any): string {
     }
   }
 
-  if (payload.detail) {
+  if (payload.detail?.response?.message) {
     violations = payload.detail.response.message;
   }
   return violations;


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

Sometimes the `detail` property in a ask error (e. g. of a deploy) can be just an empty object. This happens for example, if I try to deploy while the build is still going on. It throws a 409 with an empty `detail`:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/52d3f770-4ee3-4d7a-8844-9d62f5c42169)

This will lead to an error, trying to access `payload.detail.response.message`. This error then is being caught [here](https://github.com/jovotech/jovo-framework/blob/v4/dev/platforms/platform-alexa/src/cli/utilities.ts#L114) which leads to the whole json bein output, instead of the message being retrieved:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/c0272265-c618-46f0-8a86-35688a7969a0)

With this fix it will correctly be retrieved:
![image](https://github.com/jovotech/jovo-framework/assets/9163735/6b213107-510e-4665-86f1-472d01bf32b3)

I worked on this before the other change to [getAskError was merged](https://github.com/jovotech/jovo-framework/pull/1609/commits/37ec7f423adf504b3e7c35dcdd1959f449da173e) (which catches errors in the ask error retrieval process). Before this merge, the error was more severe as it completely dropped the actual error message, now it is more of a question of how it is displayed. However this still throws an error currently in a place where it is avoidable.

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
