### PR TITLE
:bug: Removed false positive duplicate global handler issue

### DIFF
--- a/framework/src/plugins/RouterPlugin.ts
+++ b/framework/src/plugins/RouterPlugin.ts
@@ -95,7 +95,10 @@ export class RouterPlugin extends Plugin<RouterPluginConfig> {
             if (!globalHandlerMap[mappedIntentName]) {
               globalHandlerMap[mappedIntentName] = [];
             }
-            if (!handlerMetadata.hasCondition) {
+            if (
+              !handlerMetadata.hasCondition &&
+              !globalHandlerMap[mappedIntentName].includes(handlerMetadata)
+            ) {
               globalHandlerMap[mappedIntentName].push(handlerMetadata);
             }
           });


### PR DESCRIPTION
## Proposed Changes

This commit stops the same handler to be added to `globalHandlerMap` twice. This lead to an error, where it reported a duplicate handler even though it was the same handler twice. This can happen with intentMaps, e. g. you have an intentMap like this:

```typescript
  routing: {
    intentMap: {
      'AMAZON.HelpIntent': 'HelpIntent',
    }
  },
```

and a handler like this:
```typescript
  @Handle({global: true, intents: ['HelpIntent', 'AMAZON.HelpIntent']})
  help(): Promise<void> {
    throw new Error('just a test');
  }
```

I am aware that in most cases, you should just not use `AMAZON.HelpIntent` in the `intents` array and it works just fine. However, if you are using one and the same component in multiple projects that might have different intentmaps, this might actually make things easier. Also, even though this might not be the best implementation, I don't think it was intended to treat the same handler as duplicate in this specific scenario in the first place. 

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
