### PR TITLE
:sparkles: Add StartConnectionOutput for Alexa

### DIFF
--- a/platforms/platform-alexa/docs/README.md
+++ b/platforms/platform-alexa/docs/README.md
@@ -572,7 +572,41 @@ You can build Alexa Skills with Jovo that make use of the Alexa Conversations di
 
 You can use Jovo with [Alexa Skill Connections](https://developer.amazon.com/docs/alexa/custom-skills/understand-skill-connections.html) by sending a `Connections.StartConnection` directive as shown in the [official Alexa docs](https://developer.amazon.com/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#implement-a-handler-to-return-a-connectionsstartconnection-directive-to-use-skill-connection).
 
-For this, the Jovo Alexa integration offers convenience [output classes](https://www.jovo.tech/docs/output-classes). Below is an overview of all classes:
+For example, if you want to connect to a [custom task in a specific skill](https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#for-custom-task-direct-skill-connection-with-send_errors_only), you can use the `StartConnectionOutput` class provided by the Jovo Alexa integration.
+
+```typescript
+import { StartConnectionOutput, OnCompletion } from '@jovotech/platform-alexa';
+// ...
+
+someHandler() {
+  // ...
+
+  return this.$send(StartConnectionOutput, {
+    taskName: {
+      amazonPredefinedTask: false,
+      name: 'CountDown',
+    },
+    // Input for the task
+    input: {
+      upperLimit: 10,
+      lowerLimit: 1,
+    },
+    // Decides whether session is picked up after task
+    onCompletion: OnCompletion.SendErrorsOnly,
+    token: '<your-token>',
+    // defaults to 1
+    taskVersion: 1,
+    // This is mandatory in case taskName.amazonPredefinedTask is false
+    providerSkillId: '<skill-id>',
+  });
+}
+```
+
+The Output Options can be changed to create a [managed skill connection](https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#for-managed-skill-connection), by setting `taskName.amazonPredefinedTask` to true and omitting `providerSkillId`.
+
+In case the session is supposed to be [resumed](https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#return-connectionsstartconnection-directive-with-resume_session-set-explicitly-or-by-default) after the task is handled, `onCompletion` can be changed to `OnCompletion.ResumeSession`.
+
+For some specific connections, the Jovo Alexa integration offers convenience [output classes](https://www.jovo.tech/docs/output-classes). Below is an overview of all classes:
 
 - [`ConnectionAskForPermissionConsentOutput`](https://github.com/jovotech/jovo-framework/tree/v4/latest/platforms/platform-alexa/src/output/templates/ConnectionAskForPermissionConsentOutput.ts)
 - [`ConnectionLinkAppOutput`](https://github.com/jovotech/jovo-framework/tree/v4/latest/platforms/platform-alexa/src/output/templates/ConnectionLinkAppOutput.ts)   

--- a/platforms/platform-alexa/src/output/models/index.ts
+++ b/platforms/platform-alexa/src/output/models/index.ts
@@ -57,6 +57,7 @@ export * from './common/AsinProduct';
 export * from './common/ConnectionPostalAddress';
 export * from './common/ConsentLevel';
 export * from './common/PermissionScope';
+export * from './common/OnCompletion';
 export * from './dialog/DialogConfirmIntentDirective';
 export * from './dialog/DialogConfirmSlotDirective';
 export * from './dialog/DialogDelegateDirective';

--- a/platforms/platform-alexa/src/output/templates/ConnectionAddToShoppingCartOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionAddToShoppingCartOutput.ts
@@ -1,6 +1,7 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { AsinProduct } from '../models';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionAddToShoppingCartOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -19,33 +20,15 @@ export class ConnectionAddToShoppingCartOutput extends BaseOutput<ConnectionAddT
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.AddToShoppingCart/1',
-                  input: {
-                    products: this.options.products,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'AddToShoppingCart', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        products: this.options.products,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionAskForPermissionConsentOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionAskForPermissionConsentOutput.ts
@@ -1,6 +1,7 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { ConnectionPermissionScopeLike, ConsentLevelLike } from '../models';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface PermissionScopeItem {
   permissionScope: ConnectionPermissionScopeLike;
@@ -24,35 +25,18 @@ export class ConnectionAskForPermissionConsentOutput extends BaseOutput<Connecti
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'AskForPermissionsConsent', amazonPredefinedTask: true },
+      taskVersion: 2,
 
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.AskForPermissionsConsent/2',
-                  input: {
-                    '@type': 'AskForPermissionsConsentRequest',
-                    '@version': '2',
-                    'permissionScopes': this.options.permissionScopes,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'AskForPermissionsConsentRequest',
+        '@version': '2',
+        'permissionScopes': this.options.permissionScopes,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionBuyShoppingProductsOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionBuyShoppingProductsOutput.ts
@@ -1,6 +1,7 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { AsinProduct } from '../models';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionBuyShoppingProductsOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -19,33 +20,15 @@ export class ConnectionBuyShoppingProductsOutput extends BaseOutput<ConnectionBu
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.BuyShoppingProducts/1',
-                  input: {
-                    products: this.options.products,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'BuyShoppingProducts', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        products: this.options.products,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionLinkAppOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionLinkAppOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export enum DirectLaunchDefaultPromptBehavior {
   Speak = 'SPEAK',
@@ -30,44 +31,27 @@ export class ConnectionLinkAppOutput extends BaseOutput<ConnectionLinkAppOutputO
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.LinkApp/2',
-                  input: {
-                    links: this.options.links,
-                    prompt: {
-                      topic: this.options.topic,
-                      directLaunchDefaultPromptBehavior:
-                        this.options.directLaunchDefaultPromptBehavior,
-                    },
-                    directLaunch: {
-                      enabled: this.options.directLaunchEnabled,
-                    },
-                    sendToDevice: {
-                      enabled: this.options.sendToDeviceEnabled,
-                    },
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: {
+        name: 'LinkApp',
+      },
+      taskVersion: 2,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        links: this.options.links,
+        prompt: {
+          topic: this.options.topic,
+          directLaunchDefaultPromptBehavior: this.options.directLaunchDefaultPromptBehavior,
+        },
+        directLaunch: {
+          enabled: this.options.directLaunchEnabled,
+        },
+        sendToDevice: {
+          enabled: this.options.sendToDeviceEnabled,
         },
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionPrintImageOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionPrintImageOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export enum ImageType {
   Jpg = 'JPG',
@@ -28,38 +29,20 @@ export class ConnectionPrintImageOutput extends BaseOutput<ConnectionPrintImageO
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.PrintImage/1',
-                  input: {
-                    '@type': 'PrintImageRequest',
-                    '@version': '1',
-                    'title': this.options.title,
-                    'description': this.options.description,
-                    'url': this.options.url,
-                    'imageType': this.options.imageType,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'PrintImage', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'PrintImageRequest',
+        '@version': '1',
+        'title': this.options.title,
+        'description': this.options.description,
+        'url': this.options.url,
+        'imageType': this.options.imageType,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionPrintPdfOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionPrintPdfOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionPrintPdfOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -21,37 +22,19 @@ export class ConnectionPrintPdfOutput extends BaseOutput<ConnectionPrintPdfOutpu
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.PrintPDF/1',
-                  input: {
-                    '@type': 'PrintPDFRequest',
-                    '@version': '1',
-                    'title': this.options.title,
-                    'description': this.options.description,
-                    'url': this.options.url,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'PrintPDF', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'PrintPDFRequest',
+        '@version': '1',
+        'title': this.options.title,
+        'description': this.options.description,
+        'url': this.options.url,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionPrintWebPageOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionPrintWebPageOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionPrintWebPageOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -21,37 +22,19 @@ export class ConnectionPrintWebPageOutput extends BaseOutput<ConnectionPrintWebP
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.PrintWebPage/1',
-                  input: {
-                    '@type': 'PrintWebPageRequest',
-                    '@version': '1',
-                    'title': this.options.title,
-                    'description': this.options.description,
-                    'url': this.options.url,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'PrintWebPage', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'PrintWebPageRequest',
+        '@version': '1',
+        'title': this.options.title,
+        'description': this.options.description,
+        'url': this.options.url,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionScheduleFoodEstablishmentReservationOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionScheduleFoodEstablishmentReservationOutput.ts
@@ -1,6 +1,7 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { ConnectionPostalAddress } from '../models';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionRestaurant {
   '@type': 'Restaurant';
@@ -40,37 +41,19 @@ export class ConnectionScheduleFoodEstablishmentReservationOutput extends BaseOu
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.ScheduleFoodEstablishmentReservation/1',
-                  input: {
-                    '@type': 'ScheduleFoodEstablishmentReservationRequest',
-                    '@version': '1',
-                    'startTime': this.options.startTime,
-                    'partySize': this.options.partySize,
-                    'restaurant': this.options.restaurant,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'ScheduleFoodEstablishmentReservation', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'ScheduleFoodEstablishmentReservationRequest',
+        '@version': '1',
+        'startTime': this.options.startTime,
+        'partySize': this.options.partySize,
+        'restaurant': this.options.restaurant,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionScheduleTaxiReservationOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionScheduleTaxiReservationOutput.ts
@@ -1,6 +1,7 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { ConnectionPostalAddress } from '../models';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionScheduleTaxiReservationOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -21,38 +22,20 @@ export class ConnectionScheduleTaxiReservationOutput extends BaseOutput<Connecti
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.ScheduleTaxiReservation/1',
-                  input: {
-                    '@type': 'ScheduleTaxiReservationRequest',
-                    '@version': '1',
-                    'partySize': this.options.partySize,
-                    'pickupLocation': this.options.pickupLocation,
-                    'pickupTime': this.options.pickupTime,
-                    'dropoffLocation': this.options.dropoffLocation,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'ScheduleTaxiReservation', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        '@type': 'ScheduleTaxiReservationRequest',
+        '@version': '1',
+        'partySize': this.options.partySize,
+        'pickupLocation': this.options.pickupLocation,
+        'pickupTime': this.options.pickupTime,
+        'dropoffLocation': this.options.dropoffLocation,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionTestStatusCodeOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionTestStatusCodeOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export interface ConnectionTestStatusCodeOutputOptions extends OutputOptions {
   shouldEndSession?: boolean;
@@ -18,33 +19,15 @@ export class ConnectionTestStatusCodeOutput extends BaseOutput<ConnectionTestSta
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.TestStatusCode/1',
-                  input: {
-                    code: this.options.code,
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
-          },
-        },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'TestStatusCode', amazonPredefinedTask: true },
+      taskVersion: 1,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        code: this.options.code,
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/ConnectionVerifyPersonOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/ConnectionVerifyPersonOutput.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Output, OutputOptions, OutputTemplate } from '@jovotech/framework';
 import { OnCompletion } from '../models/common/OnCompletion';
+import { StartConnectionOutput } from './StartConnectionOutput';
 
 export enum PolicyName {
   VoicePin = 'VOICE_PIN',
@@ -24,38 +25,20 @@ export class ConnectionVerifyPersonOutput extends BaseOutput<ConnectionVerifyPer
   }
 
   build(): OutputTemplate | OutputTemplate[] {
-    const shouldEndSession =
-      this.options.onCompletion === OnCompletion.SendErrorsOnly
-        ? true
-        : this.options.shouldEndSession;
-
-    return {
-      message: this.options.message,
-      platforms: {
-        alexa: {
-          nativeResponse: {
-            response: {
-              shouldEndSession,
-              directives: [
-                {
-                  type: 'Connections.StartConnection',
-                  uri: 'connection://AMAZON.VerifyPerson/2',
-                  input: {
-                    requestedAuthenticationConfidenceLevel: {
-                      level: this.options.level,
-                      customPolicy: {
-                        policyName: this.options.policyName,
-                      },
-                    },
-                  },
-                  token: this.options.token,
-                  onCompletion: this.options.onCompletion,
-                },
-              ],
-            },
+    return new StartConnectionOutput(this.jovo, {
+      taskName: { name: 'VerifyPerson', amazonPredefinedTask: true },
+      taskVersion: 2,
+      shouldEndSession: this.options.shouldEndSession,
+      onCompletion: this.options.onCompletion,
+      input: {
+        requestedAuthenticationConfidenceLevel: {
+          level: this.options.level,
+          customPolicy: {
+            policyName: this.options.policyName,
           },
         },
       },
-    };
+      token: this.options.token,
+    }).build();
   }
 }

--- a/platforms/platform-alexa/src/output/templates/StartConnectionOutput.ts
+++ b/platforms/platform-alexa/src/output/templates/StartConnectionOutput.ts
@@ -1,0 +1,89 @@
+import { Output, BaseOutput, OutputTemplate, OutputOptions, Jovo } from '@jovotech/framework';
+import { DeepPartial, JovoError } from '@jovotech/common';
+import { OnCompletion } from '../models/common/OnCompletion';
+
+interface DirectSkillConnectionOutputOptions extends OutputOptions {
+  /**
+   * The taskName consists of a prefix (either 'AMAZON' or the providerSkillId) and the actual name of the task.
+   * e. g. 'AMAZON.PrintPDF' or 'amzn1.ask.skill.12345678-90ab-cdef-1234-567890abcdef.CountDown'
+   * For managed skill connection (no providerSkillId passed), only Amazon predefined tasks will work.
+   */
+  taskName: {
+    /**
+     * If true, 'AMAZON' will be used as a taskName prefix. If false, providerSkillId will be used as taskName prefix.
+     * Default value is true
+     */
+    amazonPredefinedTask?: boolean;
+    name: string;
+  };
+  taskVersion?: number;
+  shouldEndSession?: boolean;
+  onCompletion: OnCompletion;
+  input: any;
+  token?: string;
+  /**
+   * This needs to be provided to make this a direct skill connection
+   */
+  providerSkillId?: string;
+}
+
+@Output()
+export class StartConnectionOutput extends BaseOutput<DirectSkillConnectionOutputOptions> {
+  constructor(jovo: Jovo, options: DeepPartial<DirectSkillConnectionOutputOptions> | undefined) {
+    super(jovo, options);
+  }
+
+  getDefaultOptions(): DirectSkillConnectionOutputOptions {
+    return {
+      taskVersion: 1,
+      taskName: { amazonPredefinedTask: true, name: '' },
+      input: {},
+      onCompletion: OnCompletion.ResumeSession,
+    };
+  }
+
+  build(): OutputTemplate {
+    if (!this.options.taskName.amazonPredefinedTask && !this.options.providerSkillId) {
+      throw new JovoError({
+        message: 'for direct skill connection, providerSkillId must be provided',
+        hint: 'to link to a task in a specific skill, provide providerSkillId, to use managed skill connection, set taskName.amazonPredefinedTask to true',
+        learnMore:
+          'https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-skill-connections-to-request-tasks.html#for-direct-skill-connection-1',
+      });
+    }
+
+    const shouldEndSession =
+      this.options.onCompletion === OnCompletion.SendErrorsOnly
+        ? true
+        : this.options.shouldEndSession;
+
+    const taskPrefix = this.options.taskName.amazonPredefinedTask
+      ? 'AMAZON'
+      : this.options.providerSkillId;
+
+    return {
+      platforms: {
+        alexa: {
+          nativeResponse: {
+            response: {
+              shouldEndSession,
+              directives: [
+                {
+                  type: 'Connections.StartConnection',
+                  uri: `connection://${taskPrefix}.${this.options.taskName.name}/${
+                    this.options.taskVersion
+                  }${
+                    this.options.providerSkillId ? `?provider=${this.options.providerSkillId}` : ''
+                  }`,
+                  input: this.options.input,
+                  onCompletion: this.options.onCompletion,
+                  token: this.options.token,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+  }
+}

--- a/platforms/platform-alexa/src/output/templates/index.ts
+++ b/platforms/platform-alexa/src/output/templates/index.ts
@@ -28,5 +28,6 @@ export * from './ConnectionVerifyPersonOutput';
 export * from './ConnectionScheduleFoodEstablishmentReservationOutput';
 export * from './ProgressiveResponseOutput';
 export * from './CanFulfillIntentOutput';
+export * from './StartConnectionOutput';
 
 export * from './AplRenderDocumentOutput';


### PR DESCRIPTION
<!--- Learn more in our contributing guide: https://www.jovo.tech/docs/contributing -->

## Proposed Changes

This commit adds a convenient way to add skill connections, that have not already been covered by the multiple Output classes already provided. This is especially helpful, if you want to target a specific Task (e. g. in a specific skill), as the already provided output classes only covered predefined tasks. 

The main new class added here is the `StartConnectionOutput`, which is a the most basic StartConnection Template, that should cover all types of StartConnection Directives the developer needs. Therefore I also refactored the already existing Outputs to use this more generic Output, to make these classes a bit more concise. 

I tested the new class heavliy as well as made sure, that the refactored classes still work the same. In my tests, everything worked perfectly.

I also added documentation with links to the alexa developer documentation to explain how to use this new feature!

## Types of Changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
