### PR TITLE
:bug: Fix not awaiting BigQuery addEventFilter

### DIFF
--- a/integrations/analytics-bigquery/src/JovoBigQuery.ts
+++ b/integrations/analytics-bigquery/src/JovoBigQuery.ts
@@ -91,7 +91,7 @@ export class JovoBigQuery {
       event.timeZone = this.jovo.$request.timeZone as string;
     }
 
-    if (this.config.addEventFilter && !this.config.addEventFilter(this.jovo, event)) {
+    if (this.config.addEventFilter && !(await this.config.addEventFilter(this.jovo, event))) {
       if ((this.config.logging as BigQueryLoggingConfig).addEvent) {
         // eslint-disable-next-line no-console
         console.log('BigQuery addEvent filtered', { event });


### PR DESCRIPTION
## Proposed Changes

This addresses an issue, where providing a async function for `addEventFilter` in the `BigQueryAnalyticsPluginConfig`, see [here](https://github.com/jovotech/jovo-framework/blob/v4/latest/integrations/analytics-bigquery/src/BigQueryAnalytics.ts#L29), never filters out the event, as it is not awaiting the result but treating the returned Promise as truthy

## Types of Changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
